### PR TITLE
fix(segmented control radio group): wrong value types

### DIFF
--- a/packages/frosted-ui/src/components/segmented-control-radio-group/segmented-control-radio-group.stories.tsx
+++ b/packages/frosted-ui/src/components/segmented-control-radio-group/segmented-control-radio-group.stories.tsx
@@ -89,3 +89,71 @@ export const InputRef: Story = {
     );
   },
 };
+
+export const Controlled: Story = {
+  name: 'Controlled',
+  render: () => {
+    const [theme, setTheme] = React.useState('system');
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 400 }}>
+        <Text>
+          Use <Code>value</Code> and <Code>onValueChange</Code> for controlled state.
+        </Text>
+
+        <SegmentedControlRadioGroup.Root value={theme} onValueChange={setTheme}>
+          <SegmentedControlRadioGroup.Item value="system">
+            <Monitor20 />
+          </SegmentedControlRadioGroup.Item>
+          <SegmentedControlRadioGroup.Item value="light">
+            <Sun20 />
+          </SegmentedControlRadioGroup.Item>
+          <SegmentedControlRadioGroup.Item value="dark">
+            <Moon20 />
+          </SegmentedControlRadioGroup.Item>
+        </SegmentedControlRadioGroup.Root>
+
+        <Text size="2">
+          Selected: <Code>{theme}</Code>
+        </Text>
+      </div>
+    );
+  },
+};
+
+export const TypeSafeValues: Story = {
+  name: 'Type-Safe Values',
+  render: () => {
+    type Theme = 'system' | 'light' | 'dark';
+    const [theme, setTheme] = React.useState<Theme>('system');
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 400 }}>
+        <Text>
+          Pass a string union type to get autocomplete and catch typos at compile time. The generic defaults to{' '}
+          <Code>string</Code> if not specified.
+        </Text>
+
+        <SegmentedControlRadioGroup.Root<Theme> value={theme} onValueChange={setTheme}>
+          <SegmentedControlRadioGroup.Item value="system">
+            <Monitor20 />
+          </SegmentedControlRadioGroup.Item>
+          <SegmentedControlRadioGroup.Item value="light">
+            <Sun20 />
+          </SegmentedControlRadioGroup.Item>
+          <SegmentedControlRadioGroup.Item value="dark">
+            <Moon20 />
+          </SegmentedControlRadioGroup.Item>
+        </SegmentedControlRadioGroup.Root>
+
+        <Text size="2">
+          Selected: <Code>{theme}</Code>
+        </Text>
+
+        <Text size="1" color="gray">
+          Try changing a value to <Code>&quot;sytsem&quot;</Code> — TypeScript will catch the typo!
+        </Text>
+      </div>
+    );
+  },
+};

--- a/packages/frosted-ui/src/components/segmented-control-radio-group/segmented-control-radio-group.tsx
+++ b/packages/frosted-ui/src/components/segmented-control-radio-group/segmented-control-radio-group.tsx
@@ -5,26 +5,42 @@ import { RadioGroup } from '@base-ui/react/radio-group';
 import classNames from 'classnames';
 import * as React from 'react';
 
-type SegmentedControlRadioGroupRootProps = Omit<React.ComponentProps<typeof RadioGroup>, 'className' | 'render'> &
-  React.ComponentProps<'div'>;
+type SegmentedControlRadioGroupRootProps<T extends string = string> = Omit<
+  React.ComponentProps<typeof RadioGroup>,
+  'className' | 'render' | 'value' | 'defaultValue' | 'onValueChange'
+> &
+  React.ComponentProps<'div'> & {
+    /** The controlled value of the selected radio item */
+    value?: T;
+    /** The default value of the selected radio item (uncontrolled) */
+    defaultValue?: T;
+    /** Callback fired when the value changes */
+    onValueChange?: (value: T, eventDetails: RadioGroup.ChangeEventDetails) => void;
+  };
 
-const SegmentedControlRadioGroupRoot = (props: SegmentedControlRadioGroupRootProps) => {
+function SegmentedControlRadioGroupRoot<T extends string = string>(props: SegmentedControlRadioGroupRootProps<T>) {
   const { className, children, ...rootProps } = props;
   return (
-    <RadioGroup {...rootProps} className={classNames('fui-SegmentedControlRadioGroupRoot', className)}>
+    <RadioGroup
+      {...(rootProps as React.ComponentProps<typeof RadioGroup>)}
+      className={classNames('fui-SegmentedControlRadioGroupRoot', className)}
+    >
       <div className="fui-BaseSegmentedControlList">{children}</div>
     </RadioGroup>
   );
-};
+}
 SegmentedControlRadioGroupRoot.displayName = 'SegmentedControlRadioGroupRoot';
 
-type SegmentedControlRadioGroupItemProps = Omit<
+type SegmentedControlRadioGroupItemProps<T extends string = string> = Omit<
   React.ComponentProps<typeof Radio.Root>,
-  'className' | 'render' | 'nativeButton'
+  'className' | 'render' | 'nativeButton' | 'value'
 > &
-  React.ComponentProps<'span'>;
+  React.ComponentProps<'span'> & {
+    /** The unique string value of this radio item */
+    value: T;
+  };
 
-const SegmentedControlRadioGroupItem = (props: SegmentedControlRadioGroupItemProps) => {
+function SegmentedControlRadioGroupItem<T extends string = string>(props: SegmentedControlRadioGroupItemProps<T>) {
   const { children, className, style, ...itemProps } = props;
 
   return (
@@ -36,7 +52,7 @@ const SegmentedControlRadioGroupItem = (props: SegmentedControlRadioGroupItemPro
       <span className="fui-BaseSegmentedControlTriggerInner">{children}</span>
     </Radio.Root>
   );
-};
+}
 SegmentedControlRadioGroupItem.displayName = 'SegmentedControlRadioGroupItem';
 
 export { SegmentedControlRadioGroupItem as Item, SegmentedControlRadioGroupRoot as Root };


### PR DESCRIPTION
Forcing `value` and `default` value to be of type string with an option to use generic type (string union) on the `<Root />`