### PR TITLE
add default overrides to reset.css

### DIFF
--- a/packages/frosted-ui/src/styles/reset.css
+++ b/packages/frosted-ui/src/styles/reset.css
@@ -52,3 +52,64 @@
   font-family: inherit;
   margin: 0;
 }
+
+/* Global reset based on https://tailwindcss.com/docs/preflight */
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+  border-width: 0;
+  border-style: solid;
+}
+
+blockquote,
+dl,
+dd,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+hr,
+figure,
+p,
+pre {
+  margin: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+ol,
+ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+img,
+svg,
+video,
+canvas,
+audio,
+iframe,
+embed,
+object {
+  display: block;
+  vertical-align: middle;
+}
+
+img,
+video {
+  max-width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
Adds default 'reset' styles based on https://tailwindcss.com/docs/preflight 
