### PR TITLE
fix(button): solid button tap highlight and disabled cursor

### DIFF
--- a/packages/frosted-ui/src/components/base-button/base-button.css
+++ b/packages/frosted-ui/src/components/base-button/base-button.css
@@ -166,13 +166,7 @@
     background-color: var(--accent-10);
     filter: var(--base-button-solid-active-filter);
   }
-  /* Better -webkit-tap-highlight-color */
-  @media (pointer: coarse) {
-    &:where(:active:not([data-state='open'])) {
-      outline: 0.5em solid var(--accent-a4);
-      outline-offset: 0;
-    }
-  }
+
   &:where(:focus-visible) {
     outline: 2px solid var(--color-focus-root);
     outline-offset: 2px;
@@ -197,6 +191,7 @@
     }
   }
   &:where([data-disabled]) {
+    cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     background-color: var(--gray-a3);
     outline: none;


### PR DESCRIPTION
Fixes to solid button:
- removes weird tap highlight on mobile devices
- fixes 'not available' cursor not showing in disabled state hover