### PR TITLE
fix(switch): tooltip breaks switch styling

### DIFF
--- a/packages/frosted-ui/src/components/switch/switch.css
+++ b/packages/frosted-ui/src/components/switch/switch.css
@@ -53,11 +53,11 @@
      */
     background-size: calc(var(--switch-width) * 2 + var(--switch-height)) 100%;
   }
-  &:where([data-state='unchecked'])::before {
+  &:where([aria-checked='false'])::before {
     transition-duration: 120ms, 140ms, 140ms, 140ms;
     background-position-x: 100%;
   }
-  &:where([data-state='checked'])::before {
+  &:where([aria-checked='true'])::before {
     transition-duration: 160ms, 140ms, 140ms, 140ms;
     background-position: 0%;
   }
@@ -80,7 +80,7 @@
     transform 140ms cubic-bezier(0.45, 0.05, 0.55, 0.95),
     box-shadow 140ms ease-in-out;
 
-  &:where([data-state='checked']) {
+  &:where([aria-checked='true'] > &) {
     transform: translateX(var(--switch-thumb-translate-x));
   }
 }
@@ -126,17 +126,17 @@
       background-color: var(--gray-a4);
       box-shadow: var(--shadow-1);
     }
-    &:where([data-state='unchecked']:active)::before {
+    &:where([aria-checked='false']:active)::before {
       background-color: var(--gray-a5);
     }
-    &:where([data-state='checked'])::before {
+    &:where([aria-checked='true'])::before {
       box-shadow:
         inset 0 0 0 1px var(--gray-a3),
         inset 0 0 0 1px var(--accent-a4),
         inset 0 0 0 1px var(--black-a1),
         inset 0 1.5px 2px 0 var(--black-a2);
     }
-    &:where([data-state='checked']:active)::before {
+    &:where([aria-checked='true']:active)::before {
       filter: var(--switch-button-surface-checked-active-filter);
     }
     &:where(.fui-high-contrast) {
@@ -151,7 +151,7 @@
           linear-gradient(to right, var(--switch-button-high-contrast-checked-color-overlay) 40%, transparent 60%),
           linear-gradient(to right, var(--accent-9) 40%, transparent 60%);
       }
-      &:where([data-state='checked']:active)::before {
+      &:where([aria-checked='true']:active)::before {
         filter: var(--switch-button-high-contrast-checked-active-before-filter);
       }
     }
@@ -171,13 +171,13 @@
   }
 
   & :where(.fui-SwitchThumb) {
-    &:where([data-state='unchecked']) {
+    &:where([aria-checked='false'] > &) {
       box-shadow:
         0 1px 3px var(--black-a3),
         0 2px 4px -1px var(--black-a1),
         0 0 0 1px var(--black-a2);
     }
-    &:where([data-state='checked']) {
+    &:where([aria-checked='true'] > &) {
       box-shadow:
         0 1px 3px var(--black-a2),
         0 2px 4px -1px var(--black-a1),


### PR DESCRIPTION
When Switch is wrapped in a `<Tooltip />` the switch background color breaks (it looks like its toggled on even when it isn't). This is caused by Tooltip passing `data-state` attribute to its child (switch) and since switch styles are based on conflicting `data-state` attribute too, the wrong background color is applied:

<img width="646" height="156" alt="Screenshot 2025-09-30 at 15 19 29" src="https://github.com/user-attachments/assets/5d73390b-6cef-4693-966b-97cb096837cc" />

To fix this, I've applied switch style rules based on `aria-checked` attribute.

