### PR TITLE
feat: expose styles.lite.css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ coverage
 # build output
 dist/
 packages/frosted-ui/styles.css
+packages/frosted-ui/styles.lite.css
 
 # misc
 .DS_Store

--- a/packages/frosted-ui/package.json
+++ b/packages/frosted-ui/package.json
@@ -22,6 +22,11 @@
       "require": "./styles.css",
       "default": "./styles.css"
     },
+    "./styles.lite.css": {
+      "import": "./styles.lite.css",
+      "require": "./styles.lite.css",
+      "default": "./styles.lite.css"
+    },
     "./*": {
       "require": {
         "types": "./dist/cjs/*.d.ts",
@@ -37,14 +42,15 @@
   "license": "MIT",
   "files": [
     "dist/**",
-    "styles.css"
+    "styles.css",
+    "styles.lite.css"
   ],
   "scripts": {
     "build": "rm -rf ./dist && pnpm build:js && pnpm build:css",
     "build:js": "pnpm build:js:cjs && pnpm build:js:esm",
     "build:js:cjs": "tsc --project tsconfig-cjs.json",
     "build:js:esm": "tsc --project tsconfig-esm.json",
-    "build:css": "postcss src/styles/index.css -o styles.css",
+    "build:css": "postcss src/styles/index.css -o styles.css && node scripts/build-lite-css.js src/styles/index.css -o styles.lite.css",
     "dev": "pnpm dev:js & pnpm dev:css",
     "dev:js": "pnpm dev:js:cjs & pnpm dev:js:esm",
     "dev:js:cjs": "tsc --project tsconfig-cjs.json --watch",
@@ -54,7 +60,7 @@
     "lint:js": "eslint \"src/**/*.ts*\"",
     "lint:css": "stylelint \"src/**/*.css\"",
     "generate:emoji-colors": "tsx scripts/emoji-colors/generate.ts",
-    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf styles.css",
+    "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist && rm -rf styles.css && rm -rf styles.lite.css",
     "prepublishOnly": "pnpm lint",
     "storybook": "pnpm dev:css & storybook dev -p 6006",
     "build-storybook": "storybook build --webpack-stats-json",

--- a/packages/frosted-ui/postcss-remove-p3.js
+++ b/packages/frosted-ui/postcss-remove-p3.js
@@ -1,0 +1,41 @@
+module.exports = () => ({
+  postcssPlugin: 'postcss-remove-p3',
+  OnceExit(root) {
+    const toRemove = [];
+    // Collect all P3 rules first, then remove them
+    root.walkAtRules((atRule) => {
+      if (atRule.name === 'supports') {
+        const params = String(atRule.params || '');
+        if (params.includes('display-p3')) {
+          toRemove.push(atRule);
+        } else {
+          // Check nested @media rules
+          atRule.walkAtRules('media', (mediaRule) => {
+            const mediaParams = String(mediaRule.params || '');
+            if (mediaParams.includes('color-gamut: p3') || mediaParams.includes('color-gamut:p3')) {
+              toRemove.push(atRule);
+            }
+          });
+        }
+      } else if (atRule.name === 'media') {
+        const params = String(atRule.params || '');
+        if (params.includes('color-gamut: p3') || params.includes('color-gamut:p3')) {
+          const parent = atRule.parent;
+          if (parent && parent.type === 'atrule' && parent.name === 'supports') {
+            toRemove.push(parent);
+          } else {
+            toRemove.push(atRule);
+          }
+        }
+      }
+    });
+    // Remove all collected rules
+    toRemove.forEach((rule) => {
+      if (!rule.removed) {
+        rule.remove();
+      }
+    });
+  },
+});
+
+module.exports.postcss = true;

--- a/packages/frosted-ui/postcss.config.lite.js
+++ b/packages/frosted-ui/postcss.config.lite.js
@@ -1,0 +1,19 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable no-undef */
+const path = require('path');
+const removeP3 = require('./postcss-remove-p3');
+
+module.exports = {
+  plugins: [
+    require('postcss-import')({
+      path: [path.relative(process.cwd(), '../')],
+    }),
+    require('postcss-nesting'),
+    require('./postcss-frosted-ui'),
+    require('postcss-custom-media'),
+    require('postcss-combine-duplicated-selectors'),
+    removeP3(),
+    require('postcss-discard-empty'),
+    require('autoprefixer'),
+  ],
+};

--- a/packages/frosted-ui/scripts/build-lite-css.js
+++ b/packages/frosted-ui/scripts/build-lite-css.js
@@ -1,0 +1,29 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+/* eslint-disable no-undef */
+const postcss = require('postcss');
+const config = require('../postcss.config.lite.js');
+const fs = require('fs');
+const path = require('path');
+
+// Parse command line arguments: node script.js input.css -o output.css
+const args = process.argv.slice(2);
+const inputIndex = args.findIndex(arg => !arg.startsWith('-'));
+const outputIndex = args.indexOf('-o');
+const inputFile = inputIndex >= 0 ? path.resolve(args[inputIndex]) : path.join(__dirname, '../src/styles/index.css');
+const outputFile = outputIndex >= 0 && args[outputIndex + 1] ? path.resolve(args[outputIndex + 1]) : path.join(__dirname, '../styles.lite.css');
+
+const css = fs.readFileSync(inputFile, 'utf8');
+
+postcss(config.plugins)
+  .process(css, { from: inputFile, to: outputFile })
+  .then((result) => {
+    fs.writeFileSync(outputFile, result.css);
+    if (result.map) {
+      fs.writeFileSync(outputFile + '.map', result.map.toString());
+    }
+  })
+  .catch((error) => {
+    console.error('Error building lite CSS:', error);
+    process.exit(1);
+  });
+


### PR DESCRIPTION
Exporting `styles.lite.css` without P3 colors which reduced the CSS bundle by around 29% down to 8.5k LOC.