### PR TITLE
Base UI 3

### DIFF
--- a/apps/tailwind/package.json
+++ b/apps/tailwind/package.json
@@ -26,6 +26,6 @@
     "@types/react-dom": "^19.0.0",
     "eslint-config-custom": "workspace:*",
     "tailwindcss": "^4.0.14",
-    "typescript": "^4.5.3"
+    "typescript": "^5.6.3"
   }
 }

--- a/packages/frosted-ui/src/components/base-segmented-control-list/base-segmented-control-list.css
+++ b/packages/frosted-ui/src/components/base-segmented-control-list/base-segmented-control-list.css
@@ -32,7 +32,7 @@
       color: var(--gray-a11);
     }
   }
-  &:where([data-state='active'], [data-state='checked'], [data-active]) {
+  &:where([data-selected], [data-active]) {
     color: var(--gray-a12);
   }
   &:before {
@@ -46,7 +46,7 @@
     outline: 2px solid var(--color-focus-root);
     outline-offset: 2px;
   }
-  &:where([data-state='active'], [data-state='checked'], [data-active])::before {
+  &:where([data-selected], [data-active])::before {
     background: var(--color-segmented-control-thumb);
     background-image: linear-gradient(var(--white-a3), var(--white-a3));
     box-shadow:

--- a/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
+++ b/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
@@ -28,17 +28,20 @@
 
 .fui-BaseTabsTriggerInner {
   position: absolute;
+}
 
-  :where(.fui-BaseTabsTrigger[data-state='inactive'], .fui-TabsNavLink:not([data-active])) & {
-    letter-spacing: var(--tabs-trigger-inactive-letter-spacing);
-    word-spacing: var(--tabs-trigger-inactive-word-spacing);
-  }
+.fui-BaseTabsTrigger:not([data-selected]):not([data-active]) .fui-BaseTabsTriggerInner,
+.fui-TabsNavLink:not([data-active]) .fui-BaseTabsTriggerInner {
+  letter-spacing: var(--tabs-trigger-inactive-letter-spacing);
+  word-spacing: var(--tabs-trigger-inactive-word-spacing);
+}
 
-  :where(.fui-BaseTabsTrigger[data-state='active'], .fui-TabsNavLink[data-active]) & {
-    font-weight: var(--font-weight-medium);
-    letter-spacing: var(--tabs-trigger-active-letter-spacing);
-    word-spacing: var(--tabs-trigger-active-word-spacing);
-  }
+.fui-BaseTabsTrigger[data-selected] .fui-BaseTabsTriggerInner,
+.fui-BaseTabsTrigger[data-active] .fui-BaseTabsTriggerInner,
+.fui-TabsNavLink[data-active] .fui-BaseTabsTriggerInner {
+  font-weight: var(--font-weight-medium);
+  letter-spacing: var(--tabs-trigger-active-letter-spacing);
+  word-spacing: var(--tabs-trigger-active-word-spacing);
 }
 
 .fui-BaseTabsTriggerInnerHidden {
@@ -46,11 +49,6 @@
   font-weight: var(--font-weight-medium);
   letter-spacing: var(--tabs-trigger-active-letter-spacing);
   word-spacing: var(--tabs-trigger-active-word-spacing);
-}
-
-.fui-BaseTabsContent {
-  position: relative;
-  outline: 0;
 }
 
 /***************************************************************************************************
@@ -117,14 +115,14 @@
       background-color: var(--accent-a3);
     }
   }
-  &:where([data-state='active'], [data-active]) {
+  &:where([data-selected], [data-active]) {
     color: var(--gray-12);
   }
   &:where(:focus-visible) :where(.fui-BaseTabsTriggerInner) {
     outline: 2px solid var(--color-focus-root);
     outline-offset: -2px;
   }
-  &:where([data-state='active'], [data-active])::before {
+  &:where([data-selected], [data-active])::before {
     box-sizing: border-box;
     content: '';
     height: 2px;

--- a/packages/frosted-ui/src/components/segmented-control-nav/segmented-control-nav.props.ts
+++ b/packages/frosted-ui/src/components/segmented-control-nav/segmented-control-nav.props.ts
@@ -1,9 +1,2 @@
-import { asChildProp } from '../../helpers';
-
-const segmentedControlNavLinkPropDefs = {
-  asChild: asChildProp,
-} satisfies {
-  asChild: typeof asChildProp;
-};
-
-export { segmentedControlNavLinkPropDefs };
+// Props file kept for future prop definitions
+export {};

--- a/packages/frosted-ui/src/components/segmented-control-nav/segmented-control-nav.stories.tsx
+++ b/packages/frosted-ui/src/components/segmented-control-nav/segmented-control-nav.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { SegmentedControlNav } from '..';
+import { Code, SegmentedControlNav, Text } from '..';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
@@ -31,6 +31,28 @@ export const Default: Story = {
         <SegmentedControlNav.Link href="#">Documents</SegmentedControlNav.Link>
         <SegmentedControlNav.Link href="#">Settings</SegmentedControlNav.Link>
       </SegmentedControlNav.Root>
+    </div>
+  ),
+};
+
+export const RenderProp: Story = {
+  name: 'Render Prop (Client-Side Routing)',
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 400 }}>
+      <Text>
+        Use the <Code>render</Code> prop to integrate with your framework&apos;s router for client-side navigation.
+      </Text>
+      <SegmentedControlNav.Root {...args}>
+        <SegmentedControlNav.Link active render={<a href="/account" />}>
+          Account
+        </SegmentedControlNav.Link>
+        <SegmentedControlNav.Link render={<a href="/documents" />}>Documents</SegmentedControlNav.Link>
+        <SegmentedControlNav.Link render={<a href="/settings" />}>Settings</SegmentedControlNav.Link>
+      </SegmentedControlNav.Root>
+      <Text size="1" color="gray">
+        In a real app, replace <Code>{'<a />'}</Code> with your router&apos;s Link component, e.g.{' '}
+        <Code>{'<NextLink href="/account" />'}</Code> for Next.js.
+      </Text>
     </div>
   ),
 };

--- a/packages/frosted-ui/src/components/segmented-control-nav/segmented-control-nav.tsx
+++ b/packages/frosted-ui/src/components/segmented-control-nav/segmented-control-nav.tsx
@@ -1,27 +1,17 @@
 'use client';
 
+import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import classNames from 'classnames';
-import { NavigationMenu } from 'radix-ui';
 import * as React from 'react';
-import { GetPropDefTypes, getSubtree } from '../../helpers';
-import { segmentedControlNavLinkPropDefs } from './segmented-control-nav.props';
 
-interface SegmentedControlNavRootProps
-  extends Omit<
-    React.ComponentProps<typeof NavigationMenu.Root>,
-    'asChild' | 'orientation' | 'defauValue' | 'value' | 'onValueChange' | 'delayDuration' | 'skipDelayDuration'
-  > {}
+type SegmentedControlNavRootProps = Omit<React.ComponentProps<typeof NavigationMenu.Root>, 'className' | 'render'> &
+  React.ComponentProps<'nav'>;
 
 const SegmentedControlNavRoot = (props: SegmentedControlNavRootProps) => {
   const { children, className, ...rootProps } = props;
 
   return (
-    <NavigationMenu.Root
-      className="fui-SegmentedControlNavRoot"
-      {...rootProps}
-      asChild={false}
-      orientation="horizontal"
-    >
+    <NavigationMenu.Root className="fui-SegmentedControlNavRoot" {...rootProps}>
       <NavigationMenu.List className={classNames('fui-reset', 'fui-BaseSegmentedControlList', className)}>
         {children}
       </NavigationMenu.List>
@@ -30,26 +20,27 @@ const SegmentedControlNavRoot = (props: SegmentedControlNavRootProps) => {
 };
 SegmentedControlNavRoot.displayName = 'SegmentedControlNavRoot';
 
-type SegmentedControlNavLinkOwnProps = GetPropDefTypes<typeof segmentedControlNavLinkPropDefs>;
-interface SegmentedControlNavLinkProps
-  extends Omit<React.ComponentProps<typeof NavigationMenu.Link>, 'onSelect'>,
-    SegmentedControlNavLinkOwnProps {}
+interface SegmentedControlNavLinkOwnProps {
+  /** Render the link as a custom element */
+  render?: React.ReactElement;
+  /** Additional CSS class name */
+  className?: string;
+}
+type SegmentedControlNavLinkProps = Omit<React.ComponentProps<typeof NavigationMenu.Link>, 'className' | 'render'> &
+  Omit<React.ComponentProps<'a'>, 'className'> &
+  SegmentedControlNavLinkOwnProps;
 
 const SegmentedControlNavLink = (props: SegmentedControlNavLinkProps) => {
-  const { asChild, children, className, ...linkProps } = props;
+  const { render, children, className, ...linkProps } = props;
 
   return (
     <NavigationMenu.Item className="fui-SegmentedControlNavItem">
       <NavigationMenu.Link
         {...linkProps}
+        render={render}
         className={classNames('fui-reset', 'fui-BaseSegmentedControlTrigger', 'fui-SegmentedControlNavLink', className)}
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        onSelect={() => {}}
-        asChild={asChild}
       >
-        {getSubtree({ asChild, children }, (children) => (
-          <span className="fui-BaseSegmentedControlTriggerInner">{children}</span>
-        ))}
+        <span className="fui-BaseSegmentedControlTriggerInner">{children}</span>
       </NavigationMenu.Link>
     </NavigationMenu.Item>
   );

--- a/packages/frosted-ui/src/components/segmented-control/segmented-control.css
+++ b/packages/frosted-ui/src/components/segmented-control/segmented-control.css
@@ -4,3 +4,7 @@
   position: relative;
   outline: 0;
 }
+
+.fui-SegmentedControlContent:where(:focus-visible) {
+  outline: 2px solid var(--color-focus-root);
+}

--- a/packages/frosted-ui/src/components/segmented-control/segmented-control.stories.tsx
+++ b/packages/frosted-ui/src/components/segmented-control/segmented-control.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { Button, Drawer, SegmentedControl, Text } from '..';
+import { Button, Code, Drawer, SegmentedControl, Text, TextArea, TextField } from '..';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
@@ -31,19 +31,17 @@ export const Default: Story = {
           <SegmentedControl.Trigger value="settings">Settings</SegmentedControl.Trigger>
         </SegmentedControl.List>
 
-        <div style={{ padding: '12px 16px 8px 16px' }}>
-          <SegmentedControl.Content value="account">
-            <Text size="2">Your account.</Text>
-          </SegmentedControl.Content>
+        <SegmentedControl.Content value="account" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Your account.</Text>
+        </SegmentedControl.Content>
 
-          <SegmentedControl.Content value="documents">
-            <Text size="2">Your documents.</Text>
-          </SegmentedControl.Content>
+        <SegmentedControl.Content value="documents" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Your documents.</Text>
+        </SegmentedControl.Content>
 
-          <SegmentedControl.Content value="settings">
-            <Text size="2">Your profile.</Text>
-          </SegmentedControl.Content>
-        </div>
+        <SegmentedControl.Content value="settings" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Your profile.</Text>
+        </SegmentedControl.Content>
       </SegmentedControl.Root>
     </div>
   ),
@@ -85,4 +83,157 @@ export const InDrawer: Story = {
       </Drawer.Content>
     </Drawer.Root>
   ),
+};
+
+export const ActivateOnFocus: Story = {
+  name: 'Activate on Focus',
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', maxWidth: 400 }}>
+      <Text>
+        The <Code>activateOnFocus</Code> prop controls whether segments are activated immediately when focused via
+        keyboard navigation, or only when explicitly clicked/pressed. Try using <Code>Tab</Code> to focus the control,
+        then <Code>Arrow</Code> keys to navigate.
+      </Text>
+
+      <div>
+        <Text size="2" weight="medium" style={{ marginBottom: 'var(--space-2)', display: 'block' }}>
+          activateOnFocus={'{true}'}
+        </Text>
+        <SegmentedControl.Root defaultValue="day">
+          <SegmentedControl.List {...args} activateOnFocus>
+            <SegmentedControl.Trigger value="day">Day</SegmentedControl.Trigger>
+            <SegmentedControl.Trigger value="week">Week</SegmentedControl.Trigger>
+            <SegmentedControl.Trigger value="month">Month</SegmentedControl.Trigger>
+          </SegmentedControl.List>
+
+          <SegmentedControl.Content value="day" style={{ padding: '12px 16px 8px 16px' }}>
+            <Text size="2">Daily view — Activates immediately on arrow key navigation.</Text>
+          </SegmentedControl.Content>
+          <SegmentedControl.Content value="week" style={{ padding: '12px 16px 8px 16px' }}>
+            <Text size="2">Weekly view — Activates immediately on arrow key navigation.</Text>
+          </SegmentedControl.Content>
+          <SegmentedControl.Content value="month" style={{ padding: '12px 16px 8px 16px' }}>
+            <Text size="2">Monthly view — Activates immediately on arrow key navigation.</Text>
+          </SegmentedControl.Content>
+        </SegmentedControl.Root>
+      </div>
+
+      <div>
+        <Text size="2" weight="medium" style={{ marginBottom: 'var(--space-2)', display: 'block' }}>
+          activateOnFocus={'{false}'} (default)
+        </Text>
+        <SegmentedControl.Root defaultValue="day">
+          <SegmentedControl.List {...args} activateOnFocus={false}>
+            <SegmentedControl.Trigger value="day">Day</SegmentedControl.Trigger>
+            <SegmentedControl.Trigger value="week">Week</SegmentedControl.Trigger>
+            <SegmentedControl.Trigger value="month">Month</SegmentedControl.Trigger>
+          </SegmentedControl.List>
+
+          <SegmentedControl.Content value="day" style={{ padding: '12px 16px 8px 16px' }}>
+            <Text size="2">Daily view — Must press Enter/Space to activate after focusing.</Text>
+          </SegmentedControl.Content>
+          <SegmentedControl.Content value="week" style={{ padding: '12px 16px 8px 16px' }}>
+            <Text size="2">Weekly view — Must press Enter/Space to activate after focusing.</Text>
+          </SegmentedControl.Content>
+          <SegmentedControl.Content value="month" style={{ padding: '12px 16px 8px 16px' }}>
+            <Text size="2">Monthly view — Must press Enter/Space to activate after focusing.</Text>
+          </SegmentedControl.Content>
+        </SegmentedControl.Root>
+      </div>
+
+      <Text size="1" color="gray">
+        Use <Code>activateOnFocus={'{true}'}</Code> for a more fluid experience. The default (<Code>false</Code>)
+        follows WAI-ARIA best practices, requiring explicit activation which is better for accessibility.
+      </Text>
+    </div>
+  ),
+};
+
+export const KeepMounted: Story = {
+  name: 'Keep Mounted',
+  render: (args) => {
+    const [username, setUsername] = React.useState('');
+    const [email, setEmail] = React.useState('');
+    const [bio, setBio] = React.useState('');
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 400 }}>
+        <Text>
+          The <Code>keepMounted</Code> prop on <Code>SegmentedControl.Content</Code> keeps panels in the DOM even when
+          hidden. This preserves component state like form inputs, scroll position, and avoids re-mounting expensive
+          components.
+        </Text>
+
+        <Text size="2" weight="medium">
+          With keepMounted={'{true}'} — Form state is preserved
+        </Text>
+        <SegmentedControl.Root defaultValue="profile">
+          <SegmentedControl.List {...args}>
+            <SegmentedControl.Trigger value="profile">Profile</SegmentedControl.Trigger>
+            <SegmentedControl.Trigger value="contact">Contact</SegmentedControl.Trigger>
+            <SegmentedControl.Trigger value="about">About</SegmentedControl.Trigger>
+          </SegmentedControl.List>
+          <div
+            style={{
+              padding: '16px',
+              background: 'var(--gray-2)',
+              borderRadius: 'var(--radius-2)',
+              marginTop: 'var(--space-2)',
+            }}
+          >
+            <SegmentedControl.Content value="profile" keepMounted>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+                <Text as="label" size="2">
+                  Username
+                </Text>
+                <TextField.Input
+                  size="3"
+                  value={username}
+                  onChange={(e) => setUsername(e.target.value)}
+                  placeholder="Enter your username"
+                />
+                <Text size="1" color="gray">
+                  Type something, switch segments, then come back — your input is preserved!
+                </Text>
+              </div>
+            </SegmentedControl.Content>
+            <SegmentedControl.Content value="contact" keepMounted>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+                <Text as="label" size="2">
+                  Email
+                </Text>
+                <TextField.Input
+                  size="3"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="Enter your email"
+                />
+              </div>
+            </SegmentedControl.Content>
+            <SegmentedControl.Content value="about" keepMounted>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+                <Text as="label" size="2">
+                  Bio
+                </Text>
+                <TextArea
+                  size="3"
+                  value={bio}
+                  onChange={(e) => setBio(e.target.value)}
+                  placeholder="Tell us about yourself"
+                  rows={3}
+                />
+              </div>
+            </SegmentedControl.Content>
+          </div>
+        </SegmentedControl.Root>
+
+        <Text size="1" color="gray">
+          Use <Code>keepMounted</Code> on <Code>SegmentedControl.Content</Code> for multi-step forms, preserving
+          video/audio playback state, or panels with expensive initialization. Without it, panels unmount when hidden
+          and lose their state.
+        </Text>
+      </div>
+    );
+  },
 };

--- a/packages/frosted-ui/src/components/segmented-control/segmented-control.tsx
+++ b/packages/frosted-ui/src/components/segmented-control/segmented-control.tsx
@@ -1,10 +1,14 @@
 'use client';
 
+import { Tabs as TabsPrimitive } from '@base-ui/react/tabs';
 import classNames from 'classnames';
-import { Tabs as TabsPrimitive } from 'radix-ui';
 import * as React from 'react';
 
-interface SegmentedControlRootProps extends React.ComponentProps<typeof TabsPrimitive.Root> {}
+type SegmentedControlRootProps = Omit<
+  React.ComponentProps<typeof TabsPrimitive.Root>,
+  'className' | 'render' | 'orientation'
+> &
+  React.ComponentProps<'div'>;
 
 const SegmentedControlRoot = (props: SegmentedControlRootProps) => {
   const { className, ...rootProps } = props;
@@ -12,10 +16,8 @@ const SegmentedControlRoot = (props: SegmentedControlRootProps) => {
 };
 SegmentedControlRoot.displayName = 'SegmentedControlRoot';
 
-interface SegmentedControlListOwnProps extends React.ComponentProps<'div'> {}
-interface SegmentedControlListProps
-  extends React.ComponentProps<typeof TabsPrimitive.List>,
-    SegmentedControlListOwnProps {}
+type SegmentedControlListProps = Omit<React.ComponentProps<typeof TabsPrimitive.List>, 'className' | 'render'> &
+  React.ComponentProps<'div'>;
 
 const SegmentedControlList = (props: SegmentedControlListProps) => {
   const { className, ...listProps } = props;
@@ -23,25 +25,27 @@ const SegmentedControlList = (props: SegmentedControlListProps) => {
 };
 SegmentedControlList.displayName = 'SegmentedControlList';
 
-interface SegmentedControlTriggerProps extends React.ComponentProps<typeof TabsPrimitive.Trigger> {}
+type SegmentedControlTriggerProps = Omit<React.ComponentProps<typeof TabsPrimitive.Tab>, 'className' | 'render'> &
+  React.ComponentProps<'button'>;
 
 const SegmentedControlTrigger = (props: SegmentedControlTriggerProps) => {
   const { className, children, ...triggerProps } = props;
   return (
-    <TabsPrimitive.Trigger
+    <TabsPrimitive.Tab
       {...triggerProps}
       className={classNames('fui-reset', 'fui-BaseSegmentedControlTrigger', className)}
     >
       <span className="fui-BaseSegmentedControlTriggerInner">{children}</span>
-    </TabsPrimitive.Trigger>
+    </TabsPrimitive.Tab>
   );
 };
 SegmentedControlTrigger.displayName = 'SegmentedControlTrigger';
 
-interface SegmentedControlContentProps extends React.ComponentProps<typeof TabsPrimitive.Content> {}
+type SegmentedControlContentProps = Omit<React.ComponentProps<typeof TabsPrimitive.Panel>, 'className' | 'render'> &
+  React.ComponentProps<'div'>;
 
 const SegmentedControlContent = (props: SegmentedControlContentProps) => (
-  <TabsPrimitive.Content {...props} className={classNames('fui-SegmentedControlContent', props.className)} />
+  <TabsPrimitive.Panel {...props} className={classNames('fui-SegmentedControlContent', props.className)} />
 );
 SegmentedControlContent.displayName = 'SegmentedControlContent';
 

--- a/packages/frosted-ui/src/components/tabs-nav/tabs-nav.props.ts
+++ b/packages/frosted-ui/src/components/tabs-nav/tabs-nav.props.ts
@@ -1,10 +1,1 @@
-import { asChildProp } from '../../helpers';
-
-const tabsNavLinkPropDefs = {
-  asChild: asChildProp,
-} satisfies {
-  asChild: typeof asChildProp;
-};
-
 export { baseTabsListPropDefs as tabsNavPropDefs } from '../base-tabs-list/base-tabs-list.props';
-export { tabsNavLinkPropDefs };

--- a/packages/frosted-ui/src/components/tabs-nav/tabs-nav.stories.tsx
+++ b/packages/frosted-ui/src/components/tabs-nav/tabs-nav.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { TabsNav, tabsNavPropDefs } from '..';
+import { Code, TabsNav, tabsNavPropDefs, Text } from '..';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
@@ -33,6 +33,29 @@ export const Default: Story = {
         <TabsNav.Link href="#">Documents</TabsNav.Link>
         <TabsNav.Link href="#">Settings</TabsNav.Link>
       </TabsNav.Root>
+    </div>
+  ),
+};
+
+export const RenderProp: Story = {
+  name: 'Render Prop (Client-Side Routing)',
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 600 }}>
+      <Text>
+        Use the <Code>render</Code> prop to integrate with your framework&apos;s router for client-side navigation. This
+        is useful for frameworks like Next.js, React Router, or Remix.
+      </Text>
+      <TabsNav.Root {...args}>
+        <TabsNav.Link active render={<a href="/account" />}>
+          Account
+        </TabsNav.Link>
+        <TabsNav.Link render={<a href="/documents" />}>Documents</TabsNav.Link>
+        <TabsNav.Link render={<a href="/settings" />}>Settings</TabsNav.Link>
+      </TabsNav.Root>
+      <Text size="1" color="gray">
+        In a real app, replace <Code>{'<a />'}</Code> with your router&apos;s Link component, e.g.{' '}
+        <Code>{'<NextLink href="/account" />'}</Code> for Next.js.
+      </Text>
     </div>
   ),
 };

--- a/packages/frosted-ui/src/components/tabs-nav/tabs-nav.tsx
+++ b/packages/frosted-ui/src/components/tabs-nav/tabs-nav.tsx
@@ -1,24 +1,21 @@
 'use client';
 
+import { NavigationMenu } from '@base-ui/react/navigation-menu';
 import classNames from 'classnames';
-import { NavigationMenu } from 'radix-ui';
 import * as React from 'react';
-import { GetPropDefTypes, getSubtree } from '../../helpers';
-import { tabsNavLinkPropDefs, tabsNavPropDefs } from './tabs-nav.props';
+import { GetPropDefTypes } from '../../helpers';
+import { tabsNavPropDefs } from './tabs-nav.props';
 
 type TabsNavOwnProps = GetPropDefTypes<typeof tabsNavPropDefs>;
-interface TabsNavRootProps
-  extends Omit<
-      React.ComponentProps<typeof NavigationMenu.Root>,
-      'asChild' | 'orientation' | 'defauValue' | 'value' | 'onValueChange' | 'delayDuration' | 'skipDelayDuration'
-    >,
-    TabsNavOwnProps {}
+type TabsNavRootProps = Omit<React.ComponentProps<typeof NavigationMenu.Root>, 'className' | 'render' | 'orientation'> &
+  React.ComponentProps<'nav'> &
+  TabsNavOwnProps;
 
 const TabsNavRoot = (props: TabsNavRootProps) => {
   const { children, className, size = tabsNavPropDefs.size.default, ...rootProps } = props;
 
   return (
-    <NavigationMenu.Root className="fui-TabsNavRoot" {...rootProps} asChild={false} orientation="horizontal">
+    <NavigationMenu.Root className="fui-TabsNavRoot" {...rootProps}>
       <NavigationMenu.List
         className={classNames('fui-reset', 'fui-BaseTabsList', 'fui-TabsNavList', className, `fui-r-size-${size}`)}
       >
@@ -29,29 +26,28 @@ const TabsNavRoot = (props: TabsNavRootProps) => {
 };
 TabsNavRoot.displayName = 'TabsNavRoot';
 
-type TabsNavLinkOwnProps = GetPropDefTypes<typeof tabsNavLinkPropDefs>;
-interface TabsNavLinkProps
-  extends Omit<React.ComponentProps<typeof NavigationMenu.Link>, 'onSelect'>,
-    TabsNavLinkOwnProps {}
+interface TabsNavLinkOwnProps {
+  /** Render the link as a custom element */
+  render?: React.ReactElement;
+  /** Additional CSS class name */
+  className?: string;
+}
+type TabsNavLinkProps = Omit<React.ComponentProps<typeof NavigationMenu.Link>, 'className' | 'render'> &
+  Omit<React.ComponentProps<'a'>, 'className'> &
+  TabsNavLinkOwnProps;
 
 const TabsNavLink = (props: TabsNavLinkProps) => {
-  const { asChild, children, className, ...linkProps } = props;
+  const { render, children, className, ...linkProps } = props;
 
   return (
     <NavigationMenu.Item className="fui-TabsNavItem">
       <NavigationMenu.Link
         {...linkProps}
+        render={render}
         className={classNames('fui-reset', 'fui-BaseTabsTrigger', 'fui-TabsNavLink', className)}
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        onSelect={() => {}}
-        asChild={asChild}
       >
-        {getSubtree({ asChild, children }, (children) => (
-          <>
-            <span className="fui-BaseTabsTriggerInner fui-TabsNavLinkInner">{children}</span>
-            <span className="fui-BaseTabsTriggerInnerHidden fui-TabsNavLinkInnerHidden">{children}</span>
-          </>
-        ))}
+        <span className="fui-BaseTabsTriggerInner fui-TabsNavLinkInner">{children}</span>
+        <span className="fui-BaseTabsTriggerInnerHidden fui-TabsNavLinkInnerHidden">{children}</span>
       </NavigationMenu.Link>
     </NavigationMenu.Item>
   );

--- a/packages/frosted-ui/src/components/tabs/tabs.stories.tsx
+++ b/packages/frosted-ui/src/components/tabs/tabs.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { Tabs, Text, tabsListPropDefs } from '..';
+import { Code, Tabs, Text, TextArea, TextField, tabsListPropDefs } from '..';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
@@ -35,20 +35,171 @@ export const Default: Story = {
           <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
         </Tabs.List>
 
-        <div style={{ padding: '12px 16px 8px 16px' }}>
-          <Tabs.Content value="account">
-            <Text size="2">Make changes to your account.</Text>
-          </Tabs.Content>
+        <Tabs.Content value="account" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Make changes to your account.</Text>
+        </Tabs.Content>
 
-          <Tabs.Content value="documents">
-            <Text size="2">Access and update your documents.</Text>
-          </Tabs.Content>
+        <Tabs.Content value="documents" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Access and update your documents.</Text>
+        </Tabs.Content>
 
-          <Tabs.Content value="settings">
-            <Text size="2">Edit your profile or update contact information.</Text>
-          </Tabs.Content>
-        </div>
+        <Tabs.Content value="settings" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Edit your profile or update contact information.</Text>
+        </Tabs.Content>
       </Tabs.Root>
     </div>
   ),
+};
+
+export const ActivateOnFocus: Story = {
+  name: 'Activate on Focus',
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', maxWidth: 600 }}>
+      <Text>
+        The <Code>activateOnFocus</Code> prop controls whether tabs are activated immediately when focused via keyboard
+        navigation, or only when explicitly clicked/pressed. Try using <Code>Tab</Code> to focus the tabs, then{' '}
+        <Code>Arrow</Code> keys to navigate.
+      </Text>
+
+      <div>
+        <Text size="2" weight="medium" style={{ marginBottom: 'var(--space-2)', display: 'block' }}>
+          activateOnFocus={'{true}'}
+        </Text>
+        <Tabs.Root defaultValue="tab1">
+          <Tabs.List {...args} activateOnFocus>
+            <Tabs.Trigger value="tab1">Overview</Tabs.Trigger>
+            <Tabs.Trigger value="tab2">Analytics</Tabs.Trigger>
+            <Tabs.Trigger value="tab3">Reports</Tabs.Trigger>
+          </Tabs.List>
+          <div style={{ padding: '12px 16px 8px 16px' }}>
+            <Tabs.Content value="tab1">
+              <Text size="2">Overview content — Tab activates immediately on arrow key navigation.</Text>
+            </Tabs.Content>
+            <Tabs.Content value="tab2">
+              <Text size="2">Analytics content — Tab activates immediately on arrow key navigation.</Text>
+            </Tabs.Content>
+            <Tabs.Content value="tab3">
+              <Text size="2">Reports content — Tab activates immediately on arrow key navigation.</Text>
+            </Tabs.Content>
+          </div>
+        </Tabs.Root>
+      </div>
+
+      <div>
+        <Text size="2" weight="medium" style={{ marginBottom: 'var(--space-2)', display: 'block' }}>
+          activateOnFocus={'{false}'} (default)
+        </Text>
+        <Tabs.Root defaultValue="tab1">
+          <Tabs.List {...args} activateOnFocus={false}>
+            <Tabs.Trigger value="tab1">Overview</Tabs.Trigger>
+            <Tabs.Trigger value="tab2">Analytics</Tabs.Trigger>
+            <Tabs.Trigger value="tab3">Reports</Tabs.Trigger>
+          </Tabs.List>
+          <div style={{ padding: '12px 16px 8px 16px' }}>
+            <Tabs.Content value="tab1">
+              <Text size="2">Overview content — Must press Enter/Space to activate after focusing.</Text>
+            </Tabs.Content>
+            <Tabs.Content value="tab2">
+              <Text size="2">Analytics content — Must press Enter/Space to activate after focusing.</Text>
+            </Tabs.Content>
+            <Tabs.Content value="tab3">
+              <Text size="2">Reports content — Must press Enter/Space to activate after focusing.</Text>
+            </Tabs.Content>
+          </div>
+        </Tabs.Root>
+      </div>
+
+      <Text size="1" color="gray">
+        Use <Code>activateOnFocus={'{true}'}</Code> for a more fluid experience. The default (<Code>false</Code>)
+        follows WAI-ARIA best practices, requiring explicit activation which is better for accessibility.
+      </Text>
+    </div>
+  ),
+};
+
+export const KeepMounted: Story = {
+  name: 'Keep Mounted',
+  render: (args) => {
+    const [name, setName] = React.useState('');
+    const [email, setEmail] = React.useState('');
+    const [bio, setBio] = React.useState('');
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 500 }}>
+        <Text>
+          The <Code>keepMounted</Code> prop on <Code>Tabs.Content</Code> keeps tab panels in the DOM even when hidden.
+          This preserves component state like form inputs, scroll position, and avoids re-mounting expensive components.
+        </Text>
+
+        <Text size="2" weight="medium">
+          With keepMounted={'{true}'} — Form state is preserved
+        </Text>
+        <Tabs.Root defaultValue="profile">
+          <Tabs.List {...args}>
+            <Tabs.Trigger value="profile">Profile</Tabs.Trigger>
+            <Tabs.Trigger value="contact">Contact</Tabs.Trigger>
+            <Tabs.Trigger value="about">About</Tabs.Trigger>
+          </Tabs.List>
+          <div
+            style={{
+              padding: '16px',
+              background: 'var(--gray-2)',
+              borderRadius: '0 0 var(--radius-2) var(--radius-2)',
+            }}
+          >
+            <Tabs.Content value="profile" keepMounted>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+                <Text as="label" size="2">
+                  Name
+                </Text>
+                <TextField.Input
+                  size="3"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Enter your name"
+                />
+                <Text size="1" color="gray">
+                  Type something, switch tabs, then come back — your input is preserved!
+                </Text>
+              </div>
+            </Tabs.Content>
+            <Tabs.Content value="contact" keepMounted>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+                <Text as="label" size="2">
+                  Email
+                </Text>
+                <TextField.Input
+                  size="3"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="Enter your email"
+                />
+              </div>
+            </Tabs.Content>
+            <Tabs.Content value="about" keepMounted>
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+                <Text as="label" size="2">
+                  Bio
+                </Text>
+                <TextArea
+                  size="3"
+                  value={bio}
+                  onChange={(e) => setBio(e.target.value)}
+                  placeholder="Tell us about yourself"
+                  rows={3}
+                />
+              </div>
+            </Tabs.Content>
+          </div>
+        </Tabs.Root>
+
+        <Text size="1" color="gray">
+          Use <Code>keepMounted</Code> on <Code>Tabs.Content</Code> for multi-step forms, preserving video/audio
+          playback state, or panels with expensive initialization. Without it, panels unmount when hidden and lose their
+          state.
+        </Text>
+      </div>
+    );
+  },
 };

--- a/packages/frosted-ui/src/components/tabs/tabs.tsx
+++ b/packages/frosted-ui/src/components/tabs/tabs.tsx
@@ -1,14 +1,15 @@
 'use client';
 
+import { Tabs as TabsPrimitive } from '@base-ui/react/tabs';
 import classNames from 'classnames';
-import { Tabs as TabsPrimitive } from 'radix-ui';
 import * as React from 'react';
 
 import { tabsListPropDefs } from './tabs.props';
 
-import type { GetPropDefTypes } from '../../helpers';
+import type { GetPropDefTypes, PropsWithoutColor } from '../../helpers';
 
-interface TabsRootProps extends React.ComponentProps<typeof TabsPrimitive.Root> {}
+type TabsRootProps = Omit<PropsWithoutColor<typeof TabsPrimitive.Root>, 'className' | 'render' | 'orientation'> &
+  Omit<React.HTMLAttributes<HTMLDivElement>, 'defaultValue'>;
 
 const TabsRoot = (props: TabsRootProps) => {
   const { className, ...rootProps } = props;
@@ -17,7 +18,9 @@ const TabsRoot = (props: TabsRootProps) => {
 TabsRoot.displayName = 'TabsRoot';
 
 type TabsListOwnProps = GetPropDefTypes<typeof tabsListPropDefs>;
-interface TabsListProps extends React.ComponentProps<typeof TabsPrimitive.List>, TabsListOwnProps {}
+type TabsListProps = Omit<PropsWithoutColor<typeof TabsPrimitive.List>, 'className' | 'render'> &
+  React.HTMLAttributes<HTMLDivElement> &
+  TabsListOwnProps;
 
 const TabsList = (props: TabsListProps) => {
   const { className, size = tabsListPropDefs.size.default, ...listProps } = props;
@@ -30,26 +33,28 @@ const TabsList = (props: TabsListProps) => {
 };
 TabsList.displayName = 'TabsList';
 
-interface TabsTriggerProps extends React.ComponentProps<typeof TabsPrimitive.Trigger> {}
+type TabsTriggerProps = Omit<PropsWithoutColor<typeof TabsPrimitive.Tab>, 'className' | 'render'> &
+  React.HTMLAttributes<HTMLButtonElement>;
 
 const TabsTrigger = (props: TabsTriggerProps) => {
   const { className, children, ...triggerProps } = props;
   return (
-    <TabsPrimitive.Trigger
+    <TabsPrimitive.Tab
       {...triggerProps}
       className={classNames('fui-reset', 'fui-BaseTabsTrigger', 'fui-TabsTrigger', className)}
     >
       <span className="fui-BaseTabsTriggerInner fui-TabsTriggerInner">{children}</span>
       <span className="fui-BaseTabsTriggerInnerHidden fui-TabsTriggerInnerHidden">{children}</span>
-    </TabsPrimitive.Trigger>
+    </TabsPrimitive.Tab>
   );
 };
 TabsTrigger.displayName = 'TabsTrigger';
 
-interface TabsContentProps extends React.ComponentProps<typeof TabsPrimitive.Content> {}
+type TabsContentProps = Omit<PropsWithoutColor<typeof TabsPrimitive.Panel>, 'className' | 'render'> &
+  React.HTMLAttributes<HTMLDivElement>;
 
 const TabsContent = (props: TabsContentProps) => (
-  <TabsPrimitive.Content {...props} className={classNames('fui-TabsContent', props.className)} />
+  <TabsPrimitive.Panel {...props} className={classNames('fui-TabsContent', props.className)} />
 );
 TabsContent.displayName = 'TabsContent';
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^4.0.14
         version: 4.0.14
       typescript:
-        specifier: ^4.5.3
-        version: 4.9.5
+        specifier: ^5.6.3
+        version: 5.9.3
 
   packages/eslint-config-custom:
     dependencies:
@@ -14395,9 +14395,7 @@ snapshots:
       metro-runtime: 0.83.3
     transitivePeerDependencies:
       - '@babel/core'
-      - bufferutil
       - supports-color
-      - utf-8-validate
     optional: true
 
   '@react-native/normalize-colors@0.74.89': {}


### PR DESCRIPTION
## Migrate Tabs, SegmentedControl, TabsNav, and SegmentedControlNav to Base UI

### Components Migrated
- **Tabs** → `@base-ui/react/tabs`
- **SegmentedControl** → `@base-ui/react/tabs`
- **TabsNav** → `@base-ui/react/navigation-menu`
- **SegmentedControlNav** → `@base-ui/react/navigation-menu`

### Breaking Changes

#### API Changes
- `asChild` prop replaced with `render` prop for custom element rendering
  
  ```- <TabsNav.Link asChild><a href="/foo">Link</a></TabsNav.Link>```
  ```+ <TabsNav.Link render={<a href="/foo" />}>Link</TabsNav.Link>```
  - `orientation` prop removed from `Tabs.Root` and `SegmentedControl.Root`

#### CSS Data Attributes
- `data-state="active"` → `data-selected` / `data-active`
- `data-state="inactive"` → `:not([data-selected])`

### New Features
- **`activateOnFocus`** prop on `Tabs.List` / `SegmentedControl.List` — activates tabs immediately on keyboard focus
- **`keepMounted`** prop on `Tabs.Content` / `SegmentedControl.Content` — preserves panel state when switching tabs
- **`render`** prop on `TabsNav.Link` / `SegmentedControlNav.Link` — for client-side routing integration

### Stories Added
- Activate on Focus demo
- Keep Mounted demo (form state preservation)
- Render Prop demo (client-side routing)