### PR TITLE
fix(Calendar): year selector not reacting to minValue and maxValue

### DIFF
--- a/packages/frosted-ui/src/components/calendar/calendar.tsx
+++ b/packages/frosted-ui/src/components/calendar/calendar.tsx
@@ -238,9 +238,22 @@ function YearDropdown({ state }: { state: CalendarState | RangeCalendarState }) 
     timeZone: state.timeZone,
   });
 
-  // Format 20 years on each side of the current year according
-  // to the current locale and calendar system.
-  for (let i = -20; i <= 20; i++) {
+  // Calculate the year range based on minValue and maxValue if provided
+  let startYear = -20;
+  let endYear = 20;
+
+  if (state.minValue) {
+    const yearsFromMin = state.focusedDate.year - state.minValue.year;
+    startYear = -yearsFromMin;
+  }
+
+  if (state.maxValue) {
+    const yearsToMax = state.maxValue.year - state.focusedDate.year;
+    endYear = yearsToMax;
+  }
+
+  // Format years according to the calculated range
+  for (let i = startYear; i <= endYear; i++) {
     const date = state.focusedDate.add({ years: i });
     years.push({
       value: date,
@@ -255,10 +268,13 @@ function YearDropdown({ state }: { state: CalendarState | RangeCalendarState }) 
     state.setFocused(false);
   };
 
+  // Find the index of the current focused year
+  const currentYearIndex = years.findIndex((year) => year.value.year === state.focusedDate.year);
+
   return (
     <Select.Root
       aria-label="Year"
-      value={(20).toString()}
+      value={currentYearIndex.toString()}
       onValueChange={onChange}
       disabled={state.isDisabled}
       size="1"

--- a/packages/frosted-ui/src/components/date-picker/date-picker.stories.tsx
+++ b/packages/frosted-ui/src/components/date-picker/date-picker.stories.tsx
@@ -11,7 +11,9 @@ const meta = {
   args: {
     size: datePickerPropDefs.size.default,
     color: datePickerPropDefs.color.default,
+    minValue: parseDate('1901-01-03'),
     defaultValue: parseDate('2020-02-03'),
+    maxValue: parseDate('2022-03-03'),
     onChange: (date) => console.log(date?.toString()),
     'aria-label': 'Birth date',
     isDisabled: false,


### PR DESCRIPTION
Calendar year dropdown by default shows -20 to +20 years from the current year, but it wasn't handling minValue and maxValue. 
