### PR TITLE
perf: optimize CSS selectors

### DIFF
--- a/packages/frosted-ui/.storybook/main.ts
+++ b/packages/frosted-ui/.storybook/main.ts
@@ -46,5 +46,22 @@ const config: StorybookConfig = {
       },
     },
   },
+
+  viteFinal: (config) => {
+    return {
+      ...config,
+      optimizeDeps: {
+        ...config.optimizeDeps,
+        exclude: [
+          '@storybook/addon-docs',
+          '@storybook/blocks',
+          '@storybook/theming',
+          '@storybook/components',
+          '@storybook/preview-api',
+          '@storybook/manager-api',
+        ],
+      },
+    };
+  },
 };
 export default config;

--- a/packages/frosted-ui/src/components/base-button/base-button.css
+++ b/packages/frosted-ui/src/components/base-button/base-button.css
@@ -65,8 +65,10 @@
   --base-button-classic-high-contrast-active-filter: contrast(0.82) saturate(1.2) brightness(1.16);
 }
 /* prettier-ignore */
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --base-button-classic-active-filter: brightness(1.08);
   --base-button-classic-high-contrast-hover-filter: contrast(0.88) saturate(1.3) brightness(1.14);
   --base-button-classic-high-contrast-active-filter: brightness(0.95) saturate(1.2);
@@ -142,8 +144,10 @@
   --base-button-solid-high-contrast-hover-filter: contrast(0.88) saturate(1.1) brightness(1.1);
   --base-button-solid-high-contrast-active-filter: contrast(0.82) saturate(1.2) brightness(1.16);
 }
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --base-button-solid-active-filter: brightness(1.08);
   --base-button-solid-high-contrast-hover-filter: contrast(0.88) saturate(1.3) brightness(1.18);
   --base-button-solid-high-contrast-active-filter: brightness(0.95) saturate(1.2);

--- a/packages/frosted-ui/src/components/base-menu/base-menu.css
+++ b/packages/frosted-ui/src/components/base-menu/base-menu.css
@@ -211,8 +211,10 @@
   --color-base-menu-outline: transparent;
 }
 /* prettier-ignore */
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --color-base-menu-outline: black;
 }
 

--- a/packages/frosted-ui/src/components/base-segmented-control-list/base-segmented-control-list.css
+++ b/packages/frosted-ui/src/components/base-segmented-control-list/base-segmented-control-list.css
@@ -75,7 +75,9 @@
 :where(.frosted-ui) {
   --color-segmented-control-thumb: var(--color-panel-solid);
 }
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --color-segmented-control-thumb: transparent;
 }

--- a/packages/frosted-ui/src/components/card/card.css
+++ b/packages/frosted-ui/src/components/card/card.css
@@ -171,8 +171,10 @@
   --card-background: var(--color-panel-solid);
 }
 /* prettier-ignore */
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --card-classic-hover-box-shadow:
     0 0 0 1px var(--gray-a7),
     0 0 1px 1px var(--gray-a7),
@@ -183,16 +185,14 @@
   --card-background: var(--color-panel-solid);
 }
 
-/* prettier-ignore */
 @supports (color: color-mix(in oklab, white, black)) {
-  :is(.dark, .dark-theme),
-  :is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+  .dark,
+  .dark-theme,
+  .dark :where(.frosted-ui:not(.light, .light-theme)),
+  .dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
     --card-classic-hover-box-shadow:
-      0 0 0 1px color-mix(in oklab, var(--gray-a7), var(--gray-8)),
-      0 0 1px 1px var(--gray-a7),
-      0 0 1px -1px var(--gray-a4),
-      0 0 3px -2px var(--gray-a3),
-      0 0 12px -2px var(--gray-a3),
+      0 0 0 1px color-mix(in oklab, var(--gray-a7), var(--gray-8)), 0 0 1px 1px var(--gray-a7),
+      0 0 1px -1px var(--gray-a4), 0 0 3px -2px var(--gray-a3), 0 0 12px -2px var(--gray-a3),
       0 0 16px -8px var(--gray-a9);
   }
 }

--- a/packages/frosted-ui/src/components/hover-card/hover-card.css
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.css
@@ -22,8 +22,10 @@
 :where(.frosted-ui) {
   --color-popover-outline: transparent;
 }
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --color-popover-outline: black;
 }
 

--- a/packages/frosted-ui/src/components/kbd/kbd.css
+++ b/packages/frosted-ui/src/components/kbd/kbd.css
@@ -8,8 +8,10 @@
     0 0 0 0.05em var(--gray-a5),
     0 0.08em 0.17em var(--gray-a7);
 }
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   /* prettier-ignore */
   --kbd-box-shadow:
     inset 0 -0.05em 0.5em var(--gray-a3),

--- a/packages/frosted-ui/src/components/popover/popover.css
+++ b/packages/frosted-ui/src/components/popover/popover.css
@@ -23,8 +23,10 @@
 :where(.frosted-ui) {
   --color-popover-outline: transparent;
 }
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --color-popover-outline: black;
 }
 

--- a/packages/frosted-ui/src/components/select/select.css
+++ b/packages/frosted-ui/src/components/select/select.css
@@ -336,8 +336,10 @@
 }
 
 /* prettier-ignore */
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --select-trigger-classic-box-shadow:
     inset 0 0 0 1px var(--white-a4),
     inset 0 1px 1px var(--white-a4),
@@ -470,8 +472,10 @@
   --color-select-outline: transparent;
 }
 /* prettier-ignore */
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --color-select-outline: black;
 }
 

--- a/packages/frosted-ui/src/components/slider/slider.css
+++ b/packages/frosted-ui/src/components/slider/slider.css
@@ -140,8 +140,10 @@
 :where(.frosted-ui) {
   --slider-range-high-contrast-background-image: linear-gradient(var(--black-a8), var(--black-a8));
 }
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --slider-range-high-contrast-background-image: none;
 }
 .fui-SliderRoot:where(.fui-high-contrast) {
@@ -154,8 +156,10 @@
 :where(.frosted-ui) {
   --slider-disabled-blend-mode: multiply;
 }
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --slider-disabled-blend-mode: screen;
 }
 

--- a/packages/frosted-ui/src/components/switch/switch.css
+++ b/packages/frosted-ui/src/components/switch/switch.css
@@ -4,8 +4,10 @@
   --switch-button-high-contrast-checked-active-before-filter: contrast(0.82) saturate(1.2) brightness(1.16);
 }
 
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --switch-disabled-blend-mode: screen;
   --switch-button-high-contrast-checked-color-overlay: transparent;
   --switch-button-high-contrast-checked-active-before-filter: brightness(1.08);
@@ -114,8 +116,10 @@
 :where(.frosted-ui) {
   --switch-button-surface-checked-active-filter: brightness(0.92) saturate(1.1);
 }
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --switch-button-surface-checked-active-filter: brightness(1.08);
 }
 

--- a/packages/frosted-ui/src/components/table/table.css
+++ b/packages/frosted-ui/src/components/table/table.css
@@ -150,8 +150,10 @@
 :where(.frosted-ui) {
   --data-table-border-color: color-mix(in oklab, var(--gray-a5), var(--gray-6));
 }
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --data-table-border-color: color-mix(in oklab, var(--gray-a3), var(--gray-4));
 }
 

--- a/packages/frosted-ui/src/components/tooltip/tooltip.css
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.css
@@ -38,8 +38,10 @@
   --color-tooltip-outline: transparent;
 }
 /* prettier-ignore */
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --color-tooltip-outline: black;
 }
 

--- a/packages/frosted-ui/src/styles/tokens/color.css
+++ b/packages/frosted-ui/src/styles/tokens/color.css
@@ -199,8 +199,10 @@
   --color-panel-elevation-a12: rgba(255, 255, 255, 0.2);
 }
 
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --color-background: var(--gray-1);
   --color-overlay: var(--black-a8);
   --color-panel-solid: var(--gray-2);
@@ -255,7 +257,7 @@
   --color-focus-root: var(--accent-8);
 }
 
-.frosted-ui ::selection {
+::selection {
   background-color: var(--color-selection-root);
 }
 

--- a/packages/frosted-ui/src/styles/tokens/shadow.css
+++ b/packages/frosted-ui/src/styles/tokens/shadow.css
@@ -36,8 +36,10 @@
 }
 
 /* prettier-ignore */
-:is(.dark, .dark-theme),
-:is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+.dark,
+.dark-theme,
+.dark :where(.frosted-ui:not(.light, .light-theme)),
+.dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
   --shadow-1:
     inset 0 -1px 1px 0 var(--gray-a3),
     inset 0 0 0 1px var(--gray-a3),
@@ -76,8 +78,10 @@
 
 /* prettier-ignore */
 @supports (color: color-mix(in oklab, white, black)) {
-  :is(.dark, .dark-theme),
-  :is(.dark, .dark-theme) :where(.frosted-ui:not(.light, .light-theme)) {
+  .dark,
+  .dark-theme,
+  .dark :where(.frosted-ui:not(.light, .light-theme)),
+  .dark-theme :where(.frosted-ui:not(.light, .light-theme)) {
     --shadow-1:
       inset 0 -1px 1px 0 var(--gray-a3),
       inset 0 0 0 1px var(--gray-a3),


### PR DESCRIPTION
Simple list selectors seem to be performing better. From initial testing in the complex app it shaved off around 50ms of "elapsed time" in selector stats in performance profiler. This was tested via sources override in chrome devtools which is quite buggy, that's why I want to release updated version, install it in our app and test in preview.