### PR TITLE
feat: new tooltip

### DIFF
--- a/packages/frosted-ui/src/components/tooltip/tooltip.css
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.css
@@ -1,8 +1,7 @@
 .fui-TooltipContent {
   padding: var(--space-1) var(--space-2);
-  background-color: var(--color-panel-translucent);
-  -webkit-backdrop-filter: var(--backdrop-filter-panel);
-  backdrop-filter: var(--backdrop-filter-panel);
+  background-color: var(--gray-12);
+  color: var(--gray-1);
 
   border-radius: var(--radius-4);
   border: 1px solid var(--gray-a6);
@@ -46,11 +45,11 @@
 }
 
 .fui-TooltipText {
-  color: var(--gray-12);
+  color: var(--gray-1);
   user-select: none;
   cursor: default;
 }
 
 .fui-TooltipArrow {
-  fill: transparent;
+  fill: var(--gray-12);
 }

--- a/packages/frosted-ui/src/components/tooltip/tooltip.css
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.css
@@ -5,7 +5,10 @@
 
   border-radius: var(--radius-4);
 
-  box-shadow: 0px 6px 10px 0px rgba(0, 0, 0, 0.05);
+  box-shadow:
+    0 4px 16px -8px rgba(0, 0, 0, 0.08),
+    0 3px 12px -4px rgba(0, 0, 0, 0.05),
+    0 2px 3px -2px rgba(0, 0, 61, 0.05);
 
   transform-origin: var(--radix-tooltip-content-transform-origin);
 

--- a/packages/frosted-ui/src/components/tooltip/tooltip.css
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.css
@@ -4,8 +4,6 @@
   color: var(--gray-1);
 
   border-radius: var(--radius-4);
-  border: 1px solid var(--gray-a6);
-  outline: 0.5px solid var(--color-tooltip-outline);
 
   box-shadow: 0px 6px 10px 0px rgba(0, 0, 0, 0.05);
 

--- a/packages/frosted-ui/src/components/tooltip/tooltip.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.tsx
@@ -51,7 +51,7 @@ const Tooltip = (props: TooltipProps) => {
             {...tooltipContentProps}
             className={classNames('fui-TooltipContent', className)}
           >
-            <Text as="p" className="fui-TooltipText" size="1">
+            <Text as="p" className="fui-TooltipText" size="2">
               {content}
             </Text>
             <TooltipPrimitive.Arrow className="fui-TooltipArrow" />


### PR DESCRIPTION
New Tooltip styles with contrasting color and an arrow:
<img width="450" height="223" alt="Screenshot 2025-11-20 at 18 36 48" src="https://github.com/user-attachments/assets/b88b4abe-b570-4f5d-aad6-fb9e3e178073" />
