### PR TITLE
More fixes

### DIFF
--- a/packages/frosted-ui/src/components/base-menu/base-menu.css
+++ b/packages/frosted-ui/src/components/base-menu/base-menu.css
@@ -15,7 +15,8 @@
   flex: 1 1 0%;
   display: flex;
   flex-direction: column;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding: var(--base-menu-content-padding);
 
   :where(.fui-BaseMenuContent:has(.fui-ScrollAreaScrollbar[data-orientation='vertical'])) & {

--- a/packages/frosted-ui/src/components/progress/progress.props.ts
+++ b/packages/frosted-ui/src/components/progress/progress.props.ts
@@ -4,7 +4,7 @@ import { colorProp, highContrastProp } from '../../helpers';
 const sizes = ['1', '2', '3', '4', '5', '6'] as const;
 
 const progressPropDefs = {
-  size: { type: 'enum', values: sizes, default: '3' },
+  size: { type: 'enum', values: sizes, default: '6' },
   color: { ...colorProp, default: undefined },
   highContrast: highContrastProp,
 } satisfies {

--- a/packages/frosted-ui/src/components/select/select.css
+++ b/packages/frosted-ui/src/components/select/select.css
@@ -260,13 +260,13 @@
   background-color: var(--color-surface);
   box-shadow:
     inset 0 0 0 1px var(--gray-a5),
-    0px 1px 2px 0px rgba(0, 0, 0, 0.06);
+    0px 1px 2px 0px rgba(0, 0, 0, 0.05);
 
   @media (hover: hover) {
     &:where(:hover) {
       box-shadow:
         inset 0 0 0 1px var(--gray-a7),
-        0px 1px 2px 0px rgba(0, 0, 0, 0.06);
+        0px 1px 2px 0px rgba(0, 0, 0, 0.05);
     }
   }
   &:where([data-state='open']) {

--- a/packages/frosted-ui/src/components/table/table.css
+++ b/packages/frosted-ui/src/components/table/table.css
@@ -105,6 +105,8 @@
   /* Accomodating for ghost button size=1 padding */
   margin-left: calc(-1 * var(--space-2));
   margin-right: calc(-1 * var(--space-2));
+  padding-left: var(--space-2);
+  padding-right: var(--space-2);
 }
 /***************************************************************************************************
  *                                                                                                 *
@@ -124,7 +126,7 @@
   }
   &:where(.fui-r-size-2) {
     --table-border-radius: var(--radius-4);
-    --table-column-header-cell-padding: var(--space-3) var(--space-4);
+    --table-column-header-cell-padding: var(--space-2) var(--space-4);
     --table-cell-padding: var(--space-3) var(--space-4);
     --table-cell-min-height: 44px;
     --table-bottom-padding: var(--space-3) var(--space-4);


### PR DESCRIPTION
- [x] Fix table header vertical padding in size 2, table header cell button alignment
- [x] Fix separator in dropdown and selects cause horizontal scroll on Safari
- [x] Fix: set Progress default size to 6