### PR TITLE
fix(dialog,alertdialog): missing title and description margins

### DIFF
--- a/packages/frosted-ui/.storybook/stories/components/data-list.stories.tsx
+++ b/packages/frosted-ui/.storybook/stories/components/data-list.stories.tsx
@@ -39,7 +39,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: ({ children, ...args }) => (
     <div>
-      <Text as="p">
+      <Text as="p" style={{ marginBottom: 32 }}>
         <Code>{'<DataList />'}</Code> component displays metadata as a list of key-value pairs.
       </Text>
       <DataList.Root {...args}>

--- a/packages/frosted-ui/.storybook/stories/components/dialog.stories.tsx
+++ b/packages/frosted-ui/.storybook/stories/components/dialog.stories.tsx
@@ -48,22 +48,16 @@ export const Default: Story = {
 
         <Flex direction="column" gap="3">
           <label>
-            <Text as="div" size="2" mb="1" weight="bold">
+            <Text as="div" size="2" style={{ marginBottom: 4 }} weight="bold">
               Name
             </Text>
-            <TextField.Input
-              defaultValue="Freja Johnsen"
-              placeholder="Enter your full name"
-            />
+            <TextField.Input defaultValue="Freja Johnsen" placeholder="Enter your full name" />
           </label>
           <label>
-            <Text as="div" size="2" mb="1" weight="bold">
+            <Text as="div" size="2" style={{ marginBottom: 4 }} weight="bold">
               Email
             </Text>
-            <TextField.Input
-              defaultValue="freja@example.com"
-              placeholder="Enter your email"
-            />
+            <TextField.Input defaultValue="freja@example.com" placeholder="Enter your email" />
           </label>
         </Flex>
 
@@ -96,12 +90,7 @@ export const Sizes: Story = {
 
           <Flex gap="2" justify="end">
             <Dialog.Close>
-              <Button
-                size="1"
-                variant="soft"
-                color="gray"
-                onClick={() => alert('Cancel')}
-              >
+              <Button size="1" variant="soft" color="gray" onClick={() => alert('Cancel')}>
                 Cancel
               </Button>
             </Dialog.Close>
@@ -125,12 +114,7 @@ export const Sizes: Story = {
 
           <Flex gap="2" justify="end">
             <Dialog.Close>
-              <Button
-                size="2"
-                variant="soft"
-                color="gray"
-                onClick={() => alert('Cancel')}
-              >
+              <Button size="2" variant="soft" color="gray" onClick={() => alert('Cancel')}>
                 Cancel
               </Button>
             </Dialog.Close>
@@ -154,12 +138,7 @@ export const Sizes: Story = {
 
           <Flex gap="3" justify="end">
             <Dialog.Close>
-              <Button
-                size="2"
-                variant="soft"
-                color="gray"
-                onClick={() => alert('Cancel')}
-              >
+              <Button size="2" variant="soft" color="gray" onClick={() => alert('Cancel')}>
                 Cancel
               </Button>
             </Dialog.Close>
@@ -183,12 +162,7 @@ export const Sizes: Story = {
 
           <Flex gap="3" justify="end" align="center">
             <Dialog.Close>
-              <Button
-                size="3"
-                variant="soft"
-                color="gray"
-                onClick={() => alert('Cancel')}
-              >
+              <Button size="3" variant="soft" color="gray" onClick={() => alert('Cancel')}>
                 Cancel
               </Button>
             </Dialog.Close>
@@ -213,9 +187,7 @@ export const InsetContent: Story = {
       </Dialog.Trigger>
       <Dialog.Content {...args}>
         <Dialog.Title>Users</Dialog.Title>
-        <Dialog.Description>
-          The following users have access to this project.
-        </Dialog.Description>
+        <Dialog.Description>The following users have access to this project.</Dialog.Description>
 
         <Inset side="x" my="5">
           <Table.Root variant="ghost" size="1">

--- a/packages/frosted-ui/src/components/alert-dialog.tsx
+++ b/packages/frosted-ui/src/components/alert-dialog.tsx
@@ -64,7 +64,7 @@ AlertDialogContent.displayName = 'AlertDialogContent';
 
 type AlertDialogTitleProps = React.ComponentProps<typeof Heading>;
 
-const AlertDialogTitle = ({ size: sizeProp, ...props }: AlertDialogTitleProps) => {
+const AlertDialogTitle = ({ size: sizeProp, className, ...props }: AlertDialogTitleProps) => {
   const { size: contextSize } = React.useContext(AlertDialogContentContext);
   let size: AlertDialogTitleProps['size'];
 
@@ -81,7 +81,7 @@ const AlertDialogTitle = ({ size: sizeProp, ...props }: AlertDialogTitleProps) =
 
   return (
     <AlertDialogPrimitive.Title asChild>
-      <Heading size={sizeProp || size} trim="start" {...props} />
+      <Heading size={sizeProp || size} trim="start" className={classNames('fui-DialogTitle', className)} {...props} />
     </AlertDialogPrimitive.Title>
   );
 };
@@ -89,7 +89,7 @@ AlertDialogTitle.displayName = 'AlertDialogTitle';
 
 type AlertDialogDescriptionProps = ExtractPropsForTag<typeof Text, 'p'>;
 
-const AlertDialogDescription = ({ size: sizeProp, ...props }: AlertDialogDescriptionProps) => {
+const AlertDialogDescription = ({ size: sizeProp, className, ...props }: AlertDialogDescriptionProps) => {
   const { size: contextSize } = React.useContext(AlertDialogContentContext);
   let size: AlertDialogDescriptionProps['size'];
 
@@ -106,7 +106,7 @@ const AlertDialogDescription = ({ size: sizeProp, ...props }: AlertDialogDescrip
 
   return (
     <AlertDialogPrimitive.Description asChild>
-      <Text as="p" size={sizeProp || size} {...props} />
+      <Text as="p" size={sizeProp || size} className={classNames('fui-DialogDescription', className)} {...props} />
     </AlertDialogPrimitive.Description>
   );
 };

--- a/packages/frosted-ui/src/components/dialog.css
+++ b/packages/frosted-ui/src/components/dialog.css
@@ -50,21 +50,37 @@
 
 .fui-DialogContent {
   &:where(.fui-r-size-1) {
+    --dialog-title-mb: var(--space-1);
+    --dialog-description-mb: var(--space-3);
     --dialog-content-padding: var(--space-3);
     border-radius: var(--radius-4);
   }
   &:where(.fui-r-size-2) {
+    --dialog-title-mb: var(--space-2);
+    --dialog-description-mb: var(--space-4);
     --dialog-content-padding: var(--space-4);
     border-radius: var(--radius-4);
   }
   &:where(.fui-r-size-3) {
+    --dialog-title-mb: var(--space-3);
+    --dialog-description-mb: var(--space-4);
     --dialog-content-padding: var(--space-5);
     border-radius: var(--radius-5);
   }
   &:where(.fui-r-size-4) {
+    --dialog-title-mb: var(--space-3);
+    --dialog-description-mb: var(--space-6);
     --dialog-content-padding: var(--space-6);
     border-radius: var(--radius-5);
   }
+}
+
+.fui-DialogTitle:where(.fui-Heading) {
+  margin-bottom: var(--dialog-title-mb);
+}
+
+.fui-DialogDescription {
+  margin-bottom: var(--dialog-description-mb);
 }
 
 @property --overlay-blur {

--- a/packages/frosted-ui/src/components/dialog.tsx
+++ b/packages/frosted-ui/src/components/dialog.tsx
@@ -59,7 +59,7 @@ const DialogContent = (props: DialogContentProps) => {
 DialogContent.displayName = 'DialogContent';
 
 type DialogTitleProps = React.ComponentProps<typeof Heading>;
-const DialogTitle = ({ size: sizeProp, ...props }: DialogTitleProps) => {
+const DialogTitle = ({ size: sizeProp, className, ...props }: DialogTitleProps) => {
   const { size: contextSize } = React.useContext(DialogContentContext);
   let size: DialogTitleProps['size'];
 
@@ -76,14 +76,14 @@ const DialogTitle = ({ size: sizeProp, ...props }: DialogTitleProps) => {
 
   return (
     <DialogPrimitive.Title asChild>
-      <Heading size={sizeProp || size} trim="start" {...props} />
+      <Heading size={sizeProp || size} trim="start" className={classNames('fui-DialogTitle', className)} {...props} />
     </DialogPrimitive.Title>
   );
 };
 DialogTitle.displayName = 'DialogTitle';
 
 type DialogDescriptionProps = ExtractPropsForTag<typeof Text, 'p'>;
-const DialogDescription = ({ size: sizeProp, ...props }: DialogDescriptionProps) => {
+const DialogDescription = ({ size: sizeProp, className, ...props }: DialogDescriptionProps) => {
   const { size: contextSize } = React.useContext(DialogContentContext);
   let size: DialogDescriptionProps['size'];
 
@@ -100,7 +100,7 @@ const DialogDescription = ({ size: sizeProp, ...props }: DialogDescriptionProps)
 
   return (
     <DialogPrimitive.Description asChild>
-      <Text as="p" size={sizeProp || size} {...props} />
+      <Text as="p" size={sizeProp || size} className={classNames('fui-DialogDescription', className)} {...props} />
     </DialogPrimitive.Description>
   );
 };

--- a/packages/frosted-ui/src/components/sheet.css
+++ b/packages/frosted-ui/src/components/sheet.css
@@ -60,16 +60,6 @@
   gap: 12px;
 }
 
-.fui-SheetTitle {
-  font-size: 20px;
-  font-weight: 600;
-  color: var(--color-text-primary);
-  color: blue;
-}
-.fui-SheetDescription {
-  color: green;
-}
-
 .fui-SheetContentHandle,
 .fui-SheetHeader,
 .fui-SheetBody {

--- a/packages/frosted-ui/src/styles/index.css
+++ b/packages/frosted-ui/src/styles/index.css
@@ -11,12 +11,19 @@
 @import './tokens/space.css';
 @import './tokens/typography.css';
 
+@import '../components/heading.css';
+@import '../components/text.css';
+/* dialog, alert dialog, drawer and sheet need to be imported AFTER text and heading to ensure proper heading and description styles */
+@import '../components/alert-dialog.css';
+@import '../components/dialog.css';
+@import '../components/drawer.css';
+@import '../components/sheet.css';
+
 @import '../components/lab/accordion.css';
 @import '../components/avatar.css';
 @import '../components/avatar-group.css';
 @import '../components/badge.css';
 
-@import '../components/alert-dialog.css';
 @import '../components/blockquote.css';
 @import '../components/box.css';
 @import '../components/lab/breadcrumbs.css';
@@ -29,15 +36,11 @@
 @import '../components/container.css';
 @import '../components/context-menu.css';
 @import '../components/data-list.css';
-@import '../components/dialog.css';
-@import '../components/drawer.css';
-@import '../components/sheet.css';
 @import '../components/dropdown-menu.css';
 @import '../components/em.css';
 @import '../components/filter-chip.css';
 @import '../components/flex.css';
 @import '../components/grid.css';
-@import '../components/heading.css';
 @import '../components/hover-card.css';
 @import '../components/icon-button.css';
 @import '../components/inset.css';
@@ -68,7 +71,6 @@
 @import '../components/text-field.css';
 @import '../components/otp-field.css';
 @import '../components/date-field.css';
-@import '../components/text.css';
 @import '../components/tooltip.css';
 @import '../components/widget-stack.css';
 


### PR DESCRIPTION
After I've removed shorthand margin props the dialog title and description were missing margins. 