### PR TITLE
perf(tooltip): remove 'type' prop

### DIFF
--- a/packages/frosted-ui/src/components/tooltip/tooltip.props.ts
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.props.ts
@@ -1,17 +1,9 @@
 import type { PropDef } from '../../helpers';
 
-const typeValues = ['always', 'overflow'] as const;
-
 const tooltipPropDefs = {
   content: { type: 'ReactNode', default: undefined, required: true },
-  type: {
-    type: 'enum',
-    values: typeValues,
-    default: 'always',
-  },
 } satisfies {
   content: PropDef<React.ReactNode>;
-  type: PropDef<(typeof typeValues)[number]>;
 };
 
 export { tooltipPropDefs };

--- a/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { IconButton, Text, Tooltip, tooltipPropDefs } from '..';
+import { IconButton, Tooltip } from '..';
 
 const ExampleIcon = ({ size }: { size: number }) => (
   <svg width={size} height={size} viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -17,9 +17,7 @@ const ExampleIcon = ({ size }: { size: number }) => (
 const meta = {
   title: 'Components/Tooltip',
   component: Tooltip,
-  args: {
-    type: tooltipPropDefs.type.default,
-  },
+  args: {},
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered',
@@ -43,33 +41,4 @@ export const Default: Story = {
       </IconButton>
     </Tooltip>
   ),
-};
-
-export const ShowOnOverflow: Story = {
-  name: 'Show on overflow',
-  args: {
-    content: 'This is a really long text',
-    type: 'overflow',
-  },
-  render: ({ content, type }) => {
-    return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-5)' }}>
-        <Tooltip content={content} type={type} defaultOpen>
-          <Text>{content}</Text>
-        </Tooltip>
-        <Tooltip content={content} type={type} defaultOpen>
-          <Text
-            style={{
-              width: 100,
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              whiteSpace: 'nowrap',
-            }}
-          >
-            {content}
-          </Text>
-        </Tooltip>
-      </div>
-    );
-  },
 };

--- a/packages/frosted-ui/src/components/tooltip/tooltip.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.tsx
@@ -31,83 +31,32 @@ const Tooltip = (props: TooltipProps) => {
     content,
     container,
     forceMount,
-    type = tooltipPropDefs.type.default,
     ...tooltipContentProps
   } = props;
-
-  const [isOverflowing, setIsOverflowing] = React.useState(false);
-  const [triggerElement, setTriggerElement] = React.useState<HTMLButtonElement | null>(null);
-
-  React.useLayoutEffect(() => {
-    if (type === 'overflow' && triggerElement) {
-      const updateTriggerOverflow = () => {
-        const isOverflowing =
-          triggerElement.offsetWidth < triggerElement.scrollWidth ||
-          triggerElement.offsetHeight < triggerElement.scrollHeight;
-
-        setIsOverflowing(isOverflowing);
-      };
-
-      updateTriggerOverflow();
-
-      const resizeObserver = new ResizeObserver(() => {
-        updateTriggerOverflow();
-      });
-      resizeObserver.observe(triggerElement);
-
-      const mutationObserver = new MutationObserver(() => {
-        updateTriggerOverflow();
-      });
-      mutationObserver.observe(triggerElement, {
-        attributes: true,
-        childList: true,
-        subtree: true,
-      });
-
-      return () => {
-        resizeObserver.disconnect();
-        mutationObserver.disconnect();
-      };
-    } else {
-      setIsOverflowing(false);
-    }
-  }, [triggerElement, type]);
-
   const rootProps = {
-    open: open !== undefined ? (type === 'overflow' ? open && isOverflowing : open) : open,
-    defaultOpen:
-      defaultOpen !== undefined ? (type === 'overflow' ? defaultOpen && isOverflowing : defaultOpen) : defaultOpen,
+    open,
+    defaultOpen,
     onOpenChange,
     delayDuration,
     disableHoverableContent,
   };
-
   return (
     <TooltipPrimitive.Root {...rootProps}>
-      <TooltipPrimitive.Trigger
-        asChild
-        ref={(e) => {
-          setTriggerElement(e as HTMLButtonElement);
-        }}
-      >
-        {children}
-      </TooltipPrimitive.Trigger>
+      <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
       <TooltipPrimitive.Portal container={container} forceMount={forceMount}>
-        {(type === 'overflow' ? isOverflowing : true) ? (
-          <Theme asChild>
-            <TooltipPrimitive.Content
-              sideOffset={4}
-              collisionPadding={10}
-              {...tooltipContentProps}
-              className={classNames('fui-TooltipContent', className)}
-            >
-              <Text as="p" className="fui-TooltipText" size="1">
-                {content}
-              </Text>
-              <TooltipPrimitive.Arrow className="fui-TooltipArrow" />
-            </TooltipPrimitive.Content>
-          </Theme>
-        ) : null}
+        <Theme asChild>
+          <TooltipPrimitive.Content
+            sideOffset={4}
+            collisionPadding={10}
+            {...tooltipContentProps}
+            className={classNames('fui-TooltipContent', className)}
+          >
+            <Text as="p" className="fui-TooltipText" size="1">
+              {content}
+            </Text>
+            <TooltipPrimitive.Arrow className="fui-TooltipArrow" />
+          </TooltipPrimitive.Content>
+        </Theme>
       </TooltipPrimitive.Portal>
     </TooltipPrimitive.Root>
   );


### PR DESCRIPTION
The `type="overflow"` wasn't frequently and was causing browser reflows when measuring elements size, that's why we drop support for it.