### PR TITLE
feat: add stroke token

### DIFF
--- a/packages/frosted-ui/.storybook/stories/components/sheet.stories.tsx
+++ b/packages/frosted-ui/.storybook/stories/components/sheet.stories.tsx
@@ -256,8 +256,8 @@ export const ScrollableContent: Story = {
             style={{
               flex: 1,
               overflowY: 'auto',
-              borderTop: '1px solid vaR(--gray-a4)',
-              borderBottom: '1px solid vaR(--gray-a4)',
+              borderTop: '1px solid var(--gray-a4)',
+              borderBottom: '1px solid var(--gray-a4)',
             }}
           >
             <Text as="p" size="2" mb="4">

--- a/packages/frosted-ui/src/styles/tokens/color.css
+++ b/packages/frosted-ui/src/styles/tokens/color.css
@@ -181,7 +181,7 @@
   --color-surface: rgba(255, 255, 255, 0.9);
   --backdrop-filter-panel: blur(20px) saturate(190%) contrast(50%)
     brightness(130%);
-
+  --color-stroke: var(--gray-a5);
   /* 
   Used as an overlay (via background-image gradient)
   to allow for more granular gradation of background color for the dark mode.
@@ -209,6 +209,7 @@
   --color-surface: rgba(0, 0, 0, 0.25);
   --backdrop-filter-panel: blur(20px) saturate(190%) contrast(90%)
     brightness(80%);
+  --color-stroke: var(--gray-a4);
 }
 
 /* * * * * * * * * * * * * * * * * * * */

--- a/packages/frosted-ui/src/tailwind-plugin.ts
+++ b/packages/frosted-ui/src/tailwind-plugin.ts
@@ -178,6 +178,7 @@ export const frostedThemePlugin = plugin.withOptions(
             DEFAULT: 'var(--color-surface)',
             accent: 'var(--color-surface-accent)',
           },
+          stroke: 'var(--color-stroke)',
           overlay: 'var(--color-overlay)',
           panel: {
             solid: 'var(--color-panel-solid)',


### PR DESCRIPTION
Adds stroke token for creating borders - `gray-a5` for dark mode, `gray-a4` for light mode