### PR TITLE
Rn circular progress

### DIFF
--- a/packages/frosted-ui-react-native/app/design-patterns.tsx
+++ b/packages/frosted-ui-react-native/app/design-patterns.tsx
@@ -7,6 +7,7 @@ import {
   Callout,
   Card,
   Checkbox,
+  CircularProgress,
   Dialog,
   Heading,
   Icon,
@@ -1915,6 +1916,80 @@ function StreakCounterPattern() {
   );
 }
 
+function SystemHealthPattern() {
+  const { colors } = useThemeTokens();
+
+  const metrics = [
+    { label: 'CPU', value: 42, color: 'cyan' as const },
+    { label: 'Memory', value: 68, color: 'violet' as const },
+    { label: 'Disk', value: 85, color: 'orange' as const },
+    { label: 'Network', value: 23, color: 'lime' as const },
+  ];
+
+  const getStatusColor = (value: number) => {
+    if (value >= 80) return 'danger';
+    if (value >= 60) return 'warning';
+    return 'success';
+  };
+
+  return (
+    <Card>
+      <View style={{ gap: 16 }}>
+        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+          <Heading size="3">System Health</Heading>
+          <Badge color="success" size="1">
+            <View
+              style={{
+                width: 6,
+                height: 6,
+                borderRadius: 3,
+                backgroundColor: colors.palettes.success['9'],
+              }}
+            />
+            <Text>All Systems Normal</Text>
+          </Badge>
+        </View>
+
+        <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+          {metrics.map((metric) => (
+            <View key={metric.label} style={{ alignItems: 'center', gap: 8 }}>
+              <View style={{ position: 'relative', alignItems: 'center', justifyContent: 'center' }}>
+                <CircularProgress size="6" value={metric.value} color={metric.color} />
+                <View style={{ position: 'absolute' }}>
+                  <Text size="1" weight="bold">{metric.value}</Text>
+                </View>
+              </View>
+              <Text size="1" color="gray">{metric.label}</Text>
+            </View>
+          ))}
+        </View>
+
+        <Separator size="4" />
+
+        <View style={{ gap: 8 }}>
+          {metrics.map((metric) => (
+            <View key={metric.label} style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+              <View
+                style={{
+                  width: 8,
+                  height: 8,
+                  borderRadius: 4,
+                  backgroundColor: colors.palettes[metric.color]['9'],
+                }}
+              />
+              <Text size="2" style={{ flex: 1 }}>{metric.label}</Text>
+              <Text size="2" weight="medium">{metric.value}%</Text>
+              <Badge variant="soft" color={getStatusColor(metric.value)} size="1">
+                <Text>{metric.value >= 80 ? 'High' : metric.value >= 60 ? 'Medium' : 'Low'}</Text>
+              </Badge>
+            </View>
+          ))}
+        </View>
+      </View>
+    </Card>
+  );
+}
+
 function LeaderboardPattern() {
   const { colors } = useThemeTokens();
 
@@ -2719,6 +2794,10 @@ export default function DesignPatternsScreen() {
 
         <Section title="Streak Counter">
           <StreakCounterPattern />
+        </Section>
+
+        <Section title="System Health">
+          <SystemHealthPattern />
         </Section>
 
         <Section title="Leaderboard">

--- a/packages/frosted-ui-react-native/app/kitchen-sink.tsx
+++ b/packages/frosted-ui-react-native/app/kitchen-sink.tsx
@@ -1397,9 +1397,11 @@ export default function KitchenSinkScreen() {
                 </Text>
                 <View style={[s.row, s.itemsCenter, s.gap3, { flexWrap: 'wrap' }]}>
                   <CircularProgress size="5" value={0} />
+                  <CircularProgress size="5" value={1} />
                   <CircularProgress size="5" value={25} />
                   <CircularProgress size="5" value={50} />
                   <CircularProgress size="5" value={75} />
+                  <CircularProgress size="5" value={99} />
                   <CircularProgress size="5" value={100} />
                 </View>
               </View>

--- a/packages/frosted-ui-react-native/app/kitchen-sink.tsx
+++ b/packages/frosted-ui-react-native/app/kitchen-sink.tsx
@@ -9,6 +9,7 @@ import {
   Callout,
   Card,
   Checkbox,
+  CircularProgress,
   Code,
   ContextMenu,
   Dialog,
@@ -1348,6 +1349,58 @@ export default function KitchenSinkScreen() {
                   <Progress value={50} />
                   <Progress value={75} />
                   <Progress value={100} />
+                </View>
+              </View>
+            </View>
+          </ComponentSection>
+
+          {/* Circular Progress Section */}
+          <ComponentSection title="Circular Progress">
+            <View style={s.gap6}>
+              {/* Sizes */}
+              <View style={s.gap2}>
+                <Text size="2" weight="medium">
+                  Sizes
+                </Text>
+                <View style={[s.row, s.itemsCenter, s.gap3, { flexWrap: 'wrap' }]}>
+                  <CircularProgress size="1" value={60} />
+                  <CircularProgress size="2" value={60} />
+                  <CircularProgress size="3" value={60} />
+                  <CircularProgress size="4" value={60} />
+                  <CircularProgress size="5" value={60} />
+                  <CircularProgress size="6" value={60} />
+                  <CircularProgress size="7" value={50} />
+                  <CircularProgress size="8" value={95} />
+                  <CircularProgress size="9" value={100} />
+                </View>
+              </View>
+
+              {/* Colors */}
+              <View style={s.gap2}>
+                <Text size="2" weight="medium">
+                  Colors
+                </Text>
+                <View style={[s.row, s.itemsCenter, s.gap3, { flexWrap: 'wrap' }]}>
+                  <CircularProgress size="4" color="blue" value={60} />
+                  <CircularProgress size="4" color="green" value={60} />
+                  <CircularProgress size="4" color="red" value={60} />
+                  <CircularProgress size="4" color="purple" value={60} />
+                  <CircularProgress size="4" color="orange" value={60} />
+                  <CircularProgress size="4" color="gray" value={60} />
+                </View>
+              </View>
+
+              {/* Values */}
+              <View style={s.gap2}>
+                <Text size="2" weight="medium">
+                  Values
+                </Text>
+                <View style={[s.row, s.itemsCenter, s.gap3, { flexWrap: 'wrap' }]}>
+                  <CircularProgress size="5" value={0} />
+                  <CircularProgress size="5" value={25} />
+                  <CircularProgress size="5" value={50} />
+                  <CircularProgress size="5" value={75} />
+                  <CircularProgress size="5" value={100} />
                 </View>
               </View>
             </View>

--- a/packages/frosted-ui-react-native/docs/llm/COMPONENTS.md
+++ b/packages/frosted-ui-react-native/docs/llm/COMPONENTS.md
@@ -3,7 +3,7 @@
 > **Critical**: Always import components from `@frosted-ui/react-native`, never from React Native directly for UI elements.
 
 ```tsx
-import { Button, Text, Card, Dialog, Slider } from '@frosted-ui/react-native';
+import { Button, Text, Card, Dialog, Slider, CircularProgress } from '@frosted-ui/react-native';
 ```
 
 ---
@@ -496,6 +496,69 @@ Progress bar indicator.
 | `max`   | `number`  | `100`      | Maximum value            |
 | `size`  | `'1'-'6'` | `'6'`      | Bar height (2px to 16px) |
 | `color` | `Color`   | `'accent'` | Fill color               |
+
+---
+
+### CircularProgress
+
+Circular progress indicator with SVG rendering.
+
+```tsx
+<CircularProgress value={75} max={100} size="5" color="accent" />
+```
+
+| Prop    | Type      | Default    | Description                  |
+| ------- | --------- | ---------- | ---------------------------- |
+| `value` | `number`  | `0`        | Current progress             |
+| `max`   | `number`  | `100`      | Maximum value                |
+| `size`  | `'1'-'9'` | `'3'`      | Ring size (16px to 72px)     |
+| `color` | `Color`   | `'accent'` | Progress indicator color     |
+
+#### Size Reference
+
+| Size  | Diameter | Stroke Width | Use Case                       |
+| ----- | -------- | ------------ | ------------------------------ |
+| `'1'` | 16px     | 3px          | Inline indicators              |
+| `'2'` | 20px     | 4px          | Compact UI                     |
+| `'3'` | 24px     | 5px          | **Default** — small indicators |
+| `'4'` | 32px     | 5px          | List items, stats              |
+| `'5'` | 40px     | 6px          | Card displays                  |
+| `'6'` | 48px     | 7px          | Prominent indicators           |
+| `'7'` | 56px     | 8px          | Dashboard widgets              |
+| `'8'` | 64px     | 9px          | Large displays                 |
+| `'9'` | 72px     | 10px         | Hero/featured metrics          |
+
+#### Common Patterns
+
+**With value inside:**
+
+```tsx
+<View style={{ position: 'relative', alignItems: 'center', justifyContent: 'center' }}>
+  <CircularProgress size="6" value={75} color="cyan" />
+  <View style={{ position: 'absolute' }}>
+    <Text size="2" weight="bold">75%</Text>
+  </View>
+</View>
+```
+
+**System health dashboard:**
+
+```tsx
+<View style={{ flexDirection: 'row', gap: 16 }}>
+  <View style={{ alignItems: 'center', gap: 4 }}>
+    <CircularProgress size="5" value={42} color="cyan" />
+    <Text size="1" color="gray">CPU</Text>
+  </View>
+  <View style={{ alignItems: 'center', gap: 4 }}>
+    <CircularProgress size="5" value={68} color="violet" />
+    <Text size="1" color="gray">Memory</Text>
+  </View>
+  <View style={{ alignItems: 'center', gap: 4 }}>
+    <CircularProgress size="5" value={85} color="orange" />
+    <Text size="1" color="gray">Disk</Text>
+  </View>
+</View>
+```
 
 ---
 
@@ -1081,6 +1144,7 @@ Card shown on hover (web) or press (mobile).
 | TextField, TextArea, Select  | `'1'`, `'2'`, `'3'`, `'4'` |
 | Slider                       | `'1'`, `'2'`, `'3'`        |
 | Progress, Spinner            | `'1'` - `'6'`              |
+| CircularProgress             | `'1'` - `'9'`              |
 | Tabs                         | `'1'`, `'2'`               |
 | Callout                      | `'1'`, `'2'`, `'3'`        |
 | Dialog                       | `'1'`, `'2'`, `'3'`, `'4'` |
@@ -1158,6 +1222,20 @@ All share the same height scale. IconButton is square (width = height).
 | `'4'` | 24×24px    | Card loading                  |
 | `'5'` | 32×32px    | Section loading               |
 | `'6'` | 40×40px    | Page loading                  |
+
+### CircularProgress
+
+| Size  | Diameter | Stroke | Use Case                       |
+| ----- | -------- | ------ | ------------------------------ |
+| `'1'` | 16px     | 3px    | Inline indicators              |
+| `'2'` | 20px     | 4px    | Compact UI                     |
+| `'3'` | 24px     | 5px    | **Default** — small indicators |
+| `'4'` | 32px     | 5px    | List items, stats              |
+| `'5'` | 40px     | 6px    | Card displays                  |
+| `'6'` | 48px     | 7px    | Prominent indicators           |
+| `'7'` | 56px     | 8px    | Dashboard widgets              |
+| `'8'` | 64px     | 9px    | Large displays                 |
+| `'9'` | 72px     | 10px   | Hero/featured metrics          |
 
 ---
 

--- a/packages/frosted-ui-react-native/docs/llm/DESIGN_PATTERNS.md
+++ b/packages/frosted-ui-react-native/docs/llm/DESIGN_PATTERNS.md
@@ -2329,6 +2329,45 @@ const entries = [
 </Card>
 ```
 
+### System Health (CircularProgress)
+
+Use `CircularProgress` for dashboard-style metrics:
+
+```tsx
+<Card>
+  <View style={{ gap: 16 }}>
+    <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+      <Heading size="3">System Health</Heading>
+      <Badge color="success" size="1">
+        <Text>All Systems Normal</Text>
+      </Badge>
+    </View>
+
+    {/* Circular progress indicators in a row */}
+    <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
+      {[
+        { label: 'CPU', value: 42, color: 'cyan' },
+        { label: 'Memory', value: 68, color: 'violet' },
+        { label: 'Disk', value: 85, color: 'orange' },
+        { label: 'Network', value: 23, color: 'lime' },
+      ].map((metric) => (
+        <View key={metric.label} style={{ alignItems: 'center', gap: 8 }}>
+          <View style={{ position: 'relative', alignItems: 'center', justifyContent: 'center' }}>
+            <CircularProgress size="6" value={metric.value} color={metric.color} />
+            <View style={{ position: 'absolute' }}>
+              <Text size="1" weight="bold">{metric.value}</Text>
+            </View>
+          </View>
+          <Text size="1" color="gray">{metric.label}</Text>
+        </View>
+      ))}
+    </View>
+  </View>
+</Card>
+```
+
+> **Tip**: Place text inside circular progress using absolute positioning. Use size `"5"` or larger when displaying values inside.
+
 ### Daily Challenge
 
 ```tsx

--- a/packages/frosted-ui-react-native/docs/llm/README.md
+++ b/packages/frosted-ui-react-native/docs/llm/README.md
@@ -46,6 +46,7 @@ import {
   Callout,
   Card,
   Checkbox,
+  CircularProgress,
   Dialog,
   Heading,
   IconButton,

--- a/packages/frosted-ui-react-native/src/components/circular-progress.tsx
+++ b/packages/frosted-ui-react-native/src/components/circular-progress.tsx
@@ -1,0 +1,158 @@
+import type { Color } from '@/lib/types';
+import { useThemeTokens } from '@/lib/use-theme-tokens';
+import * as React from 'react';
+import { View, type ViewProps, type ViewStyle } from 'react-native';
+import Svg, { Circle } from 'react-native-svg';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type CircularProgressSize = '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9';
+
+type CircularProgressProps = ViewProps & {
+  /** Size of the circular progress indicator */
+  size?: CircularProgressSize;
+  /** Color theme for the progress indicator */
+  color?: Color;
+  /** Current progress value */
+  value?: number;
+  /** Maximum progress value */
+  max?: number;
+};
+
+// ============================================================================
+// Size configuration matching web CSS
+// ============================================================================
+
+interface SizeConfig {
+  diameter: number;
+  strokeWidth: number;
+}
+
+function getSizeConfig(size: CircularProgressSize): SizeConfig {
+  switch (size) {
+    case '1':
+      return { diameter: 16, strokeWidth: 3 };
+    case '2':
+      return { diameter: 20, strokeWidth: 4 };
+    case '3':
+      return { diameter: 24, strokeWidth: 5 };
+    case '4':
+      return { diameter: 32, strokeWidth: 5 };
+    case '5':
+      return { diameter: 40, strokeWidth: 6 };
+    case '6':
+      return { diameter: 48, strokeWidth: 7 };
+    case '7':
+      return { diameter: 56, strokeWidth: 8 };
+    case '8':
+      return { diameter: 64, strokeWidth: 9 };
+    case '9':
+      return { diameter: 72, strokeWidth: 10 };
+  }
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+function CircularProgress({
+  size = '3',
+  color,
+  value = 0,
+  max = 100,
+  style,
+  ...props
+}: CircularProgressProps) {
+  const { colors } = useThemeTokens();
+
+  // Get size configuration
+  const { diameter, strokeWidth } = getSizeConfig(size);
+
+  // Calculate SVG geometry
+  const radius = (diameter - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const center = diameter / 2;
+
+  // Calculate progress (0 to 1)
+  const progress = Math.max(0, Math.min((value || 0) / max, 1));
+
+  // Round caps add visual length beyond the arc endpoints
+  // Each cap extends by strokeWidth/2, total extension = strokeWidth
+  // We need to compensate so visual progress matches the actual value
+  const capArcLength = strokeWidth / 2;
+  const totalCapArc = strokeWidth;
+
+  // Calculate the arc to draw (reduced to account for cap visual extension)
+  const targetVisualArc = progress * circumference;
+  const actualArcToDraw = Math.max(0, targetVisualArc - totalCapArc);
+
+  // Stroke dash offset (how much of the circumference to hide)
+  const strokeDashoffset = circumference - actualArcToDraw;
+
+  // Rotate to position start cap's outer edge at 12 o'clock
+  // Without adjustment, the arc starts at 12 o'clock but cap extends backwards
+  // Rotate forward by the angle of half a cap so the visual edge is at 12
+  const capAngle = (capArcLength / circumference) * 360;
+  const rotation = -90 + capAngle;
+
+  // Get colors
+  const gray = colors.palettes.gray;
+  const palette = colors.palettes[color ?? 'accent'] ?? gray;
+
+  // Track color (background circle) - uses alpha variant
+  const trackColor = palette.a3;
+
+  // Indicator color
+  const indicatorColor = palette['9'];
+
+  const containerStyle: ViewStyle = {
+    width: diameter,
+    height: diameter,
+  };
+
+  return (
+    <View
+      role="progressbar"
+      aria-valuemin={0}
+      aria-valuemax={max}
+      aria-valuenow={value}
+      style={[containerStyle, style]}
+      {...props}>
+      <Svg width={diameter} height={diameter} viewBox={`0 0 ${diameter} ${diameter}`}>
+        {/* Track (background circle) */}
+        <Circle
+          cx={center}
+          cy={center}
+          r={radius}
+          stroke={trackColor}
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+
+        {/* Progress indicator */}
+        {progress > 0 && (
+          <Circle
+            cx={center}
+            cy={center}
+            r={radius}
+            stroke={indicatorColor}
+            strokeWidth={strokeWidth}
+            fill="none"
+            strokeDasharray={progress >= 1 ? undefined : circumference}
+            strokeDashoffset={progress >= 1 ? undefined : strokeDashoffset}
+            strokeLinecap={progress >= 1 ? 'butt' : 'round'}
+            transform={progress >= 1 ? undefined : `rotate(${rotation} ${center} ${center})`}
+          />
+        )}
+      </Svg>
+    </View>
+  );
+}
+
+CircularProgress.displayName = 'CircularProgress';
+
+export { CircularProgress };
+export type { CircularProgressProps, CircularProgressSize };
+

--- a/packages/frosted-ui-react-native/src/components/circular-progress.tsx
+++ b/packages/frosted-ui-react-native/src/components/circular-progress.tsx
@@ -80,20 +80,20 @@ function CircularProgress({
 
   // Round caps add visual length beyond the arc endpoints
   // Each cap extends by strokeWidth/2, total extension = strokeWidth
-  // We need to compensate so visual progress matches the actual value
   const capArcLength = strokeWidth / 2;
   const totalCapArc = strokeWidth;
 
   // Calculate the arc to draw (reduced to account for cap visual extension)
+  // Minimum arc ensures at least a dot (rounded cap) is visible when progress > 0
   const targetVisualArc = progress * circumference;
-  const actualArcToDraw = Math.max(0, targetVisualArc - totalCapArc);
+  const compensatedArc = targetVisualArc - totalCapArc;
+  const minArc = progress > 0 ? 0.1 : 0;
+  const actualArcToDraw = Math.max(minArc, compensatedArc);
 
   // Stroke dash offset (how much of the circumference to hide)
   const strokeDashoffset = circumference - actualArcToDraw;
 
   // Rotate to position start cap's outer edge at 12 o'clock
-  // Without adjustment, the arc starts at 12 o'clock but cap extends backwards
-  // Rotate forward by the angle of half a cap so the visual edge is at 12
   const capAngle = (capArcLength / circumference) * 360;
   const rotation = -90 + capAngle;
 

--- a/packages/frosted-ui-react-native/src/components/index.ts
+++ b/packages/frosted-ui-react-native/src/components/index.ts
@@ -15,6 +15,7 @@ export * from './code';
 // FORMS
 //------------------------------------------------------------------------------
 export * from './checkbox';
+export * from './circular-progress';
 export * from './label';
 export * from './progress';
 export * from './radio-group';

--- a/packages/frosted-ui/src/components/circular-progress/circular-progress.css
+++ b/packages/frosted-ui/src/components/circular-progress/circular-progress.css
@@ -3,17 +3,18 @@
   display: block;
   width: var(--circular-progress-size);
   height: var(--circular-progress-size);
-  border-radius: 50%;
-  overflow: hidden;
-  --circular-progress-color: var(--accent-9);
 }
-.fui-CircularProgressRoot::before {
-  content: '';
-  inset: 0;
-  z-index: 1;
-  position: absolute;
-  border-radius: inherit;
-  border: var(--circular-progress-border-thickness) solid var(--accent-a3);
+
+.fui-CircularProgressSvg {
+  display: block;
+}
+
+.fui-CircularProgressTrack {
+  stroke: var(--accent-a3);
+}
+
+.fui-CircularProgressIndicator {
+  stroke: var(--accent-9);
 }
 
 /***************************************************************************************************
@@ -22,63 +23,38 @@
  *                                                                                                 *
  ***************************************************************************************************/
 
-/* TODO: adjust thickness */
-
 .fui-CircularProgressRoot {
   &:where(.fui-r-size-1) {
     --circular-progress-size: 16px;
-    --circular-progress-border-thickness: 3px;
   }
   &:where(.fui-r-size-2) {
     --circular-progress-size: 20px;
-    --circular-progress-border-thickness: 4px;
   }
   &:where(.fui-r-size-3) {
     --circular-progress-size: 24px;
-    --circular-progress-border-thickness: 5px;
   }
   &:where(.fui-r-size-4) {
     --circular-progress-size: 32px;
-    --circular-progress-border-thickness: 5px;
   }
   &:where(.fui-r-size-5) {
     --circular-progress-size: 40px;
-    --circular-progress-border-thickness: 6px;
   }
   &:where(.fui-r-size-6) {
     --circular-progress-size: 48px;
-    --circular-progress-border-thickness: 7px;
   }
   &:where(.fui-r-size-7) {
     --circular-progress-size: 56px;
-    --circular-progress-border-thickness: 8px;
   }
   &:where(.fui-r-size-8) {
     --circular-progress-size: 64px;
-    --circular-progress-border-thickness: 9px;
   }
   &:where(.fui-r-size-9) {
     --circular-progress-size: 72px;
-    --circular-progress-border-thickness: 10px;
   }
-}
-
-.fui-CircularProgressIndicator {
-  position: absolute;
-  inset: 0;
-  border: var(--circular-progress-border-thickness) solid var(--circular-progress-color);
-  border-radius: inherit;
-  --mask: conic-gradient(
-    black calc(1turn * var(--circular-progress-progress)),
-    /* 0.001turn to smoothen out the cut out part */ transparent
-      calc(1turn * var(--circular-progress-progress) + 0.001turn)
-  );
-  mask: var(--mask);
-  mask-image: var(--mask);
 }
 
 /* high-contrast */
 
-.fui-CircularProgressRoot:where(.fui-high-contrast) {
-  --circular-progress-color: var(--accent-12);
+.fui-CircularProgressRoot:where(.fui-high-contrast) .fui-CircularProgressIndicator {
+  stroke: var(--accent-12);
 }

--- a/packages/frosted-ui/src/components/circular-progress/circular-progress.stories.tsx
+++ b/packages/frosted-ui/src/components/circular-progress/circular-progress.stories.tsx
@@ -57,10 +57,10 @@ export const Color: Story = {
   },
   render: (args) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)', width: 300 }}>
-      <CircularProgress {...args} color="indigo" />
-      <CircularProgress {...args} color="cyan" />
-      <CircularProgress {...args} color="orange" />
-      <CircularProgress {...args} color="crimson" />
+      <CircularProgress {...args} color="indigo" value={15} />
+      <CircularProgress {...args} color="cyan" value={50} />
+      <CircularProgress {...args} color="orange" value={95} />
+      <CircularProgress {...args} color="crimson" value={100} />
     </div>
   ),
 };

--- a/packages/frosted-ui/src/components/circular-progress/circular-progress.tsx
+++ b/packages/frosted-ui/src/components/circular-progress/circular-progress.tsx
@@ -8,8 +8,20 @@ import { circularProgressPropDefs } from './circular-progress.props';
 
 type CircularProgressOwnProps = GetPropDefTypes<typeof circularProgressPropDefs>;
 interface CircularProgressProps
-  extends Omit<PropsWithoutColor<typeof ProgressPrimitive.Root>, 'children'>,
-    CircularProgressOwnProps {}
+  extends Omit<PropsWithoutColor<typeof ProgressPrimitive.Root>, 'children'>, CircularProgressOwnProps {}
+
+// Size configuration matching CSS variables
+const sizeConfig: Record<string, { diameter: number; strokeWidth: number }> = {
+  '1': { diameter: 16, strokeWidth: 3 },
+  '2': { diameter: 20, strokeWidth: 4 },
+  '3': { diameter: 24, strokeWidth: 5 },
+  '4': { diameter: 32, strokeWidth: 5 },
+  '5': { diameter: 40, strokeWidth: 6 },
+  '6': { diameter: 48, strokeWidth: 7 },
+  '7': { diameter: 56, strokeWidth: 8 },
+  '8': { diameter: 64, strokeWidth: 9 },
+  '9': { diameter: 72, strokeWidth: 10 },
+};
 
 const CircularProgress = (props: CircularProgressProps) => {
   const {
@@ -22,7 +34,32 @@ const CircularProgress = (props: CircularProgressProps) => {
     ...progressProps
   } = props;
 
-  const progress = Math.max(0, Math.min((value || 0) / max, 100));
+  const { diameter, strokeWidth } = sizeConfig[size] || sizeConfig['3'];
+  const radius = (diameter - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+  const center = diameter / 2;
+
+  // Calculate progress (0 to 1)
+  const progress = Math.max(0, Math.min((value || 0) / max, 1));
+
+  // Round caps add visual length beyond the arc endpoints
+  // Each cap extends by strokeWidth/2, total extension = strokeWidth
+  const capArcLength = strokeWidth / 2;
+  const totalCapArc = strokeWidth;
+
+  // Calculate the arc to draw (reduced to account for cap visual extension)
+  // Minimum arc ensures at least a dot (rounded cap) is visible when progress > 0
+  const targetVisualArc = progress * circumference;
+  const compensatedArc = targetVisualArc - totalCapArc;
+  const minArc = progress > 0 ? 0.1 : 0;
+  const actualArcToDraw = Math.max(minArc, compensatedArc);
+
+  // Stroke dash offset (how much of the circumference to hide)
+  const strokeDashoffset = circumference - actualArcToDraw;
+
+  // Rotate to position start cap's outer edge at 12 o'clock
+  const capAngle = (capArcLength / circumference) * 360;
+  const rotation = -90 + capAngle;
 
   return (
     <ProgressPrimitive.Root
@@ -38,15 +75,42 @@ const CircularProgress = (props: CircularProgressProps) => {
       value={value}
       max={max}
       {...progressProps}
+      asChild
     >
-      <ProgressPrimitive.Indicator
-        className="fui-CircularProgressIndicator"
-        style={
-          {
-            '--circular-progress-progress': progress,
-          } as React.CSSProperties
-        }
-      />
+      <svg
+        className="fui-CircularProgressSvg"
+        width={diameter}
+        height={diameter}
+        viewBox={`0 0 ${diameter} ${diameter}`}
+      >
+        {/* Track (background circle) */}
+        <circle
+          className="fui-CircularProgressTrack"
+          cx={center}
+          cy={center}
+          r={radius}
+          strokeWidth={strokeWidth}
+          fill="none"
+        />
+
+        {/* Progress indicator */}
+        {progress > 0 && (
+          <ProgressPrimitive.Indicator asChild>
+            <circle
+              className="fui-CircularProgressIndicator"
+              cx={center}
+              cy={center}
+              r={radius}
+              strokeWidth={strokeWidth}
+              fill="none"
+              strokeDasharray={progress >= 1 ? undefined : circumference}
+              strokeDashoffset={progress >= 1 ? undefined : strokeDashoffset}
+              strokeLinecap={progress >= 1 ? 'butt' : 'round'}
+              transform={progress >= 1 ? undefined : `rotate(${rotation} ${center} ${center})`}
+            />
+          </ProgressPrimitive.Indicator>
+        )}
+      </svg>
     </ProgressPrimitive.Root>
   );
 };


### PR DESCRIPTION
- Adds `<CircularProgress />` React Native component
- Updates web circular progress component to use rounded caps for better look:
<img width="648" height="402" alt="Screenshot 2026-01-05 at 18 27 15" src="https://github.com/user-attachments/assets/369caaed-39c5-4f71-a288-04aa22f93e39" />
<img width="648" height="402" alt="Screenshot 2026-01-05 at 18 27 26" src="https://github.com/user-attachments/assets/1ba3c390-4dbf-4985-8bd5-b009633264c2" />
