### PR TITLE
Semantic colors

### DIFF
--- a/packages/frosted-ui-react-native/app/_accent-color-context.tsx
+++ b/packages/frosted-ui-react-native/app/_accent-color-context.tsx
@@ -8,6 +8,7 @@ type AccentColorContextValue = {
 
 export const AccentColorContext = React.createContext<AccentColorContextValue>({
   accentColor: 'blue',
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   setAccentColor: () => {},
 });
 

--- a/packages/frosted-ui-react-native/app/_accent-color-context.tsx
+++ b/packages/frosted-ui-react-native/app/_accent-color-context.tsx
@@ -1,0 +1,16 @@
+import type { AccentColor } from '@frosted-ui/react-native';
+import * as React from 'react';
+
+type AccentColorContextValue = {
+  accentColor: AccentColor;
+  setAccentColor: (color: AccentColor) => void;
+};
+
+export const AccentColorContext = React.createContext<AccentColorContextValue>({
+  accentColor: 'blue',
+  setAccentColor: () => {},
+});
+
+export function useAccentColorConfig() {
+  return React.useContext(AccentColorContext);
+}

--- a/packages/frosted-ui-react-native/app/_header.tsx
+++ b/packages/frosted-ui-react-native/app/_header.tsx
@@ -34,12 +34,7 @@ export function ThemeToggle() {
   const { colorScheme, toggleColorScheme } = useTheme();
 
   return (
-    <IconButton
-      onPressIn={toggleColorScheme}
-      size="3"
-      variant="ghost"
-      color="gray"
-      style={styles.themeToggle}>
+    <IconButton onPressIn={toggleColorScheme} size="3" variant="ghost" style={styles.themeToggle}>
       <Icon as={THEME_ICONS[colorScheme]} size={20} />
     </IconButton>
   );

--- a/packages/frosted-ui-react-native/app/_header.tsx
+++ b/packages/frosted-ui-react-native/app/_header.tsx
@@ -1,16 +1,47 @@
-import { Icon, IconButton, useTheme, useThemeTokens } from '@frosted-ui/react-native';
+import {
+  DropdownMenu,
+  Icon,
+  IconButton,
+  useTheme,
+  useThemeTokens,
+  type AccentColor,
+} from '@frosted-ui/react-native';
 import { MoonStarIcon, SunIcon } from 'lucide-react-native';
-import { Platform, StyleSheet, View } from 'react-native';
+import { ActionSheetIOS, Platform, StyleSheet, View } from 'react-native';
+import { useAccentColorConfig } from './_accent-color-context';
 
 const THEME_ICONS = {
   light: SunIcon,
   dark: MoonStarIcon,
 };
 
+// Popular accent colors to show in the picker
+const ACCENT_COLORS: { value: AccentColor; label: string }[] = [
+  { value: 'blue', label: 'Blue' },
+  { value: 'indigo', label: 'Indigo' },
+  { value: 'purple', label: 'Purple' },
+  { value: 'violet', label: 'Violet' },
+  { value: 'magenta', label: 'Magenta' },
+  { value: 'pink', label: 'Pink' },
+  { value: 'red', label: 'Red' },
+  { value: 'orange', label: 'Orange' },
+  { value: 'amber', label: 'Amber' },
+  { value: 'yellow', label: 'Yellow' },
+  { value: 'lime', label: 'Lime' },
+  { value: 'green', label: 'Green' },
+  { value: 'teal', label: 'Teal' },
+  { value: 'cyan', label: 'Cyan' },
+];
+
 const styles = StyleSheet.create({
-  themeToggle: {
-    borderRadius: 9999,
+  headerRight: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
     ...(Platform.OS === 'web' && { marginRight: 16 }),
+  },
+  iconButton: {
+    borderRadius: 9999,
   },
 });
 
@@ -30,13 +61,91 @@ function HeaderBackground() {
   );
 }
 
-export function ThemeToggle() {
+function ThemeToggle() {
   const { colorScheme, toggleColorScheme } = useTheme();
 
   return (
-    <IconButton onPressIn={toggleColorScheme} size="3" variant="ghost" style={styles.themeToggle}>
+    <IconButton onPressIn={toggleColorScheme} size="3" variant="ghost" style={styles.iconButton}>
       <Icon as={THEME_ICONS[colorScheme]} size={20} />
     </IconButton>
+  );
+}
+
+function AccentColorPicker() {
+  const { accentColor, setAccentColor } = useAccentColorConfig();
+  const { colors } = useThemeTokens();
+
+  const colorCircle = (
+    <View
+      style={{
+        width: 18,
+        height: 18,
+        borderRadius: 9,
+        backgroundColor: colors.palettes.accent['9'],
+      }}
+    />
+  );
+
+  // iOS: Use native ActionSheet for better UX
+  if (Platform.OS === 'ios') {
+    const handlePress = () => {
+      const options = [...ACCENT_COLORS.map((c) => c.label), 'Cancel'];
+      const cancelButtonIndex = options.length - 1;
+      const currentIndex = ACCENT_COLORS.findIndex((c) => c.value === accentColor);
+
+      ActionSheetIOS.showActionSheetWithOptions(
+        {
+          title: 'Accent Color',
+          options,
+          cancelButtonIndex,
+          // Highlight current selection (iOS 14+)
+          ...(currentIndex >= 0 && { destructiveButtonIndex: undefined }),
+        },
+        (buttonIndex) => {
+          if (buttonIndex !== cancelButtonIndex && buttonIndex < ACCENT_COLORS.length) {
+            setAccentColor(ACCENT_COLORS[buttonIndex].value);
+          }
+        }
+      );
+    };
+
+    return (
+      <IconButton size="3" variant="ghost" style={styles.iconButton} onPress={handlePress}>
+        {colorCircle}
+      </IconButton>
+    );
+  }
+
+  // Web/Android: Use DropdownMenu
+  return (
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger asChild>
+        <IconButton size="3" variant="ghost" style={styles.iconButton}>
+          {colorCircle}
+        </IconButton>
+      </DropdownMenu.Trigger>
+      <DropdownMenu.Content side="bottom" align="end" sideOffset={8}>
+        <DropdownMenu.Label>Accent Color</DropdownMenu.Label>
+        <DropdownMenu.RadioGroup
+          value={accentColor}
+          onValueChange={(v) => setAccentColor(v as AccentColor)}>
+          {ACCENT_COLORS.map((color) => (
+            <DropdownMenu.RadioItem key={color.value} value={color.value}>
+              {color.label}
+            </DropdownMenu.RadioItem>
+          ))}
+        </DropdownMenu.RadioGroup>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  );
+}
+
+function HeaderRight() {
+  return (
+    <View style={styles.headerRight}>
+      <AccentColorPicker />
+      <ThemeToggle />
+    </View>
   );
 }
 
@@ -46,6 +155,6 @@ export function useHeaderOptions() {
     headerTransparent: true,
     headerBlurEffect: colorScheme === 'dark' ? ('dark' as const) : ('light' as const),
     headerBackground: Platform.OS !== 'ios' ? () => <HeaderBackground /> : undefined,
-    headerRight: () => <ThemeToggle />,
+    headerRight: () => <HeaderRight />,
   };
 }

--- a/packages/frosted-ui-react-native/app/_header.tsx
+++ b/packages/frosted-ui-react-native/app/_header.tsx
@@ -86,20 +86,19 @@ function AccentColorPicker() {
     />
   );
 
-  // iOS: Use native ActionSheet for better UX
+  // iOS: Use native ActionSheet
+  // Note: userInterfaceStyle for dark mode doesn't work in Expo Go, only in dev client builds
   if (Platform.OS === 'ios') {
     const handlePress = () => {
       const options = [...ACCENT_COLORS.map((c) => c.label), 'Cancel'];
       const cancelButtonIndex = options.length - 1;
-      const currentIndex = ACCENT_COLORS.findIndex((c) => c.value === accentColor);
 
       ActionSheetIOS.showActionSheetWithOptions(
         {
           title: 'Accent Color',
           options,
           cancelButtonIndex,
-          // Highlight current selection (iOS 14+)
-          ...(currentIndex >= 0 && { destructiveButtonIndex: undefined }),
+          tintColor: colors.palettes.accent['9'],
         },
         (buttonIndex) => {
           if (buttonIndex !== cancelButtonIndex && buttonIndex < ACCENT_COLORS.length) {

--- a/packages/frosted-ui-react-native/app/_layout.tsx
+++ b/packages/frosted-ui-react-native/app/_layout.tsx
@@ -1,4 +1,4 @@
-import { NAV_THEME } from '@/lib/theme';
+import { useNavTheme } from '@/lib/theme';
 import {
   ThemeProvider as FrostedThemeProvider,
   useTheme,
@@ -19,13 +19,14 @@ export {
 function RootLayoutContent() {
   const { colorScheme } = useTheme();
   const { colors } = useThemeTokens();
+  const navTheme = useNavTheme();
 
   useEffect(() => {
     SystemUI.setBackgroundColorAsync(colors.background);
   }, [colors.background]);
 
   return (
-    <NavigationThemeProvider value={NAV_THEME[colorScheme]}>
+    <NavigationThemeProvider value={navTheme[colorScheme]}>
       <StatusBar style={colorScheme === 'dark' ? 'light' : 'dark'} />
       <Stack />
       <PortalHost />

--- a/packages/frosted-ui-react-native/app/_layout.tsx
+++ b/packages/frosted-ui-react-native/app/_layout.tsx
@@ -1,12 +1,12 @@
 import { useNavTheme } from '@/lib/theme';
 import {
   ThemeProvider as FrostedThemeProvider,
+  PortalHost,
   useTheme,
   useThemeTokens,
   type AccentColor,
 } from '@frosted-ui/react-native';
 import { ThemeProvider as NavigationThemeProvider } from '@react-navigation/native';
-import { PortalHost } from '@rn-primitives/portal';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SystemUI from 'expo-system-ui';

--- a/packages/frosted-ui-react-native/app/_layout.tsx
+++ b/packages/frosted-ui-react-native/app/_layout.tsx
@@ -3,13 +3,16 @@ import {
   ThemeProvider as FrostedThemeProvider,
   useTheme,
   useThemeTokens,
+  type AccentColor,
 } from '@frosted-ui/react-native';
 import { ThemeProvider as NavigationThemeProvider } from '@react-navigation/native';
 import { PortalHost } from '@rn-primitives/portal';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import * as SystemUI from 'expo-system-ui';
-import { useEffect } from 'react';
+import * as React from 'react';
+import { useCallback, useEffect, useState } from 'react';
+import { AccentColorContext } from './_accent-color-context';
 
 export {
   // Catch any errors thrown by the Layout component.
@@ -35,9 +38,22 @@ function RootLayoutContent() {
 }
 
 export default function RootLayout() {
+  const [accentColor, setAccentColorState] = useState<AccentColor>('blue');
+
+  const setAccentColor = useCallback((color: AccentColor) => {
+    setAccentColorState(color);
+  }, []);
+
+  const contextValue = React.useMemo(
+    () => ({ accentColor, setAccentColor }),
+    [accentColor, setAccentColor]
+  );
+
   return (
-    <FrostedThemeProvider accentColor="magenta">
-      <RootLayoutContent />
-    </FrostedThemeProvider>
+    <AccentColorContext.Provider value={contextValue}>
+      <FrostedThemeProvider accentColor={accentColor}>
+        <RootLayoutContent />
+      </FrostedThemeProvider>
+    </AccentColorContext.Provider>
   );
 }

--- a/packages/frosted-ui-react-native/app/_layout.tsx
+++ b/packages/frosted-ui-react-native/app/_layout.tsx
@@ -35,7 +35,7 @@ function RootLayoutContent() {
 
 export default function RootLayout() {
   return (
-    <FrostedThemeProvider>
+    <FrostedThemeProvider accentColor="magenta">
       <RootLayoutContent />
     </FrostedThemeProvider>
   );

--- a/packages/frosted-ui-react-native/app/index.tsx
+++ b/packages/frosted-ui-react-native/app/index.tsx
@@ -57,11 +57,7 @@ export default function Screen() {
         <Image source={LOGO[colorScheme]} style={IMAGE_STYLE} resizeMode="contain" />
         <View style={s.textContainer}>
           <Text size="3" style={{ color: colors.palettes.gray.a10 }}>
-            1. Edit{' '}
-            <Code color="blue" size="3">
-              app/index.tsx
-            </Code>{' '}
-            to get started.
+            1. Edit <Code size="3">app/index.tsx</Code> to get started.
           </Text>
           <Text size="3" style={{ color: colors.palettes.gray.a10 }}>
             2. Save to see your changes instantly.

--- a/packages/frosted-ui-react-native/app/index.tsx
+++ b/packages/frosted-ui-react-native/app/index.tsx
@@ -49,7 +49,7 @@ export default function Screen() {
     <>
       <Stack.Screen
         options={{
-          title: 'Frosted UI x React Native',
+          title: 'Frosted UI',
           ...headerOptions,
         }}
       />

--- a/packages/frosted-ui-react-native/app/kitchen-sink.tsx
+++ b/packages/frosted-ui-react-native/app/kitchen-sink.tsx
@@ -92,7 +92,7 @@ export default function KitchenSinkScreen() {
     <>
       <Stack.Screen
         options={{
-          title: 'Component Kitchen Sink',
+          title: 'Components',
           ...headerOptions,
         }}
       />

--- a/packages/frosted-ui-react-native/app/kitchen-sink.tsx
+++ b/packages/frosted-ui-react-native/app/kitchen-sink.tsx
@@ -202,7 +202,7 @@ export default function KitchenSinkScreen() {
           <ComponentSection title="Buttons">
             <View style={s.gap6}>
               <View style={s.gap3}>
-                <SectionLabel>Variants - Blue</SectionLabel>
+                <SectionLabel>Variants - Default (accent)</SectionLabel>
                 <View style={[s.row, s.wrap, s.gap2]}>
                   <Button variant="solid">
                     <Text>Solid</Text>
@@ -347,7 +347,7 @@ export default function KitchenSinkScreen() {
           <ComponentSection title="IconButton">
             <View style={s.gap6}>
               <View style={s.gap3}>
-                <SectionLabel>Variants - Blue</SectionLabel>
+                <SectionLabel>Variants - Default (accent)</SectionLabel>
                 <View style={[s.row, s.wrap, s.gap2]}>
                   <IconButton variant="solid">
                     <Icon as={SettingsIcon} size={16} />
@@ -1813,11 +1813,11 @@ export default function KitchenSinkScreen() {
           <ComponentSection title="Select">
             <View style={s.gap6}>
               <View style={s.gap3}>
-                <SectionLabel>Variants - Blue</SectionLabel>
+                <SectionLabel>Variants - Default</SectionLabel>
                 <View style={[s.row, s.wrap, s.gap2]}>
-                  <SelectDemo variant="surface" color="blue" />
-                  <SelectDemo variant="soft" color="blue" />
-                  <SelectDemo variant="ghost" color="blue" />
+                  <SelectDemo variant="surface" />
+                  <SelectDemo variant="soft" />
+                  <SelectDemo variant="ghost" />
                 </View>
               </View>
 

--- a/packages/frosted-ui-react-native/app/kitchen-sink.tsx
+++ b/packages/frosted-ui-react-native/app/kitchen-sink.tsx
@@ -1538,7 +1538,7 @@ export default function KitchenSinkScreen() {
                         </Button>
                       </AlertDialog.Cancel>
                       <AlertDialog.Action>
-                        <Button variant="solid" color="red">
+                        <Button variant="solid" color="danger">
                           <Text>Revoke access</Text>
                         </Button>
                       </AlertDialog.Action>
@@ -2607,7 +2607,7 @@ function HoverCardDemo() {
         </Text>
         <HoverCard.Root>
           <HoverCard.Trigger asChild>
-            <Button variant="ghost" color="blue">
+            <Button variant="ghost">
               <Text>@nextjs</Text>
             </Button>
           </HoverCard.Trigger>
@@ -2636,7 +2636,7 @@ function HoverCardDemo() {
         </Text>
         <HoverCard.Root>
           <HoverCard.Trigger asChild>
-            <Button variant="ghost" color="violet">
+            <Button variant="ghost">
               <Text>@radix</Text>
             </Button>
           </HoverCard.Trigger>

--- a/packages/frosted-ui-react-native/app/kitchen-sink.tsx
+++ b/packages/frosted-ui-react-native/app/kitchen-sink.tsx
@@ -2233,6 +2233,46 @@ function TabsDemo() {
         </View>
       </View>
 
+      {/* Colors */}
+      <View style={s.gap2}>
+        <Text size="2" weight="medium">
+          Colors
+        </Text>
+        <View style={s.gap4}>
+          <Tabs.Root color="blue" value={value2} onValueChange={setValue2}>
+            <Tabs.List>
+              <Tabs.Trigger value="tab1">Blue</Tabs.Trigger>
+              <Tabs.Trigger value="tab2">Tab 2</Tabs.Trigger>
+              <Tabs.Trigger value="tab3">Tab 3</Tabs.Trigger>
+            </Tabs.List>
+          </Tabs.Root>
+
+          <Tabs.Root color="purple" value={value2} onValueChange={setValue2}>
+            <Tabs.List>
+              <Tabs.Trigger value="tab1">Purple</Tabs.Trigger>
+              <Tabs.Trigger value="tab2">Tab 2</Tabs.Trigger>
+              <Tabs.Trigger value="tab3">Tab 3</Tabs.Trigger>
+            </Tabs.List>
+          </Tabs.Root>
+
+          <Tabs.Root color="green" value={value2} onValueChange={setValue2}>
+            <Tabs.List>
+              <Tabs.Trigger value="tab1">Green</Tabs.Trigger>
+              <Tabs.Trigger value="tab2">Tab 2</Tabs.Trigger>
+              <Tabs.Trigger value="tab3">Tab 3</Tabs.Trigger>
+            </Tabs.List>
+          </Tabs.Root>
+
+          <Tabs.Root color="orange" value={value2} onValueChange={setValue2}>
+            <Tabs.List>
+              <Tabs.Trigger value="tab1">Orange</Tabs.Trigger>
+              <Tabs.Trigger value="tab2">Tab 2</Tabs.Trigger>
+              <Tabs.Trigger value="tab3">Tab 3</Tabs.Trigger>
+            </Tabs.List>
+          </Tabs.Root>
+        </View>
+      </View>
+
       {/* Full Example */}
       <View style={s.gap2}>
         <Text size="2" weight="medium">

--- a/packages/frosted-ui-react-native/app/kitchen-sink.tsx
+++ b/packages/frosted-ui-react-native/app/kitchen-sink.tsx
@@ -204,16 +204,16 @@ export default function KitchenSinkScreen() {
               <View style={s.gap3}>
                 <SectionLabel>Variants - Blue</SectionLabel>
                 <View style={[s.row, s.wrap, s.gap2]}>
-                  <Button variant="solid" color="blue">
+                  <Button variant="solid">
                     <Text>Solid</Text>
                   </Button>
-                  <Button variant="soft" color="blue">
+                  <Button variant="soft">
                     <Text>Soft</Text>
                   </Button>
-                  <Button variant="surface" color="blue">
+                  <Button variant="surface">
                     <Text>Surface</Text>
                   </Button>
-                  <Button variant="ghost" color="blue">
+                  <Button variant="ghost">
                     <Text>Ghost</Text>
                   </Button>
                 </View>
@@ -349,16 +349,16 @@ export default function KitchenSinkScreen() {
               <View style={s.gap3}>
                 <SectionLabel>Variants - Blue</SectionLabel>
                 <View style={[s.row, s.wrap, s.gap2]}>
-                  <IconButton variant="solid" color="blue">
+                  <IconButton variant="solid">
                     <Icon as={SettingsIcon} size={16} />
                   </IconButton>
-                  <IconButton variant="soft" color="blue">
+                  <IconButton variant="soft">
                     <Icon as={SettingsIcon} size={16} />
                   </IconButton>
-                  <IconButton variant="surface" color="blue">
+                  <IconButton variant="surface">
                     <Icon as={SettingsIcon} size={16} />
                   </IconButton>
-                  <IconButton variant="ghost" color="blue">
+                  <IconButton variant="ghost">
                     <Icon as={SettingsIcon} size={16} />
                   </IconButton>
                 </View>
@@ -427,16 +427,16 @@ export default function KitchenSinkScreen() {
               <View style={s.gap3}>
                 <SectionLabel>Variants</SectionLabel>
                 <View style={[s.row, s.wrap, s.gap2]}>
-                  <Badge variant="solid" color="blue">
+                  <Badge variant="solid">
                     <Text>Solid</Text>
                   </Badge>
-                  <Badge variant="soft" color="blue">
+                  <Badge variant="soft">
                     <Text>Soft</Text>
                   </Badge>
-                  <Badge variant="surface" color="blue">
+                  <Badge variant="surface">
                     <Text>Surface</Text>
                   </Badge>
-                  <Badge variant="outline" color="blue">
+                  <Badge variant="outline">
                     <Text>Outline</Text>
                   </Badge>
                 </View>
@@ -577,7 +577,7 @@ export default function KitchenSinkScreen() {
               {/* Variants */}
               <View style={s.gap3}>
                 <SectionLabel>Variants</SectionLabel>
-                <Callout.Root variant="soft" color="blue">
+                <Callout.Root variant="soft">
                   <Callout.Icon>
                     <Icon as={InfoIcon} />
                   </Callout.Icon>
@@ -585,7 +585,7 @@ export default function KitchenSinkScreen() {
                     <Text>Soft variant callout with helpful information.</Text>
                   </Callout.Text>
                 </Callout.Root>
-                <Callout.Root variant="surface" color="blue">
+                <Callout.Root variant="surface">
                   <Callout.Icon>
                     <Icon as={InfoIcon} />
                   </Callout.Icon>
@@ -593,7 +593,7 @@ export default function KitchenSinkScreen() {
                     <Text>Surface variant callout with helpful information.</Text>
                   </Callout.Text>
                 </Callout.Root>
-                <Callout.Root variant="outline" color="blue">
+                <Callout.Root variant="outline">
                   <Callout.Icon>
                     <Icon as={InfoIcon} />
                   </Callout.Icon>
@@ -887,9 +887,9 @@ export default function KitchenSinkScreen() {
               <View style={s.gap3}>
                 <SectionLabel>Sizes</SectionLabel>
                 <View style={[s.row, s.gap6]}>
-                  <RadioGroupDemo size="1" color="blue" />
-                  <RadioGroupDemo size="2" color="blue" />
-                  <RadioGroupDemo size="3" color="blue" />
+                  <RadioGroupDemo size="1" />
+                  <RadioGroupDemo size="2" />
+                  <RadioGroupDemo size="3" />
                 </View>
               </View>
 

--- a/packages/frosted-ui-react-native/package.json
+++ b/packages/frosted-ui-react-native/package.json
@@ -16,13 +16,13 @@
     "dist"
   ],
   "peerDependencies": {
+    "lucide-react-native": ">=0.300.0",
     "react": ">=18.0.0",
     "react-native": ">=0.70.0",
     "react-native-reanimated": ">=3.0.0",
     "react-native-safe-area-context": ">=4.0.0",
     "react-native-screens": ">=3.0.0",
-    "react-native-svg": ">=13.0.0",
-    "lucide-react-native": ">=0.300.0"
+    "react-native-svg": ">=13.0.0"
   },
   "scripts": {
     "dev": "expo start -c",
@@ -65,6 +65,7 @@
     "@babel/core": "^7.26.0",
     "@react-navigation/native": "^7.0.0",
     "@types/react": "~19.1.10",
+    "@whop-sdk/turbo-module": "^0.0.5",
     "expo": "^54.0.26",
     "expo-linking": "~8.0.9",
     "expo-router": "~6.0.16",
@@ -83,8 +84,7 @@
     "react-native-web": "^0.21.0",
     "react-native-worklets": "0.5.1",
     "tsc-alias": "^1.8.16",
-    "typescript": "~5.9.2",
-    "@whop-sdk/turbo-module": "^0.0.5"
+    "typescript": "~5.9.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/frosted-ui-react-native/src/components/avatar.tsx
+++ b/packages/frosted-ui-react-native/src/components/avatar.tsx
@@ -1,5 +1,5 @@
 import { Text } from '@/components/text';
-import type { AccentColor, Color } from '@/lib/types';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as React from 'react';
 import { Image, View, type ImageStyle, type TextStyle, type ViewStyle } from 'react-native';
@@ -9,22 +9,6 @@ const avatarShapes = ['circle', 'square'] as const;
 
 type AvatarSize = (typeof avatarSizes)[number];
 type AvatarShape = (typeof avatarShapes)[number];
-
-function resolveAccentFromColor(color?: Color): AccentColor {
-  if (!color) return 'gray';
-  switch (color) {
-    case 'danger':
-      return 'red';
-    case 'warning':
-      return 'amber';
-    case 'success':
-      return 'green';
-    case 'info':
-      return 'blue';
-    default:
-      return color as AccentColor;
-  }
-}
 
 // Size styles from CSS:
 // Size 0: 16px, Size 1: 24px, Size 2: 32px, Size 3: 40px (default)
@@ -86,8 +70,8 @@ function Avatar({ src, fallback, size = '3', shape = 'circle', color }: AvatarPr
   const { colors } = useThemeTokens();
   const [imageStatus, setImageStatus] = React.useState<'loading' | 'loaded' | 'error'>('loading');
 
-  const accentColor = resolveAccentFromColor(color);
-  const palette = colors.palettes[accentColor];
+  // Avatar defaults to gray instead of accent
+  const palette = colors.palettes[color ?? 'gray'];
   const gray = colors.palettes.gray;
 
   const avatarSize = getAvatarSize(size);

--- a/packages/frosted-ui-react-native/src/components/badge.tsx
+++ b/packages/frosted-ui-react-native/src/components/badge.tsx
@@ -1,5 +1,5 @@
 import { TextStyleContext } from '@/components/text';
-import type { AccentColor, Color } from '@/lib/types';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as Slot from '@rn-primitives/slot';
 import * as React from 'react';
@@ -15,27 +15,13 @@ type BadgeProps = React.ComponentProps<typeof View> & {
   color?: Color;
 };
 
-function resolveAccentFromColor(color?: Color): AccentColor {
-  if (!color) return 'blue';
-  switch (color) {
-    case 'danger':
-      return 'red';
-    case 'warning':
-      return 'amber';
-    case 'success':
-      return 'green';
-    case 'info':
-      return 'blue';
-    default:
-      return color as AccentColor;
-  }
-}
-
 function Badge({ variant = 'soft', size = '1', color, style, asChild, ...props }: BadgeProps) {
   const { colors } = useThemeTokens();
   const Component = asChild ? Slot.View : View;
-  const accentColor = resolveAccentFromColor(color);
-  const palette = colors.palettes[accentColor];
+  const gray = colors.palettes.gray;
+  // Semantic colors (accent, danger, etc.) are added by useThemeTokens
+  // Fallback to gray if palette key doesn't exist
+  const palette = colors.palettes[color ?? 'accent'] ?? gray;
 
   // Base layout (same on all platforms)
   const baseStyle: ViewStyle = {

--- a/packages/frosted-ui-react-native/src/components/button.tsx
+++ b/packages/frosted-ui-react-native/src/components/button.tsx
@@ -6,7 +6,6 @@ import {
   getButtonSizeStyle,
   getButtonTextColor,
   getButtonVariantStyle,
-  resolveAccentFromColor,
   type ButtonSize,
   type ButtonVariant,
 } from '@/lib/button-styles';
@@ -41,12 +40,11 @@ function Button({
   const [pressed, setPressed] = React.useState(false);
   const [hovered, setHovered] = React.useState(false);
   const [focused, setFocused] = React.useState(false);
-  const accentColor = resolveAccentFromColor(color);
 
   const gray = colors.palettes.gray;
-  // All AccentColors should be in palettes, but TypeScript's index signature types
-  // don't guarantee it with bracket notation. Fallback to gray as defensive programming.
-  const palette = colors.palettes[accentColor] ?? gray;
+  // Semantic colors (accent, danger, etc.) are added by useThemeTokens
+  // Fallback to gray if palette key doesn't exist
+  const palette = colors.palettes[color ?? 'accent'] ?? gray;
 
   const textColor = getButtonTextColor(variant, palette, gray, disabled ?? false);
 

--- a/packages/frosted-ui-react-native/src/components/callout.tsx
+++ b/packages/frosted-ui-react-native/src/components/callout.tsx
@@ -71,8 +71,9 @@ function CalloutRoot({
   ...props
 }: CalloutRootProps) {
   const { colors } = useThemeTokens();
-  // Callout defaults to gray instead of accent
-  const palette = colors.palettes[color ?? 'gray'];
+  const gray = colors.palettes.gray;
+  // Default to accent color, fallback to gray
+  const palette = colors.palettes[color ?? 'accent'] ?? gray;
 
   const baseStyle: ViewStyle = {
     flexDirection: 'row',

--- a/packages/frosted-ui-react-native/src/components/callout.tsx
+++ b/packages/frosted-ui-react-native/src/components/callout.tsx
@@ -1,5 +1,5 @@
 import { TextStyleContext } from '@/components/text';
-import type { AccentColor, Color } from '@/lib/types';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as React from 'react';
 import { View, type ViewProps, type ViewStyle } from 'react-native';
@@ -9,29 +9,11 @@ type CalloutVariant = 'soft' | 'surface' | 'outline';
 
 type CalloutContextValue = {
   size: CalloutSize;
-  color: AccentColor;
 };
 
 const CalloutContext = React.createContext<CalloutContextValue>({
   size: '2',
-  color: 'gray',
 });
-
-function resolveAccentFromColor(color?: Color): AccentColor {
-  if (!color) return 'gray';
-  switch (color) {
-    case 'danger':
-      return 'red';
-    case 'warning':
-      return 'amber';
-    case 'success':
-      return 'green';
-    case 'info':
-      return 'blue';
-    default:
-      return color as AccentColor;
-  }
-}
 
 // Size to text size mapping (matching web version)
 function getTextSize(size: CalloutSize): '1' | '2' | '3' {
@@ -89,8 +71,8 @@ function CalloutRoot({
   ...props
 }: CalloutRootProps) {
   const { colors } = useThemeTokens();
-  const accentColor = resolveAccentFromColor(color);
-  const palette = colors.palettes[accentColor];
+  // Callout defaults to gray instead of accent
+  const palette = colors.palettes[color ?? 'gray'];
 
   const baseStyle: ViewStyle = {
     flexDirection: 'row',
@@ -127,7 +109,7 @@ function CalloutRoot({
     ...variantStyle,
   };
 
-  const contextValue = React.useMemo(() => ({ size, color: accentColor }), [size, accentColor]);
+  const contextValue = React.useMemo(() => ({ size }), [size]);
 
   // Text color for children
   const textColor = palette.a11 || palette['11'];

--- a/packages/frosted-ui-react-native/src/components/checkbox.tsx
+++ b/packages/frosted-ui-react-native/src/components/checkbox.tsx
@@ -1,4 +1,4 @@
-import type { AccentColor, Color } from '@/lib/types';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as CheckboxPrimitive from '@rn-primitives/checkbox';
 import { Check } from 'lucide-react-native';
@@ -6,22 +6,6 @@ import * as React from 'react';
 import { Platform, View, type ViewStyle } from 'react-native';
 
 type CheckboxSize = '1' | '2' | '3';
-
-function resolveAccentFromColor(color?: Color): AccentColor {
-  if (!color) return 'blue';
-  switch (color) {
-    case 'danger':
-      return 'red';
-    case 'warning':
-      return 'amber';
-    case 'success':
-      return 'green';
-    case 'info':
-      return 'blue';
-    default:
-      return color as AccentColor;
-  }
-}
 
 // Size styles from CSS:
 // Size 1: --checkbox-size: var(--space-4) = 16px, border-radius: var(--radius-2) = 4px
@@ -58,9 +42,10 @@ function Checkbox({
 }: CheckboxProps) {
   const { colors } = useThemeTokens();
   const [focused, setFocused] = React.useState(false);
-  const accentColor = resolveAccentFromColor(color);
-  const palette = colors.palettes[accentColor];
   const gray = colors.palettes.gray;
+  // Semantic colors (accent, danger, etc.) are added by useThemeTokens
+  // Fallback to gray if palette key doesn't exist
+  const palette = colors.palettes[color ?? 'accent'] ?? gray;
 
   const { boxSize, borderRadius, iconSize } = getSizeStyle(size);
 

--- a/packages/frosted-ui-react-native/src/components/code.tsx
+++ b/packages/frosted-ui-react-native/src/components/code.tsx
@@ -1,5 +1,5 @@
 import { themeTokens } from '@/lib/theme-tokens';
-import type { AccentColor } from '@/lib/types';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as React from 'react';
 import { Platform, Text as RNText, type TextStyle } from 'react-native';
@@ -12,20 +12,15 @@ type CodeProps = Omit<React.ComponentProps<typeof RNText>, 'style'> & {
   size?: CodeSize;
   variant?: CodeVariant;
   weight?: CodeWeight;
-  color?: AccentColor;
+  color?: Color;
   style?: TextStyle;
 };
 
-function Code({
-  size = '2',
-  variant = 'soft',
-  weight,
-  color = 'gray',
-  style,
-  ...props
-}: CodeProps) {
+function Code({ size = '2', variant = 'soft', weight, color, style, ...props }: CodeProps) {
   const { colors, typography, fontWeights } = useThemeTokens();
-  const palette = colors.palettes[color] ?? colors.palettes.gray;
+  const gray = colors.palettes.gray;
+  // Default to accent color, fallback to gray
+  const palette = colors.palettes[color ?? 'accent'] ?? gray;
 
   // Typography from theme, with 0.95 font size adjustment like web
   const typo = typography[size];

--- a/packages/frosted-ui-react-native/src/components/icon-button.tsx
+++ b/packages/frosted-ui-react-native/src/components/icon-button.tsx
@@ -6,7 +6,6 @@ import {
   getButtonSizeStyle,
   getButtonTextColor,
   getButtonVariantStyle,
-  resolveAccentFromColor,
   type ButtonSize,
   type ButtonVariant,
 } from '@/lib/button-styles';
@@ -41,12 +40,11 @@ function IconButton({
   const [pressed, setPressed] = React.useState(false);
   const [hovered, setHovered] = React.useState(false);
   const [focused, setFocused] = React.useState(false);
-  const accentColor = resolveAccentFromColor(color);
 
   const gray = colors.palettes.gray;
-  // All AccentColors should be in palettes, but TypeScript's index signature types
-  // don't guarantee it with bracket notation. Fallback to gray as defensive programming.
-  const palette = colors.palettes[accentColor] ?? gray;
+  // Semantic colors (accent, danger, etc.) are added by useThemeTokens
+  // Fallback to gray if palette key doesn't exist
+  const palette = colors.palettes[color ?? 'accent'] ?? gray;
 
   const textColor = getButtonTextColor(variant, palette, gray, disabled ?? false);
 

--- a/packages/frosted-ui-react-native/src/components/progress.tsx
+++ b/packages/frosted-ui-react-native/src/components/progress.tsx
@@ -1,25 +1,9 @@
-import type { AccentColor, Color } from '@/lib/types';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as React from 'react';
 import { View, type ViewProps, type ViewStyle } from 'react-native';
 
 type ProgressSize = '1' | '2' | '3' | '4' | '5' | '6';
-
-function resolveAccentFromColor(color?: Color): AccentColor {
-  if (!color) return 'blue';
-  switch (color) {
-    case 'danger':
-      return 'red';
-    case 'warning':
-      return 'amber';
-    case 'success':
-      return 'green';
-    case 'info':
-      return 'blue';
-    default:
-      return color as AccentColor;
-  }
-}
 
 // Size styles from CSS:
 // Size 1: 2px, Size 2: 4px, Size 3: 6px, Size 4: 8px, Size 5: 12px, Size 6: 16px
@@ -50,9 +34,10 @@ type ProgressProps = ViewProps & {
 function Progress({ size = '6', color, value = 0, max = 100, style, ...props }: ProgressProps) {
   const { colors } = useThemeTokens();
 
-  const accentColor = resolveAccentFromColor(color);
-  const palette = colors.palettes[accentColor];
   const gray = colors.palettes.gray;
+  // Semantic colors (accent, danger, etc.) are added by useThemeTokens
+  // Fallback to gray if palette key doesn't exist
+  const palette = colors.palettes[color ?? 'accent'] ?? gray;
 
   const height = getHeight(size);
 

--- a/packages/frosted-ui-react-native/src/components/radio-group.tsx
+++ b/packages/frosted-ui-react-native/src/components/radio-group.tsx
@@ -1,4 +1,4 @@
-import type { AccentColor, Color } from '@/lib/types';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as RadioGroupPrimitive from '@rn-primitives/radio-group';
 import * as React from 'react';
@@ -8,30 +8,14 @@ type RadioSize = '1' | '2' | '3';
 
 type RadioGroupContextValue = {
   size: RadioSize;
-  color: AccentColor;
+  color: Color | 'accent';
   value?: string;
 };
 
 const RadioGroupContext = React.createContext<RadioGroupContextValue>({
   size: '2',
-  color: 'blue',
+  color: 'accent',
 });
-
-function resolveAccentFromColor(color?: Color): AccentColor {
-  if (!color) return 'blue';
-  switch (color) {
-    case 'danger':
-      return 'red';
-    case 'warning':
-      return 'amber';
-    case 'success':
-      return 'green';
-    case 'info':
-      return 'blue';
-    default:
-      return color as AccentColor;
-  }
-}
 
 // Size styles from CSS:
 // Size 1: --radio-group-item-size: var(--space-4) = 16px
@@ -54,11 +38,9 @@ type RadioGroupRootProps = RadioGroupPrimitive.RootProps & {
 };
 
 function RadioGroupRoot({ size = '2', color, value, ...props }: RadioGroupRootProps) {
-  const accentColor = resolveAccentFromColor(color);
-
   const contextValue = React.useMemo(
-    () => ({ size, color: accentColor, value }),
-    [size, accentColor, value]
+    (): RadioGroupContextValue => ({ size, color: color ?? 'accent', value }),
+    [size, color, value]
   );
 
   return (
@@ -75,8 +57,10 @@ function RadioGroupItem({ value, disabled, onFocus, onBlur, ...props }: RadioGro
   const { colors } = useThemeTokens();
   const [focused, setFocused] = React.useState(false);
 
-  const palette = colors.palettes[color];
   const gray = colors.palettes.gray;
+  // Semantic colors (accent, danger, etc.) are added by useThemeTokens
+  // Fallback to gray if palette key doesn't exist
+  const palette = colors.palettes[color] ?? gray;
 
   const itemSize = getItemSize(size);
   const indicatorSize = itemSize * 0.4; // 40% scale like CSS

--- a/packages/frosted-ui-react-native/src/components/select.tsx
+++ b/packages/frosted-ui-react-native/src/components/select.tsx
@@ -6,7 +6,6 @@ import {
   getButtonShadowStyle,
   getButtonSizeStyle,
   getButtonVariantStyle,
-  resolveAccentFromColor,
   type ButtonSize,
   type ButtonVariant,
 } from '@/lib/button-styles';
@@ -190,8 +189,7 @@ function SelectValue({ placeholder, ...props }: SelectValueProps) {
 
   // Get colors based on variant (matching web)
   const gray = colors.palettes.gray;
-  const accentColor = resolveAccentFromColor(color);
-  const palette = colors.palettes[accentColor] ?? gray;
+  const palette = colors.palettes[color ?? 'gray'];
 
   // Text colors per variant:
   // - surface: gray-12, placeholder: gray-a10, disabled: gray-a8
@@ -245,10 +243,9 @@ function SelectTrigger({
   const [pressed, setPressed] = React.useState(false);
   const [hovered, setHovered] = React.useState(false);
   const [focused, setFocused] = React.useState(false);
-  const accentColor = resolveAccentFromColor(color);
 
   const gray = colors.palettes.gray;
-  const palette = colors.palettes[accentColor] ?? gray;
+  const palette = colors.palettes[color ?? 'gray'];
 
   // When select is open, apply pressed styles (matching web [data-state='open'])
   const isPressed = pressed || open;

--- a/packages/frosted-ui-react-native/src/components/separator.tsx
+++ b/packages/frosted-ui-react-native/src/components/separator.tsx
@@ -1,4 +1,4 @@
-import type { AccentColor, Color } from '@/lib/types';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as SeparatorPrimitive from '@rn-primitives/separator';
 import { type ViewStyle } from 'react-native';
@@ -6,22 +6,6 @@ import { type ViewStyle } from 'react-native';
 const separatorSizes = ['1', '2', '3', '4'] as const;
 
 type SeparatorSize = (typeof separatorSizes)[number];
-
-function resolveAccentFromColor(color?: Color): AccentColor {
-  if (!color) return 'gray';
-  switch (color) {
-    case 'danger':
-      return 'red';
-    case 'warning':
-      return 'amber';
-    case 'success':
-      return 'green';
-    case 'info':
-      return 'blue';
-    default:
-      return color as AccentColor;
-  }
-}
 
 // Size mapping from CSS:
 // Size 1: var(--space-4) = 16px
@@ -56,8 +40,8 @@ function Separator({
 }: SeparatorProps) {
   const { colors } = useThemeTokens();
 
-  const accentColor = resolveAccentFromColor(color);
-  const palette = colors.palettes[accentColor];
+  const gray = colors.palettes.gray;
+  const palette = colors.palettes[color] ?? gray;
 
   const separatorSize = getSeparatorSize(size);
 

--- a/packages/frosted-ui-react-native/src/components/skeleton.tsx
+++ b/packages/frosted-ui-react-native/src/components/skeleton.tsx
@@ -1,6 +1,6 @@
 import { getAvatarSize, type AvatarShape, type AvatarSize } from '@/components/avatar';
 import type { TextSize } from '@/components/text';
-import type { AccentColor, Color } from '@/lib/types';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as React from 'react';
 import { Platform, View, type ViewProps, type ViewStyle } from 'react-native';
@@ -11,22 +11,6 @@ import Animated, {
   withRepeat,
   withTiming,
 } from 'react-native-reanimated';
-
-function resolveAccentFromColor(color?: Color): AccentColor {
-  if (!color) return 'gray';
-  switch (color) {
-    case 'danger':
-      return 'red';
-    case 'warning':
-      return 'amber';
-    case 'success':
-      return 'green';
-    case 'info':
-      return 'blue';
-    default:
-      return color as AccentColor;
-  }
-}
 
 // Text border radius based on size
 function getTextBorderRadius(size: TextSize): number {
@@ -119,8 +103,8 @@ function SkeletonAvatar({
   const { colors } = useThemeTokens();
   const animatedStyle = usePulseAnimation();
 
-  const accentColor = resolveAccentFromColor(color);
-  const palette = colors.palettes[accentColor];
+  const gray = colors.palettes.gray;
+  const palette = colors.palettes[color] ?? gray;
 
   const avatarSize = getAvatarSize(size);
   const borderRadius = shape === 'circle' ? avatarSize / 2 : avatarSize * 0.25;
@@ -153,8 +137,8 @@ function SkeletonText({ size = '3', color = 'gray', style, ...props }: SkeletonT
   const { colors, typography } = useThemeTokens();
   const animatedStyle = usePulseAnimation();
 
-  const accentColor = resolveAccentFromColor(color);
-  const palette = colors.palettes[accentColor];
+  const gray = colors.palettes.gray;
+  const palette = colors.palettes[color] ?? gray;
 
   const typo = typography[size];
   const borderRadius = getTextBorderRadius(size);
@@ -200,8 +184,8 @@ function SkeletonRect({ color = 'gray', style, ...props }: SkeletonRectProps) {
   const { colors } = useThemeTokens();
   const animatedStyle = usePulseAnimation();
 
-  const accentColor = resolveAccentFromColor(color);
-  const palette = colors.palettes[accentColor];
+  const gray = colors.palettes.gray;
+  const palette = colors.palettes[color] ?? gray;
 
   const rectStyle: ViewStyle = {
     backgroundColor: palette.a3,

--- a/packages/frosted-ui-react-native/src/components/switch.tsx
+++ b/packages/frosted-ui-react-native/src/components/switch.tsx
@@ -1,26 +1,10 @@
-import type { AccentColor, Color } from '@/lib/types';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as SwitchPrimitive from '@rn-primitives/switch';
 import * as React from 'react';
 import { Platform, View, type ViewStyle } from 'react-native';
 
 type SwitchSize = '1' | '2' | '3';
-
-function resolveAccentFromColor(color?: Color): AccentColor {
-  if (!color) return 'blue';
-  switch (color) {
-    case 'danger':
-      return 'red';
-    case 'warning':
-      return 'amber';
-    case 'success':
-      return 'green';
-    case 'info':
-      return 'blue';
-    default:
-      return color as AccentColor;
-  }
-}
 
 // Size styles from CSS:
 // Size 1: --switch-height: var(--space-4) = 16px
@@ -80,9 +64,10 @@ function Switch({
   const { colors } = useThemeTokens();
   const [focused, setFocused] = React.useState(false);
 
-  const accentColor = resolveAccentFromColor(color);
-  const palette = colors.palettes[accentColor];
   const gray = colors.palettes.gray;
+  // Semantic colors (accent, danger, etc.) are added by useThemeTokens
+  // Fallback to gray if palette key doesn't exist
+  const palette = colors.palettes[color ?? 'accent'] ?? gray;
 
   const { height, width, padding, thumbSize, translateX } = getSizeStyle(size);
 

--- a/packages/frosted-ui-react-native/src/components/tabs.tsx
+++ b/packages/frosted-ui-react-native/src/components/tabs.tsx
@@ -1,5 +1,6 @@
 import { Text, TextStyleContext } from '@/components/text';
 import { themeTokens } from '@/lib/theme-tokens';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as TabsPrimitive from '@rn-primitives/tabs';
 import * as React from 'react';
@@ -9,11 +10,13 @@ type TabsSize = '1' | '2';
 
 type TabsContextValue = {
   size: TabsSize;
+  color: Color | 'accent';
   value?: string;
 };
 
 const TabsContext = React.createContext<TabsContextValue>({
   size: '2',
+  color: 'accent',
   value: undefined,
 });
 
@@ -53,10 +56,14 @@ function getTriggerPadding(size: TabsSize): {
 
 type TabsRootProps = TabsPrimitive.RootProps & {
   size?: TabsSize;
+  color?: Color;
 };
 
-function TabsRoot({ size = '2', value, onValueChange, children, ...props }: TabsRootProps) {
-  const contextValue = React.useMemo(() => ({ size, value }), [size, value]);
+function TabsRoot({ size = '2', color, value, onValueChange, children, ...props }: TabsRootProps) {
+  const contextValue = React.useMemo(
+    (): TabsContextValue => ({ size, color: color ?? 'accent', value }),
+    [size, color, value]
+  );
 
   return (
     <TabsContext.Provider value={contextValue}>
@@ -98,11 +105,12 @@ type TabsTriggerInnerProps = {
 };
 
 function TabsTriggerInner({ value, hovered, children }: TabsTriggerInnerProps) {
-  const { size, value: activeValue } = React.useContext(TabsContext);
+  const { size, color, value: activeValue } = React.useContext(TabsContext);
   const { colors } = useThemeTokens();
 
   const gray = colors.palettes.gray;
-  const accent = colors.palettes.blue; // Default accent
+  // Use the color from context, falling back to accent palette
+  const palette = colors.palettes[color] ?? gray;
 
   const isActive = value === activeValue;
   const { paddingX, innerPaddingX, innerPaddingY } = getTriggerPadding(size);
@@ -136,7 +144,7 @@ function TabsTriggerInner({ value, hovered, children }: TabsTriggerInnerProps) {
     left: 0,
     right: 0,
     height: 2,
-    backgroundColor: accent['10'],
+    backgroundColor: palette['10'],
   };
 
   // Wrap string children in Text component

--- a/packages/frosted-ui-react-native/src/components/text-area.tsx
+++ b/packages/frosted-ui-react-native/src/components/text-area.tsx
@@ -4,7 +4,6 @@ import {
   getSoftVariantStyle,
   getSurfaceVariantStyle,
   getTextInputColors,
-  resolveAccentFromColor,
   type TextInputSize,
   type TextInputVariant,
 } from '@/lib/text-input-styles';
@@ -19,6 +18,9 @@ import {
   type TextStyle,
   type ViewStyle,
 } from 'react-native';
+
+// Palette key - Color with 'gray' as default (for text inputs)
+type PaletteKey = Color | 'gray';
 
 // ============================================================================
 // Types
@@ -99,7 +101,7 @@ function TextArea({
   ...props
 }: TextAreaProps) {
   const { colors } = useThemeTokens();
-  const accentColor = resolveAccentFromColor(color);
+  const paletteKey: PaletteKey = color ?? 'gray';
   const sizeStyle = getTextAreaSizeStyle(size);
   const disabled = editable === false;
   const [focused, setFocused] = React.useState(false);
@@ -108,7 +110,7 @@ function TextArea({
   let variantStyle =
     variant === 'surface'
       ? getSurfaceVariantStyle(colors)
-      : getSoftVariantStyle(colors, accentColor);
+      : getSoftVariantStyle(colors, paletteKey);
 
   // Apply disabled styles (surface keeps border, soft replaces background)
   if (disabled) {
@@ -128,7 +130,7 @@ function TextArea({
   const focusStyle: ViewStyle | undefined =
     focused && !disabled && Platform.OS === 'web'
       ? ({
-          outline: `2px solid ${colors.palettes[accentColor].a8}`,
+          outline: `2px solid ${colors.palettes[paletteKey].a8}`,
           outlineOffset: -1,
         } as ViewStyle)
       : undefined;
@@ -137,7 +139,7 @@ function TextArea({
   const { textColor, placeholderColor } = getTextInputColors(
     variant,
     colors,
-    accentColor,
+    paletteKey,
     disabled
   );
 

--- a/packages/frosted-ui-react-native/src/components/text-area.tsx
+++ b/packages/frosted-ui-react-native/src/components/text-area.tsx
@@ -95,13 +95,17 @@ interface TextAreaProps extends Omit<TextInputProps, 'style'> {
 function TextArea({
   size = '2',
   variant = 'surface',
-  color = 'gray',
+  color,
   style,
   editable,
   ...props
 }: TextAreaProps) {
   const { colors } = useThemeTokens();
+  const gray = colors.palettes.gray;
+  // For soft variant background/text, use gray as default
   const paletteKey: PaletteKey = color ?? 'gray';
+  // For focus outline, use accent as default
+  const focusPalette = colors.palettes[color ?? 'accent'] ?? gray;
   const sizeStyle = getTextAreaSizeStyle(size);
   const disabled = editable === false;
   const [focused, setFocused] = React.useState(false);
@@ -126,11 +130,11 @@ function TextArea({
     }
   }
 
-  // Focus outline (web only)
+  // Focus outline (web only) - uses accent color by default
   const focusStyle: ViewStyle | undefined =
     focused && !disabled && Platform.OS === 'web'
       ? ({
-          outline: `2px solid ${colors.palettes[paletteKey].a8}`,
+          outline: `2px solid ${focusPalette.a8}`,
           outlineOffset: -1,
         } as ViewStyle)
       : undefined;

--- a/packages/frosted-ui-react-native/src/components/text.tsx
+++ b/packages/frosted-ui-react-native/src/components/text.tsx
@@ -36,9 +36,10 @@ function Text({ asChild = false, size, weight, color, role, style, ...props }: T
   // 1. If color prop is set, use that palette's shade 11
   // 2. If context provides a color, use that
   // 3. Otherwise, use default foreground color (gray-12)
+  const gray = colors.palettes.gray;
   const resolvedColor = color
-    ? colors.palettes[color]['11']
-    : (textStyleContext?.color ?? colors.palettes.gray['12']);
+    ? (colors.palettes[color] ?? gray)['11']
+    : (textStyleContext?.color ?? gray['12']);
 
   const typo = effectiveSize ? typography[effectiveSize] : undefined;
   const fontWeightValue = effectiveWeight ? fontWeights[effectiveWeight] : undefined;

--- a/packages/frosted-ui-react-native/src/index.ts
+++ b/packages/frosted-ui-react-native/src/index.ts
@@ -25,3 +25,7 @@ export type {
 // NAVIGATION
 //------------------------------------------------------------------------------
 export { NAV_THEME, useNavTheme } from './lib/theme';
+
+// PORTAL
+//------------------------------------------------------------------------------
+export { PortalHost } from '@rn-primitives/portal';

--- a/packages/frosted-ui-react-native/src/index.ts
+++ b/packages/frosted-ui-react-native/src/index.ts
@@ -4,13 +4,13 @@ export * from './components';
 
 // UTILITIES
 //------------------------------------------------------------------------------
+export { isSemanticColor, resolveAccentFromColor } from './lib/color-utils';
 export * from './lib/types';
 export * from './lib/use-theme-tokens';
-export { resolveAccentFromColor, isSemanticColor } from './lib/color-utils';
 
 // THEME
 //------------------------------------------------------------------------------
-export { ThemeProvider, useTheme, defaultSemanticColors } from './lib/theme-context';
+export { defaultSemanticColors, ThemeProvider, useTheme } from './lib/theme-context';
 export type {
   ColorScheme,
   DangerColor,

--- a/packages/frosted-ui-react-native/src/index.ts
+++ b/packages/frosted-ui-react-native/src/index.ts
@@ -6,8 +6,18 @@ export * from './components';
 //------------------------------------------------------------------------------
 export * from './lib/types';
 export * from './lib/use-theme-tokens';
+export { resolveAccentFromColor, isSemanticColor } from './lib/color-utils';
 
 // THEME
 //------------------------------------------------------------------------------
-export { ThemeProvider, useTheme } from './lib/theme-context';
-export type { ColorScheme, ThemeContextValue, ThemeProviderProps } from './lib/theme-context';
+export { ThemeProvider, useTheme, defaultSemanticColors } from './lib/theme-context';
+export type {
+  ColorScheme,
+  DangerColor,
+  InfoColor,
+  SemanticColorConfig,
+  SuccessColor,
+  ThemeContextValue,
+  ThemeProviderProps,
+  WarningColor,
+} from './lib/theme-context';

--- a/packages/frosted-ui-react-native/src/index.ts
+++ b/packages/frosted-ui-react-native/src/index.ts
@@ -21,3 +21,7 @@ export type {
   ThemeProviderProps,
   WarningColor,
 } from './lib/theme-context';
+
+// NAVIGATION
+//------------------------------------------------------------------------------
+export { NAV_THEME, useNavTheme } from './lib/theme';

--- a/packages/frosted-ui-react-native/src/lib/button-styles.ts
+++ b/packages/frosted-ui-react-native/src/lib/button-styles.ts
@@ -81,7 +81,7 @@ export function getButtonVariantStyle(
         // Default: panelSolid bg, gray-a5 border (stroke), outer shadow
         // Hover: same bg, gray-a7 border, outer shadow
         // Pressed: gray-a3 bg, gray-a6 border, no outer shadow
-        backgroundColor = pressed ? gray.a3 : colors.panelSolid;
+        backgroundColor = pressed ? gray['3'] : colors.panelSolid;
         borderColor = pressed ? gray.a6 : hovered ? gray.a7 : gray.a5;
         borderWidth = 1;
         break;

--- a/packages/frosted-ui-react-native/src/lib/button-styles.ts
+++ b/packages/frosted-ui-react-native/src/lib/button-styles.ts
@@ -1,4 +1,3 @@
-import type { AccentColor, Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import type { ViewStyle } from 'react-native';
 import { Platform } from 'react-native';
@@ -6,21 +5,8 @@ import { Platform } from 'react-native';
 export type ButtonSize = '1' | '2' | '3' | '4';
 export type ButtonVariant = 'solid' | 'soft' | 'surface' | 'ghost';
 
-export function resolveAccentFromColor(color?: Color): AccentColor {
-  if (!color) return 'blue';
-  switch (color) {
-    case 'danger':
-      return 'red';
-    case 'warning':
-      return 'amber';
-    case 'success':
-      return 'green';
-    case 'info':
-      return 'blue';
-    default:
-      return color as AccentColor;
-  }
-}
+// Palette type - the color shades returned from colors.palettes[key]
+type Palette = ReturnType<typeof useThemeTokens>['colors']['palettes']['gray'];
 
 export function getButtonSizeStyle(size: ButtonSize, isIconButton = false): ViewStyle {
   // Based on web CSS:
@@ -58,8 +44,8 @@ export function getButtonSizeStyle(size: ButtonSize, isIconButton = false): View
 export function getButtonVariantStyle(
   variant: ButtonVariant,
   colors: ReturnType<typeof useThemeTokens>['colors'],
-  palette: ReturnType<typeof useThemeTokens>['colors']['palettes'][AccentColor],
-  gray: ReturnType<typeof useThemeTokens>['colors']['palettes']['gray'],
+  palette: Palette,
+  gray: Palette,
   disabled: boolean,
   pressed: boolean,
   hovered: boolean
@@ -130,7 +116,7 @@ export function getButtonShadowStyle(
 }
 
 export function getButtonFocusStyle(
-  palette: ReturnType<typeof useThemeTokens>['colors']['palettes'][AccentColor],
+  palette: Palette,
   focused: boolean,
   disabled: boolean
 ): ViewStyle | undefined {
@@ -158,8 +144,8 @@ export function getButtonPressedFilter(
 
 export function getButtonTextColor(
   variant: ButtonVariant,
-  palette: ReturnType<typeof useThemeTokens>['colors']['palettes'][AccentColor],
-  gray: ReturnType<typeof useThemeTokens>['colors']['palettes']['gray'],
+  palette: Palette,
+  gray: Palette,
   disabled: boolean
 ): string {
   if (disabled) {

--- a/packages/frosted-ui-react-native/src/lib/color-utils.ts
+++ b/packages/frosted-ui-react-native/src/lib/color-utils.ts
@@ -1,0 +1,60 @@
+import { useMemo } from 'react';
+import type { AccentColor, Color, SemanticColor } from './types';
+import { defaultSemanticColors, useSemanticColors, type SemanticColorConfig } from './theme-context';
+
+/**
+ * Resolves a Color (which can be an AccentColor or SemanticColor) to an AccentColor.
+ * Semantic colors are resolved using the provided semantic color configuration.
+ *
+ * @param color - The color to resolve (can be 'danger', 'warning', 'success', 'info', or any AccentColor)
+ * @param semanticColors - The semantic color configuration from ThemeProvider (optional, uses defaults if not provided)
+ * @param defaultColor - The default color to return if no color is provided (defaults to 'blue')
+ * @returns The resolved AccentColor
+ */
+export function resolveAccentFromColor(
+  color: Color | undefined,
+  semanticColors: SemanticColorConfig = defaultSemanticColors,
+  defaultColor: AccentColor = 'blue'
+): AccentColor {
+  if (!color) return defaultColor;
+
+  switch (color) {
+    case 'danger':
+      return semanticColors.dangerColor;
+    case 'warning':
+      return semanticColors.warningColor;
+    case 'success':
+      return semanticColors.successColor;
+    case 'info':
+      return semanticColors.infoColor;
+    default:
+      return color as AccentColor;
+  }
+}
+
+/**
+ * Checks if a color is a semantic color.
+ */
+export function isSemanticColor(color: Color): color is SemanticColor {
+  return color === 'danger' || color === 'warning' || color === 'success' || color === 'info';
+}
+
+/**
+ * Hook that returns a function to resolve colors using the current theme's semantic color configuration.
+ * Use this in components to properly respect ThemeProvider's color settings.
+ *
+ * @example
+ * const resolveColor = useResolveColor();
+ * const accentColor = resolveColor(props.color); // Respects ThemeProvider config
+ */
+export function useResolveColor() {
+  const semanticColors = useSemanticColors();
+
+  return useMemo(
+    () =>
+      (color: Color | undefined, defaultColor: AccentColor = 'blue'): AccentColor =>
+        resolveAccentFromColor(color, semanticColors, defaultColor),
+    [semanticColors]
+  );
+}
+

--- a/packages/frosted-ui-react-native/src/lib/color-utils.ts
+++ b/packages/frosted-ui-react-native/src/lib/color-utils.ts
@@ -1,6 +1,10 @@
 import { useMemo } from 'react';
+import {
+  defaultSemanticColors,
+  useSemanticColors,
+  type SemanticColorConfig,
+} from './theme-context';
 import type { AccentColor, Color, SemanticColor } from './types';
-import { defaultSemanticColors, useSemanticColors, type SemanticColorConfig } from './theme-context';
 
 /**
  * Resolves a Color (which can be an AccentColor or SemanticColor) to an AccentColor.
@@ -57,4 +61,3 @@ export function useResolveColor() {
     [semanticColors]
   );
 }
-

--- a/packages/frosted-ui-react-native/src/lib/text-input-styles.ts
+++ b/packages/frosted-ui-react-native/src/lib/text-input-styles.ts
@@ -1,4 +1,4 @@
-import type { AccentColor, Color } from '@/lib/types';
+import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import { Platform, type ViewStyle } from 'react-native';
 
@@ -9,25 +9,8 @@ import { Platform, type ViewStyle } from 'react-native';
 export type TextInputSize = '1' | '2' | '3' | '4';
 export type TextInputVariant = 'surface' | 'soft';
 
-// ============================================================================
-// Helpers
-// ============================================================================
-
-export function resolveAccentFromColor(color?: Color): AccentColor {
-  if (!color) return 'gray';
-  switch (color) {
-    case 'danger':
-      return 'red';
-    case 'warning':
-      return 'amber';
-    case 'success':
-      return 'green';
-    case 'info':
-      return 'blue';
-    default:
-      return color as AccentColor;
-  }
-}
+// Palette key type - any valid key in colors.palettes
+type PaletteKey = Color | 'accent' | 'gray';
 
 /**
  * Convert hex color to rgba with specified opacity
@@ -74,10 +57,10 @@ export function getSurfaceVariantStyle(
  */
 export function getSoftVariantStyle(
   colors: ReturnType<typeof useThemeTokens>['colors'],
-  accentColor: AccentColor
+  paletteKey: PaletteKey
 ): ViewStyle {
   return {
-    backgroundColor: colors.palettes[accentColor].a3,
+    backgroundColor: colors.palettes[paletteKey].a3,
   };
 }
 
@@ -87,11 +70,11 @@ export function getSoftVariantStyle(
 export function getTextInputColors(
   variant: TextInputVariant,
   colors: ReturnType<typeof useThemeTokens>['colors'],
-  accentColor: AccentColor,
+  paletteKey: PaletteKey,
   disabled?: boolean
 ): { textColor: string; placeholderColor: string } {
   const grayPalette = colors.palettes.gray;
-  const palette = colors.palettes[accentColor];
+  const palette = colors.palettes[paletteKey];
 
   // Disabled state: always use gray-a11 for text
   // Placeholder uses gray-a5 (lighter alpha shade approximating gray-a11 at 0.5 opacity)

--- a/packages/frosted-ui-react-native/src/lib/theme-context.tsx
+++ b/packages/frosted-ui-react-native/src/lib/theme-context.tsx
@@ -1,13 +1,38 @@
 import * as React from 'react';
 import { useColorScheme as useSystemColorScheme } from 'react-native';
+import type { AccentColor } from './types';
 
 type ColorScheme = 'light' | 'dark';
+
+// Allowed colors for each semantic color type (matching web version)
+type DangerColor = 'tomato' | 'red' | 'ruby';
+type WarningColor = 'yellow' | 'amber';
+type SuccessColor = 'teal' | 'jade' | 'green' | 'grass';
+type InfoColor = 'blue' | 'sky';
+
+// Semantic color configuration
+type SemanticColorConfig = {
+  accentColor: AccentColor;
+  dangerColor: DangerColor;
+  warningColor: WarningColor;
+  successColor: SuccessColor;
+  infoColor: InfoColor;
+};
+
+// Default semantic colors (matching web defaults)
+const defaultSemanticColors: SemanticColorConfig = {
+  accentColor: 'blue',
+  dangerColor: 'red',
+  warningColor: 'amber',
+  successColor: 'green',
+  infoColor: 'sky',
+};
 
 type ThemeContextValue = {
   colorScheme: ColorScheme;
   setColorScheme: (scheme: ColorScheme) => void;
   toggleColorScheme: () => void;
-};
+} & SemanticColorConfig;
 
 const ThemeContext = React.createContext<ThemeContextValue | undefined>(undefined);
 
@@ -15,25 +40,48 @@ type ThemeProviderProps = {
   children: React.ReactNode;
   /** Initial color scheme. Defaults to system preference. */
   defaultColorScheme?: ColorScheme;
+  /** Accent color for primary actions and highlights. Defaults to 'blue'. */
+  accentColor?: AccentColor;
+  /** Color for danger/error states. Defaults to 'red'. */
+  dangerColor?: DangerColor;
+  /** Color for warning states. Defaults to 'amber'. */
+  warningColor?: WarningColor;
+  /** Color for success states. Defaults to 'green'. */
+  successColor?: SuccessColor;
+  /** Color for informational states. Defaults to 'sky'. */
+  infoColor?: InfoColor;
 };
 
 /**
- * Provider for theme context that allows programmatic color scheme control.
- * Wrap your app with this provider to enable theme toggling.
+ * Provider for theme context that allows programmatic color scheme control
+ * and semantic color customization.
  *
- * When this provider is used, all Frosted UI components will respond to
- * the programmatic color scheme instead of the system preference.
+ * Wrap your app with this provider to enable theme toggling and custom colors.
  *
  * @example
  * function App() {
  *   return (
- *     <ThemeProvider>
+ *     <ThemeProvider
+ *       accentColor="purple"
+ *       dangerColor="tomato"
+ *       warningColor="yellow"
+ *       successColor="teal"
+ *       infoColor="blue"
+ *     >
  *       <YourApp />
  *     </ThemeProvider>
  *   );
  * }
  */
-function ThemeProvider({ children, defaultColorScheme }: ThemeProviderProps) {
+function ThemeProvider({
+  children,
+  defaultColorScheme,
+  accentColor = defaultSemanticColors.accentColor,
+  dangerColor = defaultSemanticColors.dangerColor,
+  warningColor = defaultSemanticColors.warningColor,
+  successColor = defaultSemanticColors.successColor,
+  infoColor = defaultSemanticColors.infoColor,
+}: ThemeProviderProps) {
   const systemColorScheme = useSystemColorScheme();
   const [colorScheme, setColorScheme] = React.useState<ColorScheme>(
     defaultColorScheme ?? (systemColorScheme === 'dark' ? 'dark' : 'light')
@@ -48,8 +96,13 @@ function ThemeProvider({ children, defaultColorScheme }: ThemeProviderProps) {
       colorScheme,
       setColorScheme,
       toggleColorScheme,
+      accentColor,
+      dangerColor,
+      warningColor,
+      successColor,
+      infoColor,
     }),
-    [colorScheme, toggleColorScheme]
+    [colorScheme, toggleColorScheme, accentColor, dangerColor, warningColor, successColor, infoColor]
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
@@ -60,7 +113,7 @@ function ThemeProvider({ children, defaultColorScheme }: ThemeProviderProps) {
  * Must be used within a ThemeProvider.
  *
  * @example
- * const { colorScheme, toggleColorScheme } = useTheme();
+ * const { colorScheme, toggleColorScheme, accentColor } = useTheme();
  */
 function useTheme(): ThemeContextValue {
   const context = React.useContext(ThemeContext);
@@ -88,5 +141,23 @@ function useColorScheme(): ColorScheme {
   return systemColorScheme === 'dark' ? 'dark' : 'light';
 }
 
-export { ThemeContext, ThemeProvider, useColorScheme, useTheme };
-export type { ColorScheme, ThemeContextValue, ThemeProviderProps };
+/**
+ * Internal hook to get the semantic color configuration.
+ * Returns defaults if not within a ThemeProvider.
+ */
+function useSemanticColors(): SemanticColorConfig {
+  const context = React.useContext(ThemeContext);
+  return context ?? defaultSemanticColors;
+}
+
+export { defaultSemanticColors, ThemeContext, ThemeProvider, useColorScheme, useSemanticColors, useTheme };
+export type {
+  ColorScheme,
+  DangerColor,
+  InfoColor,
+  SemanticColorConfig,
+  SuccessColor,
+  ThemeContextValue,
+  ThemeProviderProps,
+  WarningColor,
+};

--- a/packages/frosted-ui-react-native/src/lib/theme-context.tsx
+++ b/packages/frosted-ui-react-native/src/lib/theme-context.tsx
@@ -102,7 +102,15 @@ function ThemeProvider({
       successColor,
       infoColor,
     }),
-    [colorScheme, toggleColorScheme, accentColor, dangerColor, warningColor, successColor, infoColor]
+    [
+      colorScheme,
+      toggleColorScheme,
+      accentColor,
+      dangerColor,
+      warningColor,
+      successColor,
+      infoColor,
+    ]
   );
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
@@ -150,7 +158,14 @@ function useSemanticColors(): SemanticColorConfig {
   return context ?? defaultSemanticColors;
 }
 
-export { defaultSemanticColors, ThemeContext, ThemeProvider, useColorScheme, useSemanticColors, useTheme };
+export {
+  defaultSemanticColors,
+  ThemeContext,
+  ThemeProvider,
+  useColorScheme,
+  useSemanticColors,
+  useTheme,
+};
 export type {
   ColorScheme,
   DangerColor,

--- a/packages/frosted-ui-react-native/src/lib/theme.ts
+++ b/packages/frosted-ui-react-native/src/lib/theme.ts
@@ -1,82 +1,125 @@
 import { DarkTheme, DefaultTheme, type Theme } from '@react-navigation/native';
+import { useMemo } from 'react';
+import { useSemanticColors } from './theme-context';
 import { themeTokens } from './theme-tokens';
 
 const light = themeTokens.colors.light;
 const dark = themeTokens.colors.dark;
 
 /**
- * Navigation theme using Frosted UI design system colors.
+ * Hook to get navigation theme using Frosted UI design system colors.
+ * Reacts to the accent color from ThemeProvider.
  *
  * React Navigation uses these colors to style the navigation UI elements
  * (headers, tab bars, drawers, etc.) throughout your app.
  *
  * @see https://reactnavigation.org/docs/themes
  */
+export function useNavTheme(): Record<'light' | 'dark', Theme> {
+  const { accentColor, dangerColor } = useSemanticColors();
+
+  return useMemo(() => {
+    const lightAccent = light.palettes[accentColor];
+    const darkAccent = dark.palettes[accentColor];
+    const lightDanger = light.palettes[dangerColor];
+    const darkDanger = dark.palettes[dangerColor];
+
+    return {
+      light: {
+        ...DefaultTheme,
+        colors: {
+          /**
+           * background - The main background color of screens.
+           * Used for: Screen backgrounds, the area behind content.
+           */
+          background: light.background,
+
+          /**
+           * border - Color for borders and dividers.
+           * Used for: Header bottom border, tab bar top border,
+           * separator lines between list items.
+           */
+          border: light.stroke,
+
+          /**
+           * card - Background color for card-like elements.
+           * Used for: Header background, tab bar background,
+           * drawer background, modal backgrounds.
+           */
+          card: light.panelSolid,
+
+          /**
+           * notification - Color for notification badges.
+           * Used for: Badge dots on tab bar icons (e.g., unread count),
+           * uses the danger color from ThemeProvider.
+           */
+          notification: lightDanger['9'],
+
+          /**
+           * primary - The primary/accent color for interactive elements.
+           * Used for: Active tab icon tint, focused input borders,
+           * header button colors, link colors.
+           */
+          primary: lightAccent['a11'],
+
+          /**
+           * text - Default text color.
+           * Used for: Header title, tab bar labels, drawer item text,
+           * and any navigation-related text.
+           */
+          text: light.palettes.gray['12'],
+        },
+      },
+      dark: {
+        ...DarkTheme,
+        colors: {
+          /** background - Screen backgrounds in dark mode */
+          background: dark.background,
+
+          /** border - Borders/dividers in dark mode */
+          border: dark.stroke,
+
+          /** card - Header/tab bar backgrounds in dark mode */
+          card: dark.panelSolid,
+
+          /** notification - Badge color uses danger color */
+          notification: darkDanger['9'],
+
+          /** primary - Active/accent color in dark mode */
+          primary: darkAccent['a11'],
+
+          /** text - Text color in dark mode */
+          text: dark.palettes.gray['12'],
+        },
+      },
+    };
+  }, [accentColor, dangerColor]);
+}
+
+/**
+ * @deprecated Use useNavTheme() hook instead for dynamic accent color support.
+ * Static navigation theme with hardcoded blue accent.
+ */
 export const NAV_THEME: Record<'light' | 'dark', Theme> = {
   light: {
     ...DefaultTheme,
     colors: {
-      /**
-       * background - The main background color of screens.
-       * Used for: Screen backgrounds, the area behind content.
-       */
       background: light.background,
-
-      /**
-       * border - Color for borders and dividers.
-       * Used for: Header bottom border, tab bar top border,
-       * separator lines between list items.
-       */
       border: light.stroke,
-
-      /**
-       * card - Background color for card-like elements.
-       * Used for: Header background, tab bar background,
-       * drawer background, modal backgrounds.
-       */
       card: light.panelSolid,
-
-      /**
-       * notification - Color for notification badges.
-       * Used for: Badge dots on tab bar icons (e.g., unread count),
-       * typically a red/attention-grabbing color.
-       */
       notification: light.palettes.red['9'],
-
-      /**
-       * primary - The primary/accent color for interactive elements.
-       * Used for: Active tab icon tint, focused input borders,
-       * header button colors, link colors.
-       */
       primary: light.palettes.blue['a11'],
-
-      /**
-       * text - Default text color.
-       * Used for: Header title, tab bar labels, drawer item text,
-       * and any navigation-related text.
-       */
       text: light.palettes.gray['12'],
     },
   },
   dark: {
     ...DarkTheme,
     colors: {
-      /** background - Screen backgrounds in dark mode */
       background: dark.background,
-
-      /** border - Borders/dividers in dark mode */
       border: dark.stroke,
-
-      /** card - Header/tab bar backgrounds in dark mode */
       card: dark.panelSolid,
-
-      /** notification - Badge color (stays red in both modes) */
       notification: dark.palettes.red['9'],
-
-      /** primary - Active/accent color in dark mode */
       primary: dark.palettes.blue['a11'],
-
-      /** text - Text color in dark mode */
       text: dark.palettes.gray['12'],
     },
   },

--- a/packages/frosted-ui-react-native/src/lib/use-theme-tokens.ts
+++ b/packages/frosted-ui-react-native/src/lib/use-theme-tokens.ts
@@ -1,12 +1,47 @@
-import { useColorScheme } from './theme-context';
+import { useMemo } from 'react';
+import { useColorScheme, useSemanticColors } from './theme-context';
 import { themeTokens } from './theme-tokens';
 
 export function useThemeTokens() {
   const colorScheme = useColorScheme();
+  const semanticColors = useSemanticColors();
   const isDark = colorScheme === 'dark';
-  const colors = themeTokens.colors[isDark ? 'dark' : 'light'];
+  const baseColors = themeTokens.colors[isDark ? 'dark' : 'light'];
   // Inverted colors for components that flip theme (e.g., Tooltip)
-  const invertedColors = themeTokens.colors[isDark ? 'light' : 'dark'];
+  const invertedBaseColors = themeTokens.colors[isDark ? 'light' : 'dark'];
+
+  // Build colors with semantic palettes added to palettes object
+  const colors = useMemo(
+    () => ({
+      ...baseColors,
+      palettes: {
+        ...baseColors.palettes,
+        // Semantic palettes based on ThemeProvider configuration
+        accent: baseColors.palettes[semanticColors.accentColor],
+        danger: baseColors.palettes[semanticColors.dangerColor],
+        warning: baseColors.palettes[semanticColors.warningColor],
+        success: baseColors.palettes[semanticColors.successColor],
+        info: baseColors.palettes[semanticColors.infoColor],
+      },
+    }),
+    [baseColors, semanticColors]
+  );
+
+  const invertedColors = useMemo(
+    () => ({
+      ...invertedBaseColors,
+      palettes: {
+        ...invertedBaseColors.palettes,
+        // Semantic palettes based on ThemeProvider configuration (inverted)
+        accent: invertedBaseColors.palettes[semanticColors.accentColor],
+        danger: invertedBaseColors.palettes[semanticColors.dangerColor],
+        warning: invertedBaseColors.palettes[semanticColors.warningColor],
+        success: invertedBaseColors.palettes[semanticColors.successColor],
+        info: invertedBaseColors.palettes[semanticColors.infoColor],
+      },
+    }),
+    [invertedBaseColors, semanticColors]
+  );
 
   return {
     typography: themeTokens.typography,

--- a/packages/frosted-ui/src/components/base-button/base-button.css
+++ b/packages/frosted-ui/src/components/base-button/base-button.css
@@ -288,7 +288,7 @@
   }
   &:where([data-state='open']),
   &:where(:active) {
-    background-color: var(--gray-a3);
+    background-color: var(--gray-3);
     box-shadow: inset 0 0 0 1px var(--gray-a6);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14230,7 +14230,9 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
+      - bufferutil
       - supports-color
+      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.74.89': {}


### PR DESCRIPTION
- Adds accent and semantic color settings on the `<ThemeProvider />` (just like on the Web):
<img width="503" height="969" alt="Screenshot 2025-12-18 at 17 54 04" src="https://github.com/user-attachments/assets/8e95c79f-f3f1-43c0-a430-0c608c8da14b" />
<img width="503" height="969" alt="Screenshot 2025-12-18 at 17 57 54" src="https://github.com/user-attachments/assets/6d86bd8b-127f-4bae-a8af-a5c6a0ddd989" />

