### PR TITLE
fix(avatar,avatargroup): replace 'variant' prop with 'shape'

### DIFF
--- a/packages/frosted-ui/src/components/avatar-group/avatar-group.css
+++ b/packages/frosted-ui/src/components/avatar-group/avatar-group.css
@@ -24,7 +24,7 @@
   &:where(.fui-high-contrast) :where(.fui-AvatarFallback) {
     color: var(--accent-12);
   }
-  &:where(.fui-variant-round) {
+  &:where(.fui-shape-circle) {
     --radius-full: var(--radius-thumb);
   }
 }

--- a/packages/frosted-ui/src/components/avatar-group/avatar-group.props.ts
+++ b/packages/frosted-ui/src/components/avatar-group/avatar-group.props.ts
@@ -1,16 +1,16 @@
 import { colorProp, type PropDef } from '../../helpers';
 
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
-const variants = ['round', 'square'] as const;
+const shapes = ['circle', 'square'] as const;
 
 const avatarGroupPropDefs = {
   color: { ...colorProp, default: 'gray' },
   size: { type: 'enum', values: sizes, default: '3' },
-  variant: { type: 'enum', values: variants, default: 'round' },
+  shape: { type: 'enum', values: shapes, default: 'circle' },
 } satisfies {
   color: typeof colorProp;
   size: PropDef<(typeof sizes)[number]>;
-  variant: PropDef<(typeof variants)[number]>;
+  shape: PropDef<(typeof shapes)[number]>;
 };
 
 export { avatarGroupPropDefs };

--- a/packages/frosted-ui/src/components/avatar-group/avatar-group.tsx
+++ b/packages/frosted-ui/src/components/avatar-group/avatar-group.tsx
@@ -15,7 +15,7 @@ const AvatarGroupRoot = (props: AvatarGroupRootProps) => {
     className,
     children,
     size = avatarGroupPropDefs.size.default,
-    variant = avatarGroupPropDefs.variant.default,
+    shape = avatarGroupPropDefs.shape.default,
     color = avatarGroupPropDefs.color.default,
     ...rootProps
   } = props;
@@ -24,7 +24,7 @@ const AvatarGroupRoot = (props: AvatarGroupRootProps) => {
     <div
       data-accent-color={color}
       {...rootProps}
-      className={classNames('fui-AvatarGroupRoot', className, `fui-r-size-${size}`, `fui-variant-${variant}`)}
+      className={classNames('fui-AvatarGroupRoot', className, `fui-r-size-${size}`, `fui-shape-${shape}`)}
     >
       <div className="fui-AvatarGroupRootInner">{children}</div>
     </div>
@@ -33,7 +33,7 @@ const AvatarGroupRoot = (props: AvatarGroupRootProps) => {
 
 AvatarGroupRoot.displayName = 'AvatarGroupRoot';
 
-type AvatarGroupAvatarProps = Omit<React.ComponentProps<typeof Avatar>, 'size' | 'variant'>;
+type AvatarGroupAvatarProps = Omit<React.ComponentProps<typeof Avatar>, 'size' | 'shape'>;
 
 const AvatarGroupAvatar = ({ className, ...props }: AvatarGroupAvatarProps) => {
   return <Avatar size="3" className={classNames('fui-AvatarGroupAvatar', className)} {...props} />;

--- a/packages/frosted-ui/src/components/avatar/avatar.css
+++ b/packages/frosted-ui/src/components/avatar/avatar.css
@@ -21,7 +21,7 @@
   &:where(.fui-high-contrast) :where(.fui-AvatarFallback) {
     color: var(--accent-12);
   }
-  &:where(.fui-variant-round) {
+  &:where(.fui-shape-circle) {
     --radius-full: var(--radius-thumb);
   }
   &:where([data-status='loaded']) {

--- a/packages/frosted-ui/src/components/avatar/avatar.props.ts
+++ b/packages/frosted-ui/src/components/avatar/avatar.props.ts
@@ -2,17 +2,17 @@ import type { PropDef } from '../../helpers';
 import { colorProp, highContrastProp } from '../../helpers';
 
 const sizes = ['1', '2', '3', '4', '5', '6', '7', '8', '9'] as const;
-const variants = ['round', 'square'] as const;
+const shapes = ['circle', 'square'] as const;
 
 const avatarPropDefs = {
   size: { type: 'enum', values: sizes, default: '3' },
-  variant: { type: 'enum', values: variants, default: 'round' },
+  shape: { type: 'enum', values: shapes, default: 'circle' },
   color: { ...colorProp, default: undefined },
   highContrast: highContrastProp,
   fallback: { type: 'ReactNode', default: undefined, required: true },
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
-  variant: PropDef<(typeof variants)[number]>;
+  shape: PropDef<(typeof shapes)[number]>;
   color: typeof colorProp;
   highContrast: typeof highContrastProp;
   fallback: PropDef<React.ReactNode>;

--- a/packages/frosted-ui/src/components/avatar/avatar.stories.tsx
+++ b/packages/frosted-ui/src/components/avatar/avatar.stories.tsx
@@ -38,7 +38,7 @@ export const Default: Story = {
   ),
 };
 
-export const Variant: Story = {
+export const Shape: Story = {
   args: {
     fallback: 'Cameron Zoub',
     color: 'blue',
@@ -49,17 +49,17 @@ export const Variant: Story = {
         <Avatar
           {...args}
           src="https://images.unsplash.com/photo-1502823403499-6ccfcf4fb453?&w=256&h=256&q=70&crop=focalpoint&fp-x=0.5&fp-y=0.3&fp-z=1&fit=crop"
-          variant="round"
+          shape="circle"
         />
-        <Avatar {...args} variant="round" />
+        <Avatar {...args} shape="circle" />
       </div>
       <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
         <Avatar
           {...args}
           src="https://images.unsplash.com/photo-1502823403499-6ccfcf4fb453?&w=256&h=256&q=70&crop=focalpoint&fp-x=0.5&fp-y=0.3&fp-z=1&fit=crop"
-          variant="square"
+          shape="square"
         />
-        <Avatar {...args} variant="square" />
+        <Avatar {...args} shape="square" />
       </div>
     </div>
   ),

--- a/packages/frosted-ui/src/components/avatar/avatar.tsx
+++ b/packages/frosted-ui/src/components/avatar/avatar.tsx
@@ -23,7 +23,7 @@ const Avatar = (props: AvatarProps) => {
     color = avatarPropDefs.color.default,
     highContrast = avatarPropDefs.highContrast.default,
     fallback: fallbackProp,
-    variant = avatarPropDefs.variant.default,
+    shape = avatarPropDefs.shape.default,
     ...imageProps
   } = props;
   const [status, setStatus] = React.useState<ImageStatus>('idle');
@@ -48,7 +48,7 @@ const Avatar = (props: AvatarProps) => {
         className,
         `fui-r-size-${size}`,
         { 'fui-high-contrast': highContrast },
-        `fui-variant-${variant}`,
+        `fui-shape-${shape}`,
       )}
       style={style}
     >


### PR DESCRIPTION
Replacing `variant = round | square` in `<Avatar />` component with `shape = circle | square`.
Variant was a wrong name for that prop, because it should be reserved for visual appearance like `solid | classic | soft`. 

