### PR TITLE
feat(rn): allow passing 'accent' to 'color' prop

### DIFF
--- a/packages/frosted-ui-react-native/src/lib/color-utils.ts
+++ b/packages/frosted-ui-react-native/src/lib/color-utils.ts
@@ -23,6 +23,8 @@ export function resolveAccentFromColor(
   if (!color) return defaultColor;
 
   switch (color) {
+    case 'accent':
+      return semanticColors.accentColor;
     case 'danger':
       return semanticColors.dangerColor;
     case 'warning':

--- a/packages/frosted-ui-react-native/src/lib/types.ts
+++ b/packages/frosted-ui-react-native/src/lib/types.ts
@@ -33,11 +33,16 @@ export type AccentColor =
   | 'gray';
 
 /**
- * Semantic colors
+ * Semantic colors that map to accent colors based on ThemeProvider settings
  */
 export type SemanticColor = 'danger' | 'warning' | 'success' | 'info';
 
 /**
+ * Special color that uses the ThemeProvider's accentColor setting
+ */
+export type DynamicAccentColor = 'accent';
+
+/**
  * All available color values for component color props
  */
-export type Color = AccentColor | SemanticColor;
+export type Color = AccentColor | SemanticColor | DynamicAccentColor;


### PR DESCRIPTION
Allow passing `accent` to a `color` prop like `<Button color="accent" />`