### PR TITLE
Base UI popover

### DIFF
--- a/packages/frosted-ui/src/components/base-button/base-button.css
+++ b/packages/frosted-ui/src/components/base-button/base-button.css
@@ -103,6 +103,8 @@
       }
     }
   }
+  &:where([data-popup-open]),
+  &:where([data-pressed]),
   &:where([data-state='open']) {
     &::after {
       background-color: var(--accent-10);
@@ -163,6 +165,8 @@
       background-color: var(--accent-10);
     }
   }
+  &:where([data-popup-open]),
+  &:where([data-pressed]),
   &:where([data-state='open']) {
     background-color: var(--accent-10);
   }
@@ -185,6 +189,8 @@
         filter: var(--base-button-solid-high-contrast-hover-filter);
       }
     }
+    &:where([data-popup-open]),
+    &:where([data-pressed]),
     &:where([data-state='open']) {
       background-color: var(--accent-12);
       filter: var(--base-button-solid-high-contrast-hover-filter);
@@ -230,6 +236,8 @@
       background-color: var(--accent-a4);
     }
   }
+  &:where([data-popup-open]),
+  &:where([data-pressed]),
   &:where([data-state='open']) {
     background-color: var(--accent-a4);
   }
@@ -253,6 +261,8 @@
     outline: 2px solid var(--color-focus-root);
     outline-offset: -1px;
   }
+  &:where([data-popup-open]),
+  &:where([data-pressed]),
   &:where([data-state='open']) {
     background-color: var(--accent-a3);
   }
@@ -286,6 +296,8 @@
         0px 1px 2px 0px rgba(0, 0, 0, 0.05);
     }
   }
+  &:where([data-popup-open]),
+  &:where([data-pressed]),
   &:where([data-state='open']),
   &:where(:active) {
     background-color: var(--gray-3);

--- a/packages/frosted-ui/src/components/date-picker/date-picker.stories.tsx
+++ b/packages/frosted-ui/src/components/date-picker/date-picker.stories.tsx
@@ -65,7 +65,7 @@ export const Custom: Story = {
               <CalendarIcon /> {date.toString()}
             </Button>
           </Popover.Trigger>
-          <Popover.Content variant="translucent" align="center" style={{ width: 'unset' }}>
+          <Popover.Content variant="translucent" alignment="center" style={{ width: 'unset' }}>
             <Calendar
               minValue={parseDate('2020-01-03')}
               defaultValue={date}

--- a/packages/frosted-ui/src/components/date-picker/date-picker.tsx
+++ b/packages/frosted-ui/src/components/date-picker/date-picker.tsx
@@ -66,7 +66,7 @@ export function DatePicker<T extends DateValue>(props: DatePickerProps<T>) {
             <CalendarIcon size={size} />
           </IconButton>
         </Popover.Trigger>
-        <Popover.Content variant="translucent" align="center">
+        <Popover.Content variant="translucent" alignment="center">
           <Calendar {...calendarProps} />
         </Popover.Content>
       </Popover.Root>

--- a/packages/frosted-ui/src/components/date-range-picker/date-range-picker.stories.tsx
+++ b/packages/frosted-ui/src/components/date-range-picker/date-range-picker.stories.tsx
@@ -106,7 +106,7 @@ export const Custom: Story = {
                 : '--'}
             </Button>
           </Popover.Trigger>
-          <Popover.Content variant="translucent" align="center" style={{ minWidth: 'unset' }}>
+          <Popover.Content variant="translucent" alignment="center" style={{ minWidth: 'unset' }}>
             <div style={{ display: 'flex', flexDirection: 'column', justifyContent: 'center' }}>
               <div
                 style={{

--- a/packages/frosted-ui/src/components/date-range-picker/date-range-picker.tsx
+++ b/packages/frosted-ui/src/components/date-range-picker/date-range-picker.tsx
@@ -86,7 +86,7 @@ export function DateRangePicker<T extends DateValue>(props: DateRangePickerProps
             <CalendarIcon size={size} />
           </IconButton>
         </Popover.Trigger>
-        <Popover.Content variant="translucent" align="center">
+        <Popover.Content variant="translucent" alignment="center">
           <RangeCalendar {...calendarProps} />
         </Popover.Content>
       </Popover.Root>

--- a/packages/frosted-ui/src/components/hover-card/hover-card.css
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.css
@@ -1,6 +1,7 @@
 .fui-HoverCardContent {
   background-color: var(--color-panel-solid);
-  box-shadow: var(--shadow-4);
+  box-shadow: var(--shadow-5);
+  outline: 0;
   overflow: auto;
 
   --inset-padding: var(--hover-card-content-padding);
@@ -9,7 +10,9 @@
   transform-origin: var(--transform-origin);
 
   /* Animations */
-  transition: transform 150ms ease-out, opacity 150ms ease-out;
+  transition:
+    transform 150ms ease-out,
+    opacity 150ms ease-out;
 
   &[data-starting-style],
   &[data-ending-style] {
@@ -25,10 +28,12 @@
     background-color: var(--color-panel-translucent);
     -webkit-backdrop-filter: var(--backdrop-filter-panel);
     backdrop-filter: var(--backdrop-filter-panel);
-    outline: 0.5px solid var(--color-popover-outline);
   }
   &:where(.fui-variant-solid) {
     background-color: var(--color-panel-solid);
+  }
+  &:where(.fui-variant-translucent, .fui-variant-solid) {
+    outline: 0.5px solid var(--color-popover-outline);
   }
 }
 /* prettier-ignore */

--- a/packages/frosted-ui/src/components/hover-card/hover-card.css
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.css
@@ -3,6 +3,7 @@
   box-shadow: var(--shadow-5);
   outline: 0;
   overflow: auto;
+  text-align: start;
 
   --inset-padding: var(--hover-card-content-padding);
   padding: var(--hover-card-content-padding);

--- a/packages/frosted-ui/src/components/hover-card/hover-card.css
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.css
@@ -6,7 +6,20 @@
   --inset-padding: var(--hover-card-content-padding);
   padding: var(--hover-card-content-padding);
 
-  transform-origin: var(--radix-hover-card-content-transform-origin);
+  transform-origin: var(--transform-origin);
+
+  /* Animations */
+  transition: transform 150ms ease-out, opacity 150ms ease-out;
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+
+  &[data-ending-style] {
+    transition-duration: 75ms;
+  }
 
   &:where(.fui-variant-translucent) {
     background-color: var(--color-panel-translucent);

--- a/packages/frosted-ui/src/components/hover-card/hover-card.stories.tsx
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.stories.tsx
@@ -1,7 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Avatar, Heading, HoverCard, Inset, Link, Strong, Text, hoverCardContentPropDefs } from '..';
+import {
+  Avatar,
+  Button,
+  Code,
+  DataList,
+  Heading,
+  HoverCard,
+  Inset,
+  Link,
+  Strong,
+  Text,
+  hoverCardContentPropDefs,
+} from '..';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
@@ -47,7 +59,7 @@ export const Default: Story = {
               </Text>
 
               <Text as="div" size="2" style={{ maxWidth: 300, marginTop: 'var(--space-3)' }}>
-                React components library built on top of Radix Themes.
+                React components library built on top of Base UI primitives.
               </Text>
             </div>
           </div>
@@ -143,5 +155,678 @@ export const InsetContent: Story = {
       </HoverCard.Root>{' '}
       in the latter twentieth century.
     </Text>
+  ),
+};
+
+export const Delays: Story = {
+  name: 'Custom Delays',
+  args: {
+    size: hoverCardContentPropDefs.size.default,
+    variant: hoverCardContentPropDefs.variant.default,
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 500 }}>
+      <Text>
+        The <Code>delay</Code> and <Code>closeDelay</Code> props on <Code>HoverCard.Trigger</Code> control how long to
+        wait before opening/closing the hover card. This is useful for preventing accidental triggers.
+      </Text>
+
+      <div style={{ display: 'flex', gap: 'var(--space-4)' }}>
+        <HoverCard.Root>
+          <HoverCard.Trigger delay={0} closeDelay={0}>
+            <Link href="#">Instant (0ms)</Link>
+          </HoverCard.Trigger>
+          <HoverCard.Content {...args}>
+            <Text size="2">Opens and closes instantly with no delay.</Text>
+          </HoverCard.Content>
+        </HoverCard.Root>
+
+        <HoverCard.Root>
+          <HoverCard.Trigger delay={200} closeDelay={150}>
+            <Link href="#">Default (200/150ms)</Link>
+          </HoverCard.Trigger>
+          <HoverCard.Content {...args}>
+            <Text size="2">Uses the default delays: 200ms open, 150ms close.</Text>
+          </HoverCard.Content>
+        </HoverCard.Root>
+
+        <HoverCard.Root>
+          <HoverCard.Trigger delay={600} closeDelay={300}>
+            <Link href="#">Slow (600/300ms)</Link>
+          </HoverCard.Trigger>
+          <HoverCard.Content {...args}>
+            <Text size="2">Slower delays for more deliberate interactions.</Text>
+          </HoverCard.Content>
+        </HoverCard.Root>
+      </div>
+    </div>
+  ),
+};
+
+export const Controlled: Story = {
+  name: 'Controlled Mode',
+  args: {
+    size: hoverCardContentPropDefs.size.default,
+    variant: hoverCardContentPropDefs.variant.default,
+  },
+  render: function ControlledDemo(args) {
+    const [open, setOpen] = React.useState(false);
+    const [hoverCount, setHoverCount] = React.useState(0);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 500 }}>
+        <Text>
+          Use <Code>open</Code> and <Code>onOpenChange</Code> props on <Code>HoverCard.Root</Code> for controlled mode.
+        </Text>
+
+        <DataList.Root>
+          <DataList.Item>
+            <DataList.Label>Open state</DataList.Label>
+            <DataList.Value>
+              <Code>{String(open)}</Code>
+            </DataList.Value>
+          </DataList.Item>
+          <DataList.Item>
+            <DataList.Label>Hover count</DataList.Label>
+            <DataList.Value>
+              <Code>{hoverCount}</Code>
+            </DataList.Value>
+          </DataList.Item>
+        </DataList.Root>
+
+        <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
+          <Button variant="soft" size="1" onClick={() => setOpen(!open)}>
+            Toggle programmatically
+          </Button>
+          <Button variant="soft" size="1" color="gray" onClick={() => setHoverCount(0)}>
+            Reset count
+          </Button>
+        </div>
+
+        <Text>
+          Hover over{' '}
+          <HoverCard.Root
+            open={open}
+            onOpenChange={(newOpen) => {
+              setOpen(newOpen);
+              if (newOpen) setHoverCount((c) => c + 1);
+            }}
+          >
+            <HoverCard.Trigger>
+              <Link href="#">this link</Link>
+            </HoverCard.Trigger>
+            <HoverCard.Content {...args}>
+              <Text size="2">This is a controlled hover card. You've hovered {hoverCount} times.</Text>
+            </HoverCard.Content>
+          </HoverCard.Root>{' '}
+          to see the hover card.
+        </Text>
+      </div>
+    );
+  },
+};
+
+export const Positioning: Story = {
+  name: 'Positioning',
+  args: {
+    size: hoverCardContentPropDefs.size.default,
+    variant: hoverCardContentPropDefs.variant.default,
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 600 }}>
+      <Text>
+        Use <Code>side</Code> and <Code>alignment</Code> props to control positioning.
+      </Text>
+
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(3, 1fr)',
+          gap: 'var(--space-4)',
+          padding: 'var(--space-6)',
+        }}
+      >
+        {/* Top row */}
+        <div />
+        <div style={{ textAlign: 'center' }}>
+          <HoverCard.Root>
+            <HoverCard.Trigger>
+              <Link href="#">Top</Link>
+            </HoverCard.Trigger>
+            <HoverCard.Content {...args} side="top" alignment="center">
+              <Text size="2">Positioned on top, centered</Text>
+            </HoverCard.Content>
+          </HoverCard.Root>
+        </div>
+        <div />
+
+        {/* Middle row */}
+        <div style={{ textAlign: 'center' }}>
+          <HoverCard.Root>
+            <HoverCard.Trigger>
+              <Link href="#">Left</Link>
+            </HoverCard.Trigger>
+            <HoverCard.Content {...args} side="left" alignment="center">
+              <Text size="2">Positioned on left, centered</Text>
+            </HoverCard.Content>
+          </HoverCard.Root>
+        </div>
+        <div />
+        <div style={{ textAlign: 'center' }}>
+          <HoverCard.Root>
+            <HoverCard.Trigger>
+              <Link href="#">Right</Link>
+            </HoverCard.Trigger>
+            <HoverCard.Content {...args} side="right" alignment="center">
+              <Text size="2">Positioned on right, centered</Text>
+            </HoverCard.Content>
+          </HoverCard.Root>
+        </div>
+
+        {/* Bottom row */}
+        <div />
+        <div style={{ textAlign: 'center' }}>
+          <HoverCard.Root>
+            <HoverCard.Trigger>
+              <Link href="#">Bottom</Link>
+            </HoverCard.Trigger>
+            <HoverCard.Content {...args} side="bottom" alignment="center">
+              <Text size="2">Positioned on bottom, centered</Text>
+            </HoverCard.Content>
+          </HoverCard.Root>
+        </div>
+        <div />
+      </div>
+
+      <Text size="2" color="gray">
+        Alignment options: <Code>start</Code>, <Code>center</Code>, <Code>end</Code>
+      </Text>
+    </div>
+  ),
+};
+
+export const ProfileCard: Story = {
+  name: 'Profile Card (Real World)',
+  args: {
+    size: '2',
+    variant: 'translucent',
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 500 }}>
+      <Text>
+        A common use case is showing user profiles on hover. This provides quick context without navigating away.
+      </Text>
+
+      <Text>
+        The project was created by{' '}
+        <HoverCard.Root>
+          <HoverCard.Trigger>
+            <Link href="https://github.com/whopio">@whopio</Link>
+          </HoverCard.Trigger>
+          <HoverCard.Content {...args}>
+            <div style={{ display: 'flex', gap: 'var(--space-4)' }}>
+              <Avatar
+                size="4"
+                src="https://avatars.githubusercontent.com/u/91078276?s=200&v=4"
+                fallback="W"
+                shape="square"
+              />
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+                <Heading size="3" as="h3">
+                  Whop
+                </Heading>
+                <Text as="div" size="2" color="gray">
+                  @whopio
+                </Text>
+                <Text as="div" size="2" style={{ marginTop: 'var(--space-2)', maxWidth: 280 }}>
+                  Build, sell, and engage with software products. We make it easy for creators to launch and grow their
+                  digital businesses.
+                </Text>
+                <div style={{ display: 'flex', gap: 'var(--space-3)', marginTop: 'var(--space-2)' }}>
+                  <Text size="2" color="gray">
+                    <Strong>127</Strong> repos
+                  </Text>
+                  <Text size="2" color="gray">
+                    <Strong>42</Strong> members
+                  </Text>
+                </div>
+              </div>
+            </div>
+          </HoverCard.Content>
+        </HoverCard.Root>{' '}
+        and is open source.
+      </Text>
+    </div>
+  ),
+};
+
+export const LinkPreview: Story = {
+  name: 'Link Preview',
+  args: {
+    size: '2',
+    variant: 'translucent',
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 500 }}>
+      <Text>
+        HoverCard is perfect for showing link previews, giving users a glimpse of what they'll see before clicking.
+      </Text>
+
+      <Text>
+        The principles of good{' '}
+        <HoverCard.Root>
+          <HoverCard.Trigger>
+            <Link href="https://en.wikipedia.org/wiki/Typography" target="_blank">
+              typography
+            </Link>
+          </HoverCard.Trigger>
+          <HoverCard.Content {...args}>
+            <Inset side="top" pb="current">
+              <img
+                src="https://images.unsplash.com/photo-1619615391095-dfa29e1672ef?q=80&w=448&h=200&fit=crop"
+                alt="Typography example"
+                style={{
+                  display: 'block',
+                  width: '100%',
+                  height: 120,
+                  objectFit: 'cover',
+                  backgroundColor: 'var(--gray-5)',
+                }}
+              />
+            </Inset>
+            <div style={{ maxWidth: 300 }}>
+              <Text size="2" weight="medium" as="div">
+                Typography - Wikipedia
+              </Text>
+              <Text size="1" color="gray" as="div" style={{ marginTop: 'var(--space-1)' }}>
+                en.wikipedia.org
+              </Text>
+              <Text size="2" as="div" style={{ marginTop: 'var(--space-2)' }}>
+                Typography is the art and science of arranging type to make written language clear, visually appealing,
+                and effective in communication.
+              </Text>
+            </div>
+          </HoverCard.Content>
+        </HoverCard.Root>{' '}
+        remain into the digital age.
+      </Text>
+    </div>
+  ),
+};
+
+export const OpenChangeComplete: Story = {
+  name: 'Open Change Complete Callback',
+  args: {
+    size: hoverCardContentPropDefs.size.default,
+    variant: hoverCardContentPropDefs.variant.default,
+  },
+  render: function OpenChangeCompleteDemo(args) {
+    const [events, setEvents] = React.useState<string[]>([]);
+
+    const addEvent = (event: string) => {
+      const time = new Date().toLocaleTimeString('en-US', { hour12: false });
+      setEvents((prev) => [`${time} - ${event}`, ...prev].slice(0, 6));
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 500 }}>
+        <Text>
+          <Code>onOpenChange</Code> fires immediately, while <Code>onOpenChangeComplete</Code> fires after animations
+          complete. Useful for cleanup actions that should wait for exit animations.
+        </Text>
+
+        <Text>
+          Hover over{' '}
+          <HoverCard.Root
+            onOpenChange={(open) => addEvent(`onOpenChange: ${open}`)}
+            onOpenChangeComplete={(open) => addEvent(`onOpenChangeComplete: ${open}`)}
+          >
+            <HoverCard.Trigger>
+              <Link href="#">this link</Link>
+            </HoverCard.Trigger>
+            <HoverCard.Content {...args}>
+              <Text size="2">Watch the event log to see the timing difference.</Text>
+            </HoverCard.Content>
+          </HoverCard.Root>{' '}
+          to see the events.
+        </Text>
+
+        <div
+          style={{
+            padding: 'var(--space-3)',
+            backgroundColor: 'var(--gray-2)',
+            borderRadius: 'var(--radius-2)',
+            fontFamily: 'monospace',
+            fontSize: 'var(--font-size-1)',
+            minHeight: 100,
+          }}
+        >
+          <Text size="1" color="gray" weight="medium" style={{ display: 'block', marginBottom: 'var(--space-2)' }}>
+            Event Log:
+          </Text>
+          {events.length === 0 ? (
+            <Text size="1" color="gray">
+              Hover to generate events...
+            </Text>
+          ) : (
+            events.map((event, i) => (
+              <div key={i} style={{ color: 'var(--gray-11)' }}>
+                {event}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    );
+  },
+};
+
+export const Anchor: Story = {
+  name: 'Custom Anchor',
+  args: {
+    size: hoverCardContentPropDefs.size.default,
+    variant: hoverCardContentPropDefs.variant.default,
+  },
+  render: function AnchorDemo(args) {
+    const avatarRef = React.useRef<HTMLDivElement>(null);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 500 }}>
+        <Text>
+          Use the <Code>anchor</Code> prop on <Code>HoverCard.Content</Code> to position relative to a different
+          element.
+        </Text>
+
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-4)' }}>
+          <div style={{ display: 'flex' }} ref={avatarRef}>
+            <Avatar size="4" fallback="JD" shape="circle" color="lime" />
+          </div>
+
+          <HoverCard.Root>
+            <HoverCard.Trigger>
+              <Link href="#" color="lime">
+                John Doe
+              </Link>
+            </HoverCard.Trigger>
+            <HoverCard.Content {...args} anchor={avatarRef}>
+              <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
+                <div>
+                  <Text size="2" weight="medium" as="div">
+                    John Doe
+                  </Text>
+                  <Text size="2" color="gray" as="div">
+                    Software Engineer
+                  </Text>
+                  <Text size="2" as="div" style={{ marginTop: 'var(--space-2)', maxWidth: 200 }}>
+                    Building great user experiences with React and TypeScript.
+                  </Text>
+                </div>
+              </div>
+            </HoverCard.Content>
+          </HoverCard.Root>
+
+          <Text size="2" color="gray">
+            ← Hover the link, card appears near avatar
+          </Text>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const WithButton: Story = {
+  name: 'With Button Trigger',
+  args: {
+    size: hoverCardContentPropDefs.size.default,
+    variant: hoverCardContentPropDefs.variant.default,
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 500 }}>
+      <Text>
+        The trigger can be any element. Use the <Code>render</Code> pattern to wrap buttons or other interactive
+        elements.
+      </Text>
+
+      <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
+        <HoverCard.Root>
+          <HoverCard.Trigger>
+            <Button variant="soft">Hover me</Button>
+          </HoverCard.Trigger>
+          <HoverCard.Content {...args}>
+            <Text size="2">This hover card is triggered by a button instead of a link.</Text>
+          </HoverCard.Content>
+        </HoverCard.Root>
+
+        <HoverCard.Root>
+          <HoverCard.Trigger>
+            <Avatar fallback="AB" shape="circle" style={{ cursor: 'pointer' }} />
+          </HoverCard.Trigger>
+          <HoverCard.Content {...args}>
+            <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
+              <div>
+                <Text size="2" weight="medium" as="div">
+                  Alice Brown
+                </Text>
+                <Text size="2" color="gray" as="div">
+                  Product Designer
+                </Text>
+              </div>
+            </div>
+          </HoverCard.Content>
+        </HoverCard.Root>
+      </div>
+    </div>
+  ),
+};
+
+export const CollisionBoundary: Story = {
+  name: 'Collision Boundary',
+  args: {
+    size: hoverCardContentPropDefs.size.default,
+    variant: hoverCardContentPropDefs.variant.default,
+  },
+  render: function CollisionBoundaryDemo(args) {
+    const [boundary, setBoundary] = React.useState<HTMLDivElement | null>(null);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 600 }}>
+        <Text>
+          The <Code>collisionBoundary</Code> prop constrains the hover card to stay within a specific element instead of
+          the viewport.
+        </Text>
+
+        <div
+          ref={setBoundary}
+          style={{
+            border: '2px dashed var(--gray-6)',
+            borderRadius: 'var(--radius-3)',
+            padding: 'var(--space-6)',
+            height: 300,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            position: 'relative',
+          }}
+        >
+          <Text size="1" color="gray" style={{ position: 'absolute', top: 'var(--space-2)', left: 'var(--space-2)' }}>
+            Collision boundary
+          </Text>
+          <HoverCard.Root>
+            <HoverCard.Trigger>
+              <Link href="#">Hover me</Link>
+            </HoverCard.Trigger>
+            <HoverCard.Content {...args} collisionBoundary={boundary ?? undefined} side="bottom">
+              <Text size="2" style={{ maxWidth: 250 }}>
+                This hover card is constrained to stay within the dashed boundary, not the viewport.
+              </Text>
+            </HoverCard.Content>
+          </HoverCard.Root>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const CollisionAvoidance: Story = {
+  name: 'Collision Avoidance',
+  args: {
+    size: hoverCardContentPropDefs.size.default,
+    variant: hoverCardContentPropDefs.variant.default,
+  },
+  render: function CollisionAvoidanceDemo(args) {
+    const [boundary, setBoundary] = React.useState<HTMLDivElement | null>(null);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 600 }}>
+        <Text>
+          The <Code>collisionAvoidance</Code> prop controls how the hover card avoids collisions. It accepts an object
+          with <Code>side</Code> and <Code>align</Code> properties.
+        </Text>
+        <ul style={{ margin: 0, paddingLeft: 'var(--space-4)' }}>
+          <li>
+            <Text size="2">
+              <Code>side: 'flip'</Code> (default) - Flips to opposite side if not enough space
+            </Text>
+          </li>
+          <li>
+            <Text size="2">
+              <Code>side: 'none'</Code> - No side collision avoidance
+            </Text>
+          </li>
+          <li>
+            <Text size="2">
+              <Code>align: 'flip' | 'shift' | 'none'</Code> - Controls alignment axis behavior
+            </Text>
+          </li>
+        </ul>
+
+        <div
+          ref={setBoundary}
+          style={{
+            height: 400,
+            overflow: 'auto',
+            border: '1px solid var(--gray-6)',
+            borderRadius: 'var(--radius-2)',
+            position: 'relative',
+          }}
+        >
+          <div style={{ height: 400 }} />
+          <div style={{ display: 'flex', gap: 'var(--space-6)', justifyContent: 'center', padding: 'var(--space-4)' }}>
+            <HoverCard.Root>
+              <HoverCard.Trigger>
+                <Link href="#">flip (default)</Link>
+              </HoverCard.Trigger>
+              <HoverCard.Content
+                {...args}
+                side="top"
+                collisionAvoidance={{ side: 'flip' }}
+                collisionBoundary={boundary ?? undefined}
+              >
+                <Text size="2" style={{ maxWidth: 200 }}>
+                  This will flip to bottom if there's not enough space on top.
+                </Text>
+              </HoverCard.Content>
+            </HoverCard.Root>
+
+            <HoverCard.Root>
+              <HoverCard.Trigger>
+                <Link href="#">align: shift</Link>
+              </HoverCard.Trigger>
+              <HoverCard.Content
+                {...args}
+                side="top"
+                collisionAvoidance={{ side: 'flip', align: 'shift' }}
+                collisionBoundary={boundary ?? undefined}
+              >
+                <Text size="2" style={{ maxWidth: 200 }}>
+                  Flips side, shifts alignment to stay in view.
+                </Text>
+              </HoverCard.Content>
+            </HoverCard.Root>
+
+            <HoverCard.Root>
+              <HoverCard.Trigger>
+                <Link href="#">none</Link>
+              </HoverCard.Trigger>
+              <HoverCard.Content
+                {...args}
+                side="top"
+                collisionAvoidance={{ side: 'none', align: 'none' }}
+                collisionBoundary={boundary ?? undefined}
+              >
+                <Text size="2" style={{ maxWidth: 200 }}>
+                  This won't avoid collisions at all.
+                </Text>
+              </HoverCard.Content>
+            </HoverCard.Root>
+          </div>
+          <div style={{ height: 400 }} />
+        </div>
+
+        <Text size="2" color="gray">
+          Scroll the box above so triggers are near the top edge to see flip vs none behavior.
+        </Text>
+      </div>
+    );
+  },
+};
+
+export const Sticky: Story = {
+  name: 'Sticky',
+  args: {
+    size: hoverCardContentPropDefs.size.default,
+    variant: hoverCardContentPropDefs.variant.default,
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 600 }}>
+      <Text>
+        The <Code>sticky</Code> prop controls whether the hover card repositions to stay in the viewport when the anchor
+        scrolls toward the edge.
+      </Text>
+      <ul style={{ margin: 0, paddingLeft: 'var(--space-4)' }}>
+        <li>
+          <Text size="2">
+            <Code>sticky=false</Code> (default) - The popup hides when anchor scrolls out of viewport
+          </Text>
+        </li>
+        <li>
+          <Text size="2">
+            <Code>sticky=true</Code> - The popup stays at viewport edge as anchor scrolls away
+          </Text>
+        </li>
+      </ul>
+
+      <div style={{ display: 'flex', gap: 'var(--space-4)' }}>
+        <HoverCard.Root>
+          <HoverCard.Trigger>
+            <Link href="#">sticky=false</Link>
+          </HoverCard.Trigger>
+          <HoverCard.Content {...args} sticky={false} side="top">
+            <Text size="2" style={{ maxWidth: 200 }}>
+              Scroll the page down - this hover card will disappear when the anchor leaves the viewport.
+            </Text>
+          </HoverCard.Content>
+        </HoverCard.Root>
+
+        <HoverCard.Root>
+          <HoverCard.Trigger>
+            <Link href="#">sticky=true</Link>
+          </HoverCard.Trigger>
+          <HoverCard.Content {...args} sticky={true} side="top">
+            <Text size="2" style={{ maxWidth: 200 }}>
+              Scroll the page down - this hover card will stick to the viewport edge.
+            </Text>
+          </HoverCard.Content>
+        </HoverCard.Root>
+      </div>
+
+      <Text size="2" color="gray">
+        Open a hover card, then scroll the page (not a container) to see the difference. Works best when this story is
+        near the top of the viewport.
+      </Text>
+
+      {/* Spacer to enable page scrolling */}
+      <div style={{ height: 800 }} />
+    </div>
   ),
 };

--- a/packages/frosted-ui/src/components/hover-card/hover-card.stories.tsx
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.stories.tsx
@@ -830,3 +830,109 @@ export const Sticky: Story = {
     </div>
   ),
 };
+
+export const DisableAnchorTracking: Story = {
+  name: 'Disable Anchor Tracking',
+  args: {
+    size: '2',
+    variant: 'translucent',
+  },
+  render: function Render(args) {
+    const [position, setPosition] = React.useState(0);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text>
+          The <Code>disableAnchorTracking</Code> prop controls whether the hover card repositions when the anchor
+          element moves due to layout changes (not scrolling). This is useful for performance optimization or when you
+          want the hover card to stay in its original position.
+        </Text>
+
+        <Button size="1" onClick={() => setPosition((p) => (p === 0 ? 80 : 0))}>
+          Move anchors
+        </Button>
+
+        <div style={{ display: 'flex', gap: 'var(--space-6)' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              Default (tracking enabled)
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Hover card follows when anchor moves
+            </Text>
+            <div
+              style={{
+                width: 220,
+                height: 100,
+                border: '1px solid var(--gray-6)',
+                borderRadius: 'var(--radius-2)',
+                padding: 'var(--space-3)',
+                position: 'relative',
+              }}
+            >
+              <HoverCard.Root open>
+                <HoverCard.Trigger>
+                  <Link
+                    href="#"
+                    style={{
+                      display: 'inline-block',
+                      transform: `translateX(${position}px)`,
+                      transition: 'transform 300ms ease',
+                    }}
+                  >
+                    Hover target
+                  </Link>
+                </HoverCard.Trigger>
+                <HoverCard.Content {...args} side="bottom">
+                  <Text size="2">Follows anchor movement</Text>
+                </HoverCard.Content>
+              </HoverCard.Root>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              disableAnchorTracking=true
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Hover card stays in original position
+            </Text>
+            <div
+              style={{
+                width: 220,
+                height: 100,
+                border: '1px solid var(--gray-6)',
+                borderRadius: 'var(--radius-2)',
+                padding: 'var(--space-3)',
+                position: 'relative',
+              }}
+            >
+              <HoverCard.Root open>
+                <HoverCard.Trigger>
+                  <Link
+                    href="#"
+                    style={{
+                      display: 'inline-block',
+                      transform: `translateX(${position}px)`,
+                      transition: 'transform 300ms ease',
+                    }}
+                  >
+                    Hover target
+                  </Link>
+                </HoverCard.Trigger>
+                <HoverCard.Content {...args} disableAnchorTracking side="bottom">
+                  <Text size="2">Stays in place</Text>
+                </HoverCard.Content>
+              </HoverCard.Root>
+            </div>
+          </div>
+        </div>
+
+        <Text size="1" color="gray">
+          Click the button above to move the anchor elements. The left hover card will follow, while the right one stays
+          fixed at its original position.
+        </Text>
+      </div>
+    );
+  },
+};

--- a/packages/frosted-ui/src/components/hover-card/hover-card.tsx
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.tsx
@@ -74,7 +74,7 @@ const HoverCardContent = (props: HoverCardContentProps) => {
     container,
     size = hoverCardContentPropDefs.size.default,
     variant = hoverCardContentPropDefs.variant.default,
-    alignment = 'start',
+    alignment = 'center',
     side,
     sideOffset = 8,
     alignmentOffset,

--- a/packages/frosted-ui/src/components/hover-card/hover-card.tsx
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.tsx
@@ -15,7 +15,11 @@ interface HoverCardRootProps extends Omit<
 const HoverCardRoot: React.FC<HoverCardRootProps> = (props) => <PreviewCardPrimitive.Root {...props} />;
 HoverCardRoot.displayName = 'HoverCardRoot';
 
-interface HoverCardTriggerProps extends Omit<React.ComponentProps<typeof PreviewCardPrimitive.Trigger>, 'render'> {
+interface HoverCardTriggerProps extends Omit<
+  React.ComponentProps<typeof PreviewCardPrimitive.Trigger>,
+  'render' | 'className'
+> {
+  className?: string;
   children: React.ReactElement;
   /** How long to wait before the preview card opens. Specified in milliseconds. */
   delay?: number;

--- a/packages/frosted-ui/src/components/hover-card/hover-card.tsx
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.tsx
@@ -15,10 +15,7 @@ interface HoverCardRootProps extends Omit<
 const HoverCardRoot: React.FC<HoverCardRootProps> = (props) => <PreviewCardPrimitive.Root {...props} />;
 HoverCardRoot.displayName = 'HoverCardRoot';
 
-interface HoverCardTriggerProps extends Omit<
-  React.ComponentProps<typeof PreviewCardPrimitive.Trigger>,
-  'className' | 'render'
-> {
+interface HoverCardTriggerProps extends Omit<React.ComponentProps<typeof PreviewCardPrimitive.Trigger>, 'render'> {
   children: React.ReactElement;
   /** How long to wait before the preview card opens. Specified in milliseconds. */
   delay?: number;

--- a/packages/frosted-ui/src/components/hover-card/hover-card.tsx
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.tsx
@@ -58,6 +58,7 @@ interface HoverCardContentProps
       | 'arrowPadding'
       | 'sticky'
       | 'anchor'
+      | 'disableAnchorTracking'
     >,
     HoverCardContentOwnProps {
   className?: string;
@@ -85,6 +86,7 @@ const HoverCardContent = (props: HoverCardContentProps) => {
     arrowPadding,
     sticky,
     anchor,
+    disableAnchorTracking,
     children,
     ...contentProps
   } = props;
@@ -101,6 +103,7 @@ const HoverCardContent = (props: HoverCardContentProps) => {
         arrowPadding={arrowPadding}
         sticky={sticky}
         anchor={anchor}
+        disableAnchorTracking={disableAnchorTracking}
         className="fui-HoverCardPositioner"
       >
         <Theme asChild>

--- a/packages/frosted-ui/src/components/hover-card/hover-card.tsx
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.tsx
@@ -1,58 +1,117 @@
 'use client';
 
+import { PreviewCard as PreviewCardPrimitive } from '@base-ui/react/preview-card';
 import classNames from 'classnames';
-import { HoverCard as HoverCardPrimitive } from 'radix-ui';
 import * as React from 'react';
 import { Theme } from '../../theme';
 import { hoverCardContentPropDefs } from './hover-card.props';
 
 import type { GetPropDefTypes } from '../../helpers';
 
-interface HoverCardRootProps extends React.ComponentProps<typeof HoverCardPrimitive.Root> {}
-const HoverCardRoot: React.FC<HoverCardRootProps> = (props) => (
-  <HoverCardPrimitive.Root closeDelay={150} openDelay={200} {...props} />
-);
+interface HoverCardRootProps extends Omit<
+  React.ComponentProps<typeof PreviewCardPrimitive.Root>,
+  'className' | 'render'
+> {}
+const HoverCardRoot: React.FC<HoverCardRootProps> = (props) => <PreviewCardPrimitive.Root {...props} />;
 HoverCardRoot.displayName = 'HoverCardRoot';
 
-interface HoverCardTriggerProps extends Omit<React.ComponentProps<typeof HoverCardPrimitive.Trigger>, 'asChild'> {}
-const HoverCardTrigger = (props: HoverCardTriggerProps) => (
-  <HoverCardPrimitive.Trigger className={classNames('fui-HoverCardTrigger', props.className)} {...props} asChild />
-);
+interface HoverCardTriggerProps extends Omit<
+  React.ComponentProps<typeof PreviewCardPrimitive.Trigger>,
+  'className' | 'render'
+> {
+  children: React.ReactElement;
+  /** How long to wait before the preview card opens. Specified in milliseconds. */
+  delay?: number;
+  /** How long to wait before closing the preview card. Specified in milliseconds. */
+  closeDelay?: number;
+}
+const HoverCardTrigger = (props: HoverCardTriggerProps) => {
+  const { children, delay = 200, closeDelay = 150, ...rest } = props;
+  return (
+    <PreviewCardPrimitive.Trigger
+      className="fui-HoverCardTrigger"
+      delay={delay}
+      closeDelay={closeDelay}
+      render={children}
+      {...rest}
+    />
+  );
+};
 HoverCardTrigger.displayName = 'HoverCardTrigger';
+
+type PositionerProps = React.ComponentProps<typeof PreviewCardPrimitive.Positioner>;
+type PortalProps = React.ComponentProps<typeof PreviewCardPrimitive.Portal>;
+type PopupProps = React.ComponentProps<typeof PreviewCardPrimitive.Popup>;
 
 type HoverCardContentOwnProps = GetPropDefTypes<typeof hoverCardContentPropDefs>;
 interface HoverCardContentProps
-  extends Omit<React.ComponentProps<typeof HoverCardPrimitive.Content>, 'asChild'>,
+  extends
+    Omit<PopupProps, 'className' | 'render'>,
+    Pick<
+      PositionerProps,
+      | 'side'
+      | 'sideOffset'
+      | 'collisionPadding'
+      | 'collisionBoundary'
+      | 'collisionAvoidance'
+      | 'arrowPadding'
+      | 'sticky'
+      | 'anchor'
+    >,
     HoverCardContentOwnProps {
-  container?: React.ComponentProps<typeof HoverCardPrimitive.Portal>['container'];
+  className?: string;
+  container?: PortalProps['container'];
+  keepMounted?: PortalProps['keepMounted'];
+  /** The alignment of the content relative to the trigger. */
+  alignment?: PositionerProps['align'];
+  /** The offset from the alignment edge in pixels. */
+  alignmentOffset?: PositionerProps['alignOffset'];
 }
 const HoverCardContent = (props: HoverCardContentProps) => {
   const {
     className,
-    forceMount,
+    keepMounted,
     container,
     size = hoverCardContentPropDefs.size.default,
     variant = hoverCardContentPropDefs.variant.default,
+    alignment = 'start',
+    side,
+    sideOffset = 8,
+    alignmentOffset,
+    collisionPadding = 10,
+    collisionBoundary,
+    collisionAvoidance,
+    arrowPadding,
+    sticky,
+    anchor,
+    children,
     ...contentProps
   } = props;
   return (
-    <HoverCardPrimitive.Portal container={container} forceMount={forceMount}>
-      <Theme asChild>
-        <HoverCardPrimitive.Content
-          align="start"
-          sideOffset={8}
-          collisionPadding={10}
-          {...contentProps}
-          className={classNames(
-            'fui-PopperContent',
-            'fui-HoverCardContent',
-            `fui-variant-${variant}`,
-            className,
-            `fui-r-size-${size}`,
-          )}
-        />
-      </Theme>
-    </HoverCardPrimitive.Portal>
+    <PreviewCardPrimitive.Portal container={container} keepMounted={keepMounted}>
+      <PreviewCardPrimitive.Positioner
+        align={alignment}
+        side={side}
+        sideOffset={sideOffset}
+        alignOffset={alignmentOffset}
+        collisionPadding={collisionPadding}
+        collisionBoundary={collisionBoundary}
+        collisionAvoidance={collisionAvoidance}
+        arrowPadding={arrowPadding}
+        sticky={sticky}
+        anchor={anchor}
+        className="fui-HoverCardPositioner"
+      >
+        <Theme asChild>
+          <PreviewCardPrimitive.Popup
+            {...contentProps}
+            className={classNames('fui-HoverCardContent', `fui-variant-${variant}`, className, `fui-r-size-${size}`)}
+          >
+            {children}
+          </PreviewCardPrimitive.Popup>
+        </Theme>
+      </PreviewCardPrimitive.Positioner>
+    </PreviewCardPrimitive.Portal>
   );
 };
 HoverCardContent.displayName = 'HoverCardContent';

--- a/packages/frosted-ui/src/components/popover/popover.css
+++ b/packages/frosted-ui/src/components/popover/popover.css
@@ -1,13 +1,13 @@
 .fui-PopoverContent {
   box-shadow: var(--shadow-5);
-  min-width: var(--radix-popover-trigger-width);
+  min-width: var(--anchor-width);
   outline: 0;
   overflow: auto;
 
   --inset-padding: var(--popover-content-padding);
   padding: var(--popover-content-padding);
 
-  transform-origin: var(--radix-popover-content-transform-origin);
+  transform-origin: var(--transform-origin);
 
   &:where(.fui-variant-translucent) {
     background-color: var(--color-panel-translucent);
@@ -17,6 +17,24 @@
   }
   &:where(.fui-variant-solid) {
     background-color: var(--color-panel-solid);
+  }
+
+  /* Animations */
+  @media (prefers-reduced-motion: no-preference) {
+    transition:
+      transform 150ms ease-out,
+      opacity 150ms ease-out;
+
+    &[data-starting-style] {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+
+    &[data-ending-style] {
+      opacity: 0;
+      transform: scale(0.95);
+      transition-duration: 75ms;
+    }
   }
 }
 /* prettier-ignore */

--- a/packages/frosted-ui/src/components/popover/popover.css
+++ b/packages/frosted-ui/src/components/popover/popover.css
@@ -13,10 +13,12 @@
     background-color: var(--color-panel-translucent);
     -webkit-backdrop-filter: var(--backdrop-filter-panel);
     backdrop-filter: var(--backdrop-filter-panel);
-    outline: 0.5px solid var(--color-popover-outline);
   }
   &:where(.fui-variant-solid) {
     background-color: var(--color-panel-solid);
+  }
+  &:where(.fui-variant-translucent, .fui-variant-solid) {
+    outline: 0.5px solid var(--color-popover-outline);
   }
 
   /* Animations */

--- a/packages/frosted-ui/src/components/popover/popover.css
+++ b/packages/frosted-ui/src/components/popover/popover.css
@@ -3,6 +3,7 @@
   min-width: var(--anchor-width);
   outline: 0;
   overflow: auto;
+  text-align: start;
 
   --inset-padding: var(--popover-content-padding);
   padding: var(--popover-content-padding);

--- a/packages/frosted-ui/src/components/popover/popover.stories.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.stories.tsx
@@ -1160,3 +1160,156 @@ function QuickActionsDemo({ args }: { args: Record<string, unknown> }) {
     </Popover.Root>
   );
 }
+
+export const FinalFocus: Story = {
+  name: 'Final Focus',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    const alternateRef = React.useRef<HTMLButtonElement>(null);
+    const inputRef = React.useRef<HTMLInputElement>(null);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text size="2" color="gray">
+          The <Code>finalFocus</Code> prop controls where focus returns after the popover closes. By default, focus
+          returns to the trigger element.
+        </Text>
+
+        <div style={{ display: 'flex', gap: 'var(--space-6)', flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              Default behavior
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Focus returns to the trigger after close
+            </Text>
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button size="1">Open</Button>
+              </Popover.Trigger>
+              <Popover.Content {...args}>
+                <Text size="2">Close me and focus returns to the trigger button.</Text>
+                <Popover.Close>
+                  <Button size="1" variant="soft" style={{ marginTop: 12 }}>
+                    Close
+                  </Button>
+                </Popover.Close>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              finalFocus=false
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Focus is not moved after close
+            </Text>
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button size="1">Open</Button>
+              </Popover.Trigger>
+              <Popover.Content {...args} finalFocus={false}>
+                <Text size="2">Close me and focus stays where it is (not moved).</Text>
+                <Popover.Close>
+                  <Button size="1" variant="soft" style={{ marginTop: 12 }}>
+                    Close
+                  </Button>
+                </Popover.Close>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              finalFocus={'{ref}'}
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Focus moves to a specific element
+            </Text>
+            <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
+              <Popover.Root>
+                <Popover.Trigger>
+                  <Button size="1">Open</Button>
+                </Popover.Trigger>
+                <Popover.Content {...args} finalFocus={alternateRef}>
+                  <Text size="2">Close me and focus moves to the &quot;Target&quot; button.</Text>
+                  <Popover.Close>
+                    <Button size="1" variant="soft" style={{ marginTop: 12 }}>
+                      Close
+                    </Button>
+                  </Popover.Close>
+                </Popover.Content>
+              </Popover.Root>
+              <Button ref={alternateRef} size="1" variant="solid">
+                Target
+              </Button>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              finalFocus={'{function}'}
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Dynamic focus based on close method
+            </Text>
+            <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
+              <Popover.Root>
+                <Popover.Trigger>
+                  <Button size="1">Open</Button>
+                </Popover.Trigger>
+                <Popover.Content
+                  {...args}
+                  finalFocus={(interactionType) => {
+                    // Focus input if closed by keyboard (Escape), otherwise default behavior
+                    if (interactionType === 'keyboard') {
+                      return inputRef.current;
+                    }
+                    return true; // Default: return to trigger
+                  }}
+                >
+                  <Text size="2">
+                    Press <Code>Escape</Code> → focuses the input.
+                    <br />
+                    Click outside → returns to trigger.
+                  </Text>
+                  <Popover.Close>
+                    <Button size="1" variant="soft" style={{ marginTop: 12 }}>
+                      Close
+                    </Button>
+                  </Popover.Close>
+                </Popover.Content>
+              </Popover.Root>
+            </div>
+          </div>
+        </div>
+
+        <div
+          style={{
+            marginTop: 'var(--space-4)',
+            padding: 'var(--space-4)',
+            background: 'var(--gray-a3)',
+            borderRadius: 'var(--radius-3)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--space-2)',
+          }}
+        >
+          <Text size="1" weight="medium">
+            Focus target for dynamic example
+          </Text>
+          <TextField.Input ref={inputRef} placeholder="Focus lands here when pressing Escape..." />
+        </div>
+
+        <Text size="1" color="gray">
+          The <Code>finalFocus</Code> function receives the interaction type (<Code>keyboard</Code>,{' '}
+          <Code>pointer</Code>, <Code>touch</Code>) so you can customize behavior based on how the popover was closed.
+        </Text>
+      </div>
+    );
+  },
+};

--- a/packages/frosted-ui/src/components/popover/popover.stories.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.stories.tsx
@@ -1313,3 +1313,174 @@ export const FinalFocus: Story = {
     );
   },
 };
+
+export const InitialFocus: Story = {
+  name: 'Initial Focus',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    const deleteButtonRef = React.useRef<HTMLButtonElement>(null);
+    const searchInputRef = React.useRef<HTMLInputElement>(null);
+    const recentButtonRef = React.useRef<HTMLButtonElement>(null);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text size="2" color="gray">
+          The <Code>initialFocus</Code> prop controls which element receives focus when the popover opens. By default,
+          focus moves to the first focusable element inside the popover.
+        </Text>
+
+        <div style={{ display: 'flex', gap: 'var(--space-6)', flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              Default behavior
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              First focusable element receives focus
+            </Text>
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button size="1">Open</Button>
+              </Popover.Trigger>
+              <Popover.Content {...args} style={{ width: 260 }}>
+                <Heading size="3" style={{ marginBottom: 8 }}>
+                  Edit Item
+                </Heading>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+                  <TextField.Input placeholder="Item name" defaultValue="My Item" />
+                  <TextArea placeholder="Description" defaultValue="A short description..." />
+                  <div style={{ display: 'flex', gap: 'var(--space-2)', justifyContent: 'flex-end' }}>
+                    <Popover.Close>
+                      <Button size="1" variant="soft">
+                        Cancel
+                      </Button>
+                    </Popover.Close>
+                    <Button size="1">Save</Button>
+                  </div>
+                </div>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              initialFocus=false
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              No element is focused on open
+            </Text>
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button size="1">Open</Button>
+              </Popover.Trigger>
+              <Popover.Content {...args} initialFocus={false} style={{ width: 260 }}>
+                <Heading size="3" style={{ marginBottom: 8 }}>
+                  Information
+                </Heading>
+                <Text size="2" color="gray">
+                  This is a read-only info panel. No element receives focus when it opens, which can be useful for
+                  non-interactive popovers.
+                </Text>
+                <Popover.Close>
+                  <Button size="1" variant="soft" style={{ marginTop: 12 }}>
+                    Got it
+                  </Button>
+                </Popover.Close>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              initialFocus={'{ref}'}
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Focus a specific element (the Delete button)
+            </Text>
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button size="1" color="red" variant="soft">
+                  Delete
+                </Button>
+              </Popover.Trigger>
+              <Popover.Content {...args} initialFocus={deleteButtonRef} style={{ width: 260 }}>
+                <Heading size="3" style={{ marginBottom: 8 }}>
+                  Confirm Deletion
+                </Heading>
+                <Text size="2" color="gray" style={{ marginBottom: 12, display: 'block' }}>
+                  Are you sure you want to delete this item? This action cannot be undone.
+                </Text>
+                <div style={{ display: 'flex', gap: 'var(--space-2)', justifyContent: 'flex-end' }}>
+                  <Popover.Close>
+                    <Button size="1" variant="soft">
+                      Cancel
+                    </Button>
+                  </Popover.Close>
+                  <Popover.Close>
+                    <Button ref={deleteButtonRef} size="1" color="red">
+                      Delete
+                    </Button>
+                  </Popover.Close>
+                </div>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              initialFocus={'{function}'}
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Dynamic focus based on open method
+            </Text>
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button size="1">Search</Button>
+              </Popover.Trigger>
+              <Popover.Content
+                {...args}
+                initialFocus={(interactionType) => {
+                  // Focus search input when opened via keyboard
+                  if (interactionType === 'keyboard') {
+                    return searchInputRef.current;
+                  }
+                  // Focus button when opened via pointer/touch
+                  return recentButtonRef.current;
+                }}
+                style={{ width: 280 }}
+              >
+                <Heading size="3" style={{ marginBottom: 8 }}>
+                  Quick Search
+                </Heading>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+                  <TextField.Input ref={searchInputRef} placeholder="Search..." />
+                  <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+                    <Button ref={recentButtonRef} size="1" variant="soft" style={{ flex: 1 }}>
+                      Recent
+                    </Button>
+                    <Button size="1" variant="soft" style={{ flex: 1 }}>
+                      Favorites
+                    </Button>
+                  </div>
+                  <Text size="1" color="gray">
+                    Keyboard open → focuses input
+                    <br />
+                    Click open → focuses first button
+                  </Text>
+                </div>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+        </div>
+
+        <Text size="1" color="gray">
+          The <Code>initialFocus</Code> function receives the interaction type (<Code>keyboard</Code>,{' '}
+          <Code>pointer</Code>, <Code>touch</Code>) so you can customize initial focus based on how the popover was
+          opened.
+        </Text>
+      </div>
+    );
+  },
+};

--- a/packages/frosted-ui/src/components/popover/popover.stories.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.stories.tsx
@@ -516,3 +516,160 @@ export const AnchorProp: Story = {
     );
   },
 };
+
+export const DisableAnchorTracking: Story = {
+  name: 'Disable Anchor Tracking',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    const [position, setPosition] = React.useState(0);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text size="2" color="gray">
+          The <Code>disableAnchorTracking</Code> prop controls whether the popover repositions when the anchor element
+          moves due to layout changes (not scrolling). Open both popovers and click the button to move the anchors.
+        </Text>
+
+        <Button size="1" onClick={() => setPosition((p) => (p === 0 ? 50 : 0))}>
+          Move anchors
+        </Button>
+
+        <div style={{ display: 'flex', gap: 'var(--space-6)' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              Default (tracking enabled)
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Popover follows when anchor moves
+            </Text>
+            <div
+              style={{
+                width: 200,
+                height: 100,
+                border: '1px solid var(--gray-6)',
+                borderRadius: 'var(--radius-2)',
+                padding: 'var(--space-3)',
+                position: 'relative',
+              }}
+            >
+              <Popover.Root open>
+                <Popover.Trigger>
+                  <Button
+                    size="1"
+                    style={{
+                      transform: `translateX(${position}px)`,
+                      transition: 'transform 300ms ease',
+                    }}
+                  >
+                    Trigger
+                  </Button>
+                </Popover.Trigger>
+                <Popover.Content {...args} side="bottom">
+                  <Text size="2">Follows anchor movement</Text>
+                </Popover.Content>
+              </Popover.Root>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              disableAnchorTracking=true
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Popover stays in original position
+            </Text>
+            <div
+              style={{
+                width: 200,
+                height: 100,
+                border: '1px solid var(--gray-6)',
+                borderRadius: 'var(--radius-2)',
+                padding: 'var(--space-3)',
+                position: 'relative',
+              }}
+            >
+              <Popover.Root open>
+                <Popover.Trigger>
+                  <Button
+                    size="1"
+                    style={{
+                      transform: `translateX(${position}px)`,
+                      transition: 'transform 300ms ease',
+                    }}
+                  >
+                    Trigger
+                  </Button>
+                </Popover.Trigger>
+                <Popover.Content {...args} disableAnchorTracking side="bottom">
+                  <Text size="2">Stays in place</Text>
+                </Popover.Content>
+              </Popover.Root>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const Sticky: Story = {
+  name: 'Sticky',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text size="2" color="gray">
+          The <Code>sticky</Code> prop controls whether the popover stays visible in the viewport when the anchor is
+          scrolled out of view. Open the popover then scroll this page to see the effect.
+        </Text>
+
+        <div style={{ display: 'flex', gap: 'var(--space-6)', marginTop: 'var(--space-4)' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              sticky=false (default)
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 200 }}>
+              Popover hides when anchor leaves viewport
+            </Text>
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button size="1">Open Popover</Button>
+              </Popover.Trigger>
+              <Popover.Content {...args} sticky={false} side="right">
+                <Text size="2">I hide when anchor leaves viewport</Text>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              sticky=true
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 200 }}>
+              Popover stays visible at viewport edge
+            </Text>
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button size="1">Open Popover</Button>
+              </Popover.Trigger>
+              <Popover.Content {...args} sticky={true} side="right">
+                <Text size="2">I stay visible at the viewport edge</Text>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+        </div>
+
+        <div style={{ height: '150vh' }} />
+        <Text size="1" color="gray">
+          ↑ Scroll back up to see the buttons
+        </Text>
+      </div>
+    );
+  },
+};

--- a/packages/frosted-ui/src/components/popover/popover.stories.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.stories.tsx
@@ -16,6 +16,7 @@ import {
   Switch,
   Text,
   TextArea,
+  TextField,
   popoverContentPropDefs,
 } from '../../../src/components/';
 
@@ -848,6 +849,99 @@ export const CollisionAvoidanceDemo: Story = {
         <Text size="1" color="gray">
           The dashed box is set as the collision boundary. Try positioning your browser so the triggers are near the
           edge of the boundary.
+        </Text>
+      </div>
+    );
+  },
+};
+
+export const Modal: Story = {
+  name: 'Modal Behavior',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text size="2" color="gray">
+          The <Code>modal</Code> prop on <Code>Popover.Root</Code> controls how the popover interacts with the rest of
+          the page. Open each popover and try interacting with the input below.
+        </Text>
+
+        <div style={{ display: 'flex', gap: 'var(--space-6)', flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              modal=false (default)
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              No restrictions. You can interact with elements outside the popover.
+            </Text>
+            <Popover.Root modal={false}>
+              <Popover.Trigger>
+                <Button size="1">Open</Button>
+              </Popover.Trigger>
+              <Popover.Content {...args}>
+                <Text size="2">Click outside or interact with other elements freely.</Text>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              modal=true
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Full modal: scroll locked, outside interactions disabled, focus trapped.
+            </Text>
+            <Popover.Root modal={true}>
+              <Popover.Trigger>
+                <Button size="1">Open</Button>
+              </Popover.Trigger>
+              <Popover.Content {...args}>
+                <Text size="2">Page scroll is locked. Click outside to close.</Text>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              modal="trap-focus"
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+              Focus trapped, but scroll allowed and outside clicks work.
+            </Text>
+            <Popover.Root modal="trap-focus">
+              <Popover.Trigger>
+                <Button size="1">Open</Button>
+              </Popover.Trigger>
+              <Popover.Content {...args}>
+                <Text size="2">Focus is trapped but you can scroll the page.</Text>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+        </div>
+
+        <div
+          style={{
+            marginTop: 'var(--space-4)',
+            padding: 'var(--space-4)',
+            background: 'var(--gray-a3)',
+            borderRadius: 'var(--radius-3)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--space-2)',
+          }}
+        >
+          <Text size="1" weight="medium">
+            Test interaction area
+          </Text>
+          <TextField.Input placeholder="Try to focus this input while popover is open..." />
+        </div>
+
+        <div style={{ height: '100vh' }} />
+        <Text size="1" color="gray">
+          ↑ Extra space to test scroll locking with modal=true
         </Text>
       </div>
     );

--- a/packages/frosted-ui/src/components/popover/popover.stories.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.stories.tsx
@@ -1,10 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
+import { Bell16 } from '@frosted-ui/icons';
 import React from 'react';
 import {
   Avatar,
   Button,
   Checkbox,
+  Code,
   Heading,
   IconButton,
   Inset,
@@ -89,7 +91,7 @@ export const Variant: Story = {
               <AppearanceIcon />
             </IconButton>
           </Popover.Trigger>
-          <Popover.Content {...args} variant="translucent" align="center" style={{ width: 292 }}>
+          <Popover.Content {...args} variant="translucent" alignment="center" style={{ width: 292 }}>
             <Heading size="3" style={{ marginBottom: 12 }}>
               Theme
             </Heading>
@@ -123,7 +125,7 @@ export const Variant: Story = {
               <AppearanceIcon />
             </IconButton>
           </Popover.Trigger>
-          <Popover.Content {...args} variant="solid" align="center" style={{ width: 292 }}>
+          <Popover.Content {...args} variant="solid" alignment="center" style={{ width: 292 }}>
             <Heading size="3" style={{ marginBottom: 8 }}>
               Theme
             </Heading>
@@ -263,3 +265,195 @@ const AppearanceIcon = () => (
     </defs>
   </svg>
 );
+
+export const OpenOnHover: Story = {
+  name: 'Opening on Hover',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+      <Text size="2" color="gray">
+        Use <code>openOnHover</code> to open the popover on hover. Use <code>delay</code> to specify how long to wait
+        before opening.
+      </Text>
+      <div style={{ display: 'flex', gap: 'var(--space-4)' }}>
+        <Popover.Root>
+          <Popover.Trigger openOnHover>
+            <Button variant="soft">Hover me (default delay)</Button>
+          </Popover.Trigger>
+          <Popover.Content {...args} style={{ width: 280 }}>
+            <Heading size="3" style={{ marginBottom: 8 }}>
+              Quick Preview
+            </Heading>
+            <Text size="2" color="gray">
+              This popover opens on hover with the default 300ms delay.
+            </Text>
+          </Popover.Content>
+        </Popover.Root>
+
+        <Popover.Root>
+          <Popover.Trigger openOnHover delay={0}>
+            <Button variant="soft">Hover me (no delay)</Button>
+          </Popover.Trigger>
+          <Popover.Content {...args} style={{ width: 280 }}>
+            <Heading size="3" style={{ marginBottom: 8 }}>
+              Instant Preview
+            </Heading>
+            <Text size="2" color="gray">
+              This popover opens immediately on hover with no delay.
+            </Text>
+          </Popover.Content>
+        </Popover.Root>
+      </div>
+    </div>
+  ),
+};
+
+const detachedHandle = Popover.createHandle();
+
+export const DetachedTriggers: Story = {
+  name: 'Detached Triggers',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+      <Text size="2" color="gray">
+        Use <code>Popover.createHandle()</code> to control a popover from a trigger located outside the{' '}
+        <code>Popover.Root</code>.
+      </Text>
+
+      <Popover.Trigger handle={detachedHandle}>
+        <Button>Detached Trigger</Button>
+      </Popover.Trigger>
+
+      <Popover.Root handle={detachedHandle}>
+        <Popover.Content {...args} style={{ width: 280 }}>
+          <Heading size="3" style={{ marginBottom: 8 }}>
+            Detached Popover
+          </Heading>
+          <Text size="2" color="gray">
+            This popover is controlled by a trigger outside of its Root component.
+          </Text>
+          <Popover.Close>
+            <Button size="1" variant="soft" style={{ marginTop: 12 }}>
+              Close
+            </Button>
+          </Popover.Close>
+        </Popover.Content>
+      </Popover.Root>
+    </div>
+  ),
+};
+
+export const MultipleTriggers: Story = {
+  name: 'Multiple Triggers',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    const handle = React.useMemo(() => Popover.createHandle<string>(), []);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+        <Text size="2" color="gray">
+          Multiple triggers can control the same popover using a shared handle. Each trigger can pass a different{' '}
+          <code>payload</code>.
+        </Text>
+        <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+          <Popover.Trigger handle={handle} payload="Button A">
+            <Button variant="soft">Button A</Button>
+          </Popover.Trigger>
+          <Popover.Trigger handle={handle} payload="Button B">
+            <Button variant="soft">Button B</Button>
+          </Popover.Trigger>
+          <Popover.Trigger handle={handle} payload="Button C">
+            <Button variant="soft">Button C</Button>
+          </Popover.Trigger>
+        </div>
+
+        <Popover.Root handle={handle}>
+          {(payload) => (
+            <Popover.Content {...args} style={{ width: 280 }}>
+              <Heading size="3" style={{ marginBottom: 8 }}>
+                Triggered by: {String(payload)}
+              </Heading>
+              <Text size="2" color="gray">
+                The popover content can access the payload from the trigger that opened it.
+              </Text>
+            </Popover.Content>
+          )}
+        </Popover.Root>
+      </div>
+    );
+  },
+};
+
+export const ControlledWithMultipleTriggers: Story = {
+  name: 'Controlled Mode with Multiple Triggers',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    const handle = React.useMemo(() => Popover.createHandle(), []);
+    const [open, setOpen] = React.useState(false);
+    const [triggerId, setTriggerId] = React.useState<string | null>(null);
+
+    const handleOpenChange = (isOpen: boolean, eventDetails: { trigger?: { id?: string } }) => {
+      setOpen(isOpen);
+      setTriggerId(eventDetails.trigger?.id ?? null);
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+        <Text size="2" color="gray">
+          Use <Code>open</Code>, <Code>onOpenChange</Code>, and <Code>triggerId</Code> for fully controlled mode with
+          multiple detached triggers.
+        </Text>
+
+        <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+          <Popover.Trigger handle={handle} id="trigger-1">
+            <IconButton variant="surface" color="gray">
+              <Bell16 />
+            </IconButton>
+          </Popover.Trigger>
+          <Popover.Trigger handle={handle} id="trigger-2">
+            <IconButton variant="surface" color="gray">
+              <Bell16 />
+            </IconButton>
+          </Popover.Trigger>
+          <Popover.Trigger handle={handle} id="trigger-3">
+            <IconButton variant="surface" color="gray">
+              <Bell16 />
+            </IconButton>
+          </Popover.Trigger>
+          <Button
+            variant="surface"
+            onClick={() => {
+              setTriggerId('trigger-2');
+              setOpen(true);
+            }}
+          >
+            Open programmatically
+          </Button>
+        </div>
+
+        <Popover.Root handle={handle} open={open} onOpenChange={handleOpenChange} triggerId={triggerId}>
+          <Popover.Content {...args} style={{ width: 280 }}>
+            <Heading size="3" style={{ marginBottom: 8 }}>
+              Notifications
+            </Heading>
+            <Text size="2" color="gray">
+              You are all caught up. Good job!
+            </Text>
+          </Popover.Content>
+        </Popover.Root>
+      </div>
+    );
+  },
+};

--- a/packages/frosted-ui/src/components/popover/popover.stories.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.stories.tsx
@@ -1027,3 +1027,136 @@ export const OpenChangeCallbacks: Story = {
     );
   },
 };
+
+export const ActionsRef: Story = {
+  name: 'Actions Ref',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    const actionsRef = React.useRef<{ unmount: () => void; close: () => void } | null>(null);
+    const [email, setEmail] = React.useState('');
+    const [isSubmitting, setIsSubmitting] = React.useState(false);
+    const [status, setStatus] = React.useState<'idle' | 'success'>('idle');
+
+    const handleSubmit = async (e: React.FormEvent) => {
+      e.preventDefault();
+      setIsSubmitting(true);
+
+      // Simulate API call
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
+      setIsSubmitting(false);
+      setStatus('success');
+
+      // Close popover after showing success message
+      setTimeout(() => {
+        actionsRef.current?.close();
+        // Reset form after close
+        setTimeout(() => {
+          setEmail('');
+          setStatus('idle');
+        }, 200);
+      }, 1500);
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text size="2" color="gray">
+          The <Code>actionsRef</Code> prop provides imperative control over the popover. Use <Code>close()</Code> to
+          programmatically close the popover after a form submission or async action completes.
+        </Text>
+
+        <div style={{ display: 'flex', gap: 'var(--space-4)', flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              Newsletter Signup (auto-closes on success)
+            </Text>
+            <Popover.Root actionsRef={actionsRef}>
+              <Popover.Trigger>
+                <Button>Subscribe to Newsletter</Button>
+              </Popover.Trigger>
+              <Popover.Content {...args} style={{ width: 280 }}>
+                {status === 'success' ? (
+                  <div style={{ textAlign: 'center', padding: 'var(--space-2)' }}>
+                    <Text size="2" color="green" weight="medium">
+                      ✓ Successfully subscribed!
+                    </Text>
+                  </div>
+                ) : (
+                  <form onSubmit={handleSubmit}>
+                    <Heading size="3" style={{ marginBottom: 8 }}>
+                      Stay Updated
+                    </Heading>
+                    <Text size="2" color="gray" style={{ marginBottom: 12, display: 'block' }}>
+                      Get the latest news delivered to your inbox.
+                    </Text>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+                      <TextField.Input
+                        type="email"
+                        placeholder="Enter your email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        required
+                      />
+                      <Button type="submit" disabled={isSubmitting}>
+                        {isSubmitting ? 'Subscribing...' : 'Subscribe'}
+                      </Button>
+                    </div>
+                  </form>
+                )}
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              Quick Actions Menu
+            </Text>
+            <QuickActionsDemo args={args} />
+          </div>
+        </div>
+
+        <Text size="1" color="gray">
+          The popover closes automatically after successful form submission or when an action completes.
+        </Text>
+      </div>
+    );
+  },
+};
+
+function QuickActionsDemo({ args }: { args: Record<string, unknown> }) {
+  const actionsRef = React.useRef<{ unmount: () => void; close: () => void } | null>(null);
+  const [copied, setCopied] = React.useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText('https://example.com/share/abc123');
+    setCopied(true);
+    setTimeout(() => {
+      actionsRef.current?.close();
+      setTimeout(() => setCopied(false), 200);
+    }, 800);
+  };
+
+  return (
+    <Popover.Root actionsRef={actionsRef}>
+      <Popover.Trigger>
+        <Button variant="soft">Share</Button>
+      </Popover.Trigger>
+      <Popover.Content {...args} style={{ width: 200 }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+          <Button variant="ghost" style={{ justifyContent: 'flex-start' }} onClick={handleCopy}>
+            {copied ? '✓ Copied!' : 'Copy Link'}
+          </Button>
+          <Button variant="ghost" style={{ justifyContent: 'flex-start' }} onClick={() => actionsRef.current?.close()}>
+            Share to Twitter
+          </Button>
+          <Button variant="ghost" style={{ justifyContent: 'flex-start' }} onClick={() => actionsRef.current?.close()}>
+            Share to LinkedIn
+          </Button>
+        </div>
+      </Popover.Content>
+    </Popover.Root>
+  );
+}

--- a/packages/frosted-ui/src/components/popover/popover.stories.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.stories.tsx
@@ -947,3 +947,83 @@ export const Modal: Story = {
     );
   },
 };
+
+export const OpenChangeCallbacks: Story = {
+  name: 'Open Change Callbacks',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    const [logs, setLogs] = React.useState<string[]>([]);
+
+    const addLog = (message: string) => {
+      const time = new Date().toLocaleTimeString('en-US', {
+        hour12: false,
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        fractionalSecondDigits: 3,
+      });
+      setLogs((prev) => [`[${time}] ${message}`, ...prev].slice(0, 10));
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text size="2" color="gray">
+          Compare <Code>onOpenChange</Code> (fires immediately) vs <Code>onOpenChangeComplete</Code> (fires after
+          animations complete). Open and close the popover to see the timing difference.
+        </Text>
+
+        <Popover.Root
+          onOpenChange={(open) => addLog(`onOpenChange: ${open ? 'opening' : 'closing'}`)}
+          onOpenChangeComplete={(open) => addLog(`onOpenChangeComplete: ${open ? 'opened' : 'closed'}`)}
+        >
+          <Popover.Trigger>
+            <Button>Toggle Popover</Button>
+          </Popover.Trigger>
+          <Popover.Content {...args}>
+            <Heading size="3" style={{ marginBottom: 8 }}>
+              Animated Popover
+            </Heading>
+            <Text size="2" color="gray">
+              Watch the event log to see callback timing.
+            </Text>
+          </Popover.Content>
+        </Popover.Root>
+
+        <div
+          style={{
+            padding: 'var(--space-3)',
+            background: 'var(--gray-a3)',
+            borderRadius: 'var(--radius-2)',
+            fontFamily: 'monospace',
+            fontSize: 'var(--font-size-1)',
+            minHeight: 200,
+          }}
+        >
+          <Text size="1" weight="medium" style={{ marginBottom: 8, display: 'block' }}>
+            Event Log:
+          </Text>
+          {logs.length === 0 ? (
+            <Text size="1" color="gray">
+              Open/close the popover to see events...
+            </Text>
+          ) : (
+            logs.map((log, i) => (
+              <div key={i} style={{ color: log.includes('Complete') ? 'var(--accent-11)' : 'var(--gray-11)' }}>
+                {log}
+              </div>
+            ))
+          )}
+        </div>
+
+        <Text size="1" color="gray">
+          <Code>onOpenChange</Code> fires instantly when state changes.
+          <br />
+          <Code>onOpenChangeComplete</Code> fires after the enter/exit animation finishes.
+        </Text>
+      </div>
+    );
+  },
+};

--- a/packages/frosted-ui/src/components/popover/popover.stories.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.stories.tsx
@@ -673,3 +673,183 @@ export const Sticky: Story = {
     );
   },
 };
+
+export const CollisionBoundary: Story = {
+  name: 'Collision Boundary',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    const [boundary, setBoundary] = React.useState<HTMLElement | null>(null);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text size="2" color="gray">
+          The <Code>collisionBoundary</Code> prop defines the area within which the popover should stay. By default,
+          it&apos;s the viewport. You can set it to a specific element to constrain the popover within that container.
+        </Text>
+
+        <div style={{ display: 'flex', gap: 'var(--space-6)' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              Default (viewport boundary)
+            </Text>
+            <div
+              style={{
+                width: 250,
+                height: 200,
+                border: '2px dashed var(--gray-6)',
+                borderRadius: 'var(--radius-2)',
+                padding: 'var(--space-3)',
+                display: 'flex',
+                alignItems: 'flex-end',
+                justifyContent: 'center',
+              }}
+            >
+              <Popover.Root>
+                <Popover.Trigger>
+                  <Button size="1">Open (prefers bottom)</Button>
+                </Popover.Trigger>
+                <Popover.Content {...args} side="bottom">
+                  <Text size="2">May extend outside the dashed box</Text>
+                </Popover.Content>
+              </Popover.Root>
+            </div>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              Custom boundary (dashed box)
+            </Text>
+            <div
+              ref={setBoundary}
+              style={{
+                width: 250,
+                height: 200,
+                border: '2px dashed var(--accent-9)',
+                borderRadius: 'var(--radius-2)',
+                padding: 'var(--space-3)',
+                display: 'flex',
+                alignItems: 'flex-end',
+                justifyContent: 'center',
+              }}
+            >
+              <Popover.Root>
+                <Popover.Trigger>
+                  <Button size="1">Open (prefers bottom)</Button>
+                </Popover.Trigger>
+                <Popover.Content {...args} side="bottom" collisionBoundary={boundary ?? undefined}>
+                  <Text size="2">Stays within the dashed box</Text>
+                </Popover.Content>
+              </Popover.Root>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const CollisionAvoidanceDemo: Story = {
+  name: 'Collision Avoidance',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    const [boundary, setBoundary] = React.useState<HTMLElement | null>(null);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text size="2" color="gray">
+          The <Code>collisionAvoidance</Code> prop controls how the popover avoids collisions with the boundary. You can
+          configure behavior for both the <Code>side</Code> axis (flip or shift) and the <Code>align</Code> axis.
+        </Text>
+
+        <div
+          ref={setBoundary}
+          style={{
+            display: 'flex',
+            gap: 'var(--space-4)',
+            flexWrap: 'wrap',
+            border: '2px dashed var(--gray-6)',
+            borderRadius: 'var(--radius-2)',
+            padding: 'var(--space-4)',
+          }}
+        >
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              side: "flip" (default)
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 150 }}>
+              Flips to opposite side when there&apos;s not enough space
+            </Text>
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button size="1">Open</Button>
+              </Popover.Trigger>
+              <Popover.Content
+                {...args}
+                side="bottom"
+                collisionBoundary={boundary ?? undefined}
+                collisionAvoidance={{ side: 'flip', align: 'shift' }}
+              >
+                <Text size="2">Flips to top if no space below</Text>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              side: "shift"
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 150 }}>
+              Shifts along the side instead of flipping
+            </Text>
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button size="1">Open</Button>
+              </Popover.Trigger>
+              <Popover.Content
+                {...args}
+                side="bottom"
+                collisionBoundary={boundary ?? undefined}
+                collisionAvoidance={{ side: 'shift', align: 'shift' }}
+              >
+                <Text size="2">Shifts position, stays on same side</Text>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+            <Text size="1" weight="medium">
+              side: "none"
+            </Text>
+            <Text size="1" color="gray" style={{ maxWidth: 150 }}>
+              No collision avoidance on side axis
+            </Text>
+            <Popover.Root>
+              <Popover.Trigger>
+                <Button size="1">Open</Button>
+              </Popover.Trigger>
+              <Popover.Content
+                {...args}
+                side="bottom"
+                collisionBoundary={boundary ?? undefined}
+                collisionAvoidance={{ side: 'none', align: 'shift' }}
+              >
+                <Text size="2">Stays on preferred side regardless</Text>
+              </Popover.Content>
+            </Popover.Root>
+          </div>
+        </div>
+
+        <Text size="1" color="gray">
+          The dashed box is set as the collision boundary. Try positioning your browser so the triggers are near the
+          edge of the boundary.
+        </Text>
+      </div>
+    );
+  },
+};

--- a/packages/frosted-ui/src/components/popover/popover.stories.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.stories.tsx
@@ -457,3 +457,62 @@ export const ControlledWithMultipleTriggers: Story = {
     );
   },
 };
+
+export const AnchorProp: Story = {
+  name: 'Custom Anchor',
+  args: {
+    size: popoverContentPropDefs.size.default,
+    variant: popoverContentPropDefs.variant.default,
+  },
+  render: function Render(args) {
+    const [anchor, setAnchor] = React.useState<HTMLElement | null>(null);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text size="2" color="gray">
+          Use the <Code>anchor</Code> prop to position the popover relative to a different element than the trigger.
+          This is useful for tooltips on specific parts of a component, or when you want visual separation between the
+          trigger and the anchored content.
+        </Text>
+
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 'var(--space-4)',
+            padding: 'var(--space-4)',
+            background: 'var(--gray-a3)',
+            borderRadius: 'var(--radius-3)',
+          }}
+        >
+          <Popover.Root>
+            <Popover.Trigger>
+              <Button>Edit Profile</Button>
+            </Popover.Trigger>
+            <Popover.Content {...args} anchor={anchor} side="top" alignment="start">
+              <Heading size="3" style={{ marginBottom: 8 }}>
+                Profile Picture
+              </Heading>
+              <Text size="2" color="gray">
+                Click to upload a new profile picture. Recommended size: 400×400px.
+              </Text>
+            </Popover.Content>
+          </Popover.Root>
+
+          <div
+            ref={setAnchor}
+            style={{
+              display: 'flex',
+            }}
+          >
+            <Avatar size="5" color="magenta" fallback="JD" />
+          </div>
+        </div>
+
+        <Text size="1" color="gray">
+          The button triggers the popover, but it anchors to the avatar element instead.
+        </Text>
+      </div>
+    );
+  },
+};

--- a/packages/frosted-ui/src/components/popover/popover.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.tsx
@@ -54,7 +54,7 @@ const PopoverContent = (props: PopoverContentProps & PopoverContentOwnProps) => 
     variant = popoverContentPropDefs.variant.default,
     // Positioner props
     anchor,
-    alignment = 'start',
+    alignment = 'center',
     side,
     sideOffset = 8,
     alignmentOffset,

--- a/packages/frosted-ui/src/components/popover/popover.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.tsx
@@ -40,6 +40,7 @@ interface PopoverContentProps extends Omit<
   collisionPadding?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['collisionPadding'];
   arrowPadding?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['arrowPadding'];
   sticky?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['sticky'];
+  disableAnchorTracking?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['disableAnchorTracking'];
 }
 
 const PopoverContent = (props: PopoverContentProps & PopoverContentOwnProps) => {
@@ -58,6 +59,7 @@ const PopoverContent = (props: PopoverContentProps & PopoverContentOwnProps) => 
     collisionPadding = 10,
     arrowPadding,
     sticky,
+    disableAnchorTracking,
     // Popup props
     ...popupProps
   } = props;
@@ -74,6 +76,7 @@ const PopoverContent = (props: PopoverContentProps & PopoverContentOwnProps) => 
         collisionPadding={collisionPadding}
         arrowPadding={arrowPadding}
         sticky={sticky}
+        disableAnchorTracking={disableAnchorTracking}
       >
         <Theme asChild>
           <PopoverPrimitive.Popup

--- a/packages/frosted-ui/src/components/popover/popover.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.tsx
@@ -38,6 +38,8 @@ interface PopoverContentProps extends Omit<
   sideOffset?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['sideOffset'];
   alignmentOffset?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['alignOffset'];
   collisionPadding?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['collisionPadding'];
+  collisionBoundary?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['collisionBoundary'];
+  collisionAvoidance?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['collisionAvoidance'];
   arrowPadding?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['arrowPadding'];
   sticky?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['sticky'];
   disableAnchorTracking?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['disableAnchorTracking'];
@@ -57,6 +59,8 @@ const PopoverContent = (props: PopoverContentProps & PopoverContentOwnProps) => 
     sideOffset = 8,
     alignmentOffset,
     collisionPadding = 10,
+    collisionBoundary,
+    collisionAvoidance,
     arrowPadding,
     sticky,
     disableAnchorTracking,
@@ -74,6 +78,8 @@ const PopoverContent = (props: PopoverContentProps & PopoverContentOwnProps) => 
         sideOffset={sideOffset}
         alignOffset={alignmentOffset}
         collisionPadding={collisionPadding}
+        collisionBoundary={collisionBoundary}
+        collisionAvoidance={collisionAvoidance}
         arrowPadding={arrowPadding}
         sticky={sticky}
         disableAnchorTracking={disableAnchorTracking}

--- a/packages/frosted-ui/src/components/popover/popover.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.tsx
@@ -1,66 +1,105 @@
 'use client';
 
+import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
 import classNames from 'classnames';
-import { Popover as PopoverPrimitive } from 'radix-ui';
 import * as React from 'react';
 import { Theme } from '../../theme';
 import { popoverContentPropDefs } from './popover.props';
 
 import type { GetPropDefTypes } from '../../helpers';
 
-interface PopoverRootProps extends React.ComponentProps<typeof PopoverPrimitive.Root> {}
+type PopoverRootOwnProps = Omit<React.ComponentProps<typeof PopoverPrimitive.Root>, 'className' | 'render'>;
+interface PopoverRootProps extends PopoverRootOwnProps {}
 const PopoverRoot: React.FC<PopoverRootProps> = (props: PopoverRootProps) => <PopoverPrimitive.Root {...props} />;
 PopoverRoot.displayName = 'PopoverRoot';
 
-interface PopoverTriggerProps extends Omit<React.ComponentProps<typeof PopoverPrimitive.Trigger>, 'asChild'> {}
+interface PopoverTriggerProps extends Omit<
+  React.ComponentProps<typeof PopoverPrimitive.Trigger>,
+  'className' | 'render'
+> {}
 
-const PopoverTrigger = (props: PopoverTriggerProps) => <PopoverPrimitive.Trigger {...props} asChild />;
+const PopoverTrigger = ({ children, ...props }: PopoverTriggerProps) => (
+  <PopoverPrimitive.Trigger {...props} render={children as React.ReactElement} />
+);
 PopoverTrigger.displayName = 'PopoverTrigger';
 
 type PopoverContentOwnProps = GetPropDefTypes<typeof popoverContentPropDefs>;
-interface PopoverContentProps
-  extends Omit<React.ComponentProps<typeof PopoverPrimitive.Content>, 'asChild'>,
-    PopoverContentOwnProps {
+interface PopoverContentProps extends Omit<
+  React.ComponentProps<typeof PopoverPrimitive.Popup>,
+  'className' | 'render'
+> {
+  className?: string;
   container?: React.ComponentProps<typeof PopoverPrimitive.Portal>['container'];
+  keepMounted?: React.ComponentProps<typeof PopoverPrimitive.Portal>['keepMounted'];
+  // Positioner props - we expose `alignment` which maps to Base UI's `align`
+  alignment?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['align'];
+  side?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['side'];
+  sideOffset?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['sideOffset'];
+  alignmentOffset?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['alignOffset'];
+  collisionPadding?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['collisionPadding'];
+  arrowPadding?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['arrowPadding'];
+  sticky?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['sticky'];
 }
 
-const PopoverContent = (props: PopoverContentProps) => {
+const PopoverContent = (props: PopoverContentProps & PopoverContentOwnProps) => {
   const {
     className,
-    forceMount,
+    keepMounted,
     container,
     size = popoverContentPropDefs.size.default,
     variant = popoverContentPropDefs.variant.default,
-    ...contentProps
+    // Positioner props
+    alignment = 'start',
+    side,
+    sideOffset = 8,
+    alignmentOffset,
+    collisionPadding = 10,
+    arrowPadding,
+    sticky,
+    // Popup props
+    ...popupProps
   } = props;
+
   return (
-    <PopoverPrimitive.Portal container={container} forceMount={forceMount}>
-      <Theme asChild>
-        <PopoverPrimitive.Content
-          align="start"
-          sideOffset={8}
-          collisionPadding={10}
-          {...contentProps}
-          className={classNames(
-            'fui-PopperContent',
-            'fui-PopoverContent',
-            `fui-variant-${variant}`,
-            className,
-            `fui-r-size-${size}`,
-          )}
-        />
-      </Theme>
+    <PopoverPrimitive.Portal container={container} keepMounted={keepMounted}>
+      <PopoverPrimitive.Positioner
+        className="fui-PopoverPositioner"
+        align={alignment}
+        side={side}
+        sideOffset={sideOffset}
+        alignOffset={alignmentOffset}
+        collisionPadding={collisionPadding}
+        arrowPadding={arrowPadding}
+        sticky={sticky}
+      >
+        <Theme asChild>
+          <PopoverPrimitive.Popup
+            {...popupProps}
+            className={classNames('fui-PopoverContent', `fui-variant-${variant}`, className, `fui-r-size-${size}`)}
+          />
+        </Theme>
+      </PopoverPrimitive.Positioner>
     </PopoverPrimitive.Portal>
   );
 };
 PopoverContent.displayName = 'PopoverContent';
 
-interface PopoverCloseProps extends Omit<React.ComponentProps<typeof PopoverPrimitive.Close>, 'asChild'> {}
+interface PopoverCloseProps extends Omit<React.ComponentProps<typeof PopoverPrimitive.Close>, 'className' | 'render'> {}
 
-const PopoverClose = (props: PopoverCloseProps) => <PopoverPrimitive.Close {...props} asChild />;
+const PopoverClose = ({ children, ...props }: PopoverCloseProps) => (
+  <PopoverPrimitive.Close {...props} render={children as React.ReactElement} />
+);
 PopoverClose.displayName = 'PopoverClose';
 
-export { PopoverClose as Close, PopoverContent as Content, PopoverRoot as Root, PopoverTrigger as Trigger };
+const createHandle = PopoverPrimitive.createHandle;
+
+export {
+  PopoverClose as Close,
+  PopoverContent as Content,
+  createHandle,
+  PopoverRoot as Root,
+  PopoverTrigger as Trigger,
+};
 export type {
   PopoverCloseProps as CloseProps,
   PopoverContentProps as ContentProps,

--- a/packages/frosted-ui/src/components/popover/popover.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.tsx
@@ -13,7 +13,12 @@ interface PopoverRootProps extends PopoverRootOwnProps {}
 const PopoverRoot: React.FC<PopoverRootProps> = (props: PopoverRootProps) => <PopoverPrimitive.Root {...props} />;
 PopoverRoot.displayName = 'PopoverRoot';
 
-interface PopoverTriggerProps extends Omit<React.ComponentProps<typeof PopoverPrimitive.Trigger>, 'render'> {}
+interface PopoverTriggerProps extends Omit<
+  React.ComponentProps<typeof PopoverPrimitive.Trigger>,
+  'render' | 'className'
+> {
+  className?: string;
+}
 
 const PopoverTrigger = ({ children, ...props }: PopoverTriggerProps) => (
   <PopoverPrimitive.Trigger {...props} render={children as React.ReactElement} />

--- a/packages/frosted-ui/src/components/popover/popover.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.tsx
@@ -32,6 +32,7 @@ interface PopoverContentProps extends Omit<
   container?: React.ComponentProps<typeof PopoverPrimitive.Portal>['container'];
   keepMounted?: React.ComponentProps<typeof PopoverPrimitive.Portal>['keepMounted'];
   // Positioner props - we expose `alignment` which maps to Base UI's `align`
+  anchor?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['anchor'];
   alignment?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['align'];
   side?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['side'];
   sideOffset?: React.ComponentProps<typeof PopoverPrimitive.Positioner>['sideOffset'];
@@ -49,6 +50,7 @@ const PopoverContent = (props: PopoverContentProps & PopoverContentOwnProps) => 
     size = popoverContentPropDefs.size.default,
     variant = popoverContentPropDefs.variant.default,
     // Positioner props
+    anchor,
     alignment = 'start',
     side,
     sideOffset = 8,
@@ -64,6 +66,7 @@ const PopoverContent = (props: PopoverContentProps & PopoverContentOwnProps) => 
     <PopoverPrimitive.Portal container={container} keepMounted={keepMounted}>
       <PopoverPrimitive.Positioner
         className="fui-PopoverPositioner"
+        anchor={anchor}
         align={alignment}
         side={side}
         sideOffset={sideOffset}

--- a/packages/frosted-ui/src/components/popover/popover.tsx
+++ b/packages/frosted-ui/src/components/popover/popover.tsx
@@ -13,10 +13,7 @@ interface PopoverRootProps extends PopoverRootOwnProps {}
 const PopoverRoot: React.FC<PopoverRootProps> = (props: PopoverRootProps) => <PopoverPrimitive.Root {...props} />;
 PopoverRoot.displayName = 'PopoverRoot';
 
-interface PopoverTriggerProps extends Omit<
-  React.ComponentProps<typeof PopoverPrimitive.Trigger>,
-  'className' | 'render'
-> {}
+interface PopoverTriggerProps extends Omit<React.ComponentProps<typeof PopoverPrimitive.Trigger>, 'render'> {}
 
 const PopoverTrigger = ({ children, ...props }: PopoverTriggerProps) => (
   <PopoverPrimitive.Trigger {...props} render={children as React.ReactElement} />

--- a/packages/frosted-ui/src/styles/animations.css
+++ b/packages/frosted-ui/src/styles/animations.css
@@ -92,6 +92,7 @@
   .fui-PopperContent {
     animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
 
+    /* Radix UI (legacy) */
     &:where([data-state='open']) {
       animation-duration: 300ms;
 
@@ -110,6 +111,41 @@
     }
 
     &:where([data-state='closed']) {
+      animation-duration: 150ms;
+
+      &:where([data-side='top']) {
+        animation-name: fui-slide-to-top, fui-fade-out;
+      }
+      &:where([data-side='bottom']) {
+        animation-name: fui-slide-to-bottom, fui-fade-out;
+      }
+      &:where([data-side='left']) {
+        animation-name: fui-slide-to-left, fui-fade-out;
+      }
+      &:where([data-side='right']) {
+        animation-name: fui-slide-to-right, fui-fade-out;
+      }
+    }
+
+    /* Base UI */
+    &:where([data-open]) {
+      animation-duration: 300ms;
+
+      &:where([data-side='top']) {
+        animation-name: fui-slide-from-top, fui-fade-in;
+      }
+      &:where([data-side='bottom']) {
+        animation-name: fui-slide-from-bottom, fui-fade-in;
+      }
+      &:where([data-side='left']) {
+        animation-name: fui-slide-from-left, fui-fade-in;
+      }
+      &:where([data-side='right']) {
+        animation-name: fui-slide-from-right, fui-fade-in;
+      }
+    }
+
+    &:where([data-ending-style]) {
       animation-duration: 150ms;
 
       &:where([data-side='top']) {


### PR DESCRIPTION
# Migrate Popover and HoverCard to Base UI

This PR migrates `Popover` and `HoverCard` components from Radix UI to Base UI primitives, bringing improved features, better animations, and more control over positioning and focus management.

## Breaking Changes

### Renamed Props

| Component         | Old Prop     | New Prop      |
| ----------------- | ------------ | ------------- |
| Popover.Content   | `align`      | `alignment`   |
| Popover.Content   | `forceMount` | `keepMounted` |
| HoverCard.Content | `align`      | `alignment`   |
| HoverCard.Content | `forceMount` | `keepMounted` |

### Moved Props

| Component | Prop         | Old Location     | New Location        |
| --------- | ------------ | ---------------- | ------------------- |
| HoverCard | `delay`      | `HoverCard.Root` | `HoverCard.Trigger` |
| HoverCard | `closeDelay` | `HoverCard.Root` | `HoverCard.Trigger` |

### Renamed CSS Variables

| Old Variable                                  | New Variable         |
| --------------------------------------------- | -------------------- |
| `--radix-popover-trigger-width`               | `--anchor-width`     |
| `--radix-popover-content-transform-origin`    | `--transform-origin` |
| `--radix-hover-card-content-transform-origin` | `--transform-origin` |

## New Features

### Popover

#### New Content Props

- **`anchor`** - Position the popover relative to a different element than the trigger
- **`disableAnchorTracking`** - Disable position updates when anchor moves (layout changes)
- **`sticky`** - Keep popover visible at viewport edge when anchor scrolls away
- **`collisionBoundary`** - Define a custom boundary for collision detection
- **`collisionAvoidance`** - Configure flip/shift behavior (`{ side: 'flip' | 'shift' | 'none', align: 'shift' | 'none' }`)
- **`initialFocus`** - Control which element receives focus when popover opens (`boolean | RefObject | function`)
- **`finalFocus`** - Control where focus returns when popover closes (`boolean | RefObject | function`)

#### New Root Props

- **`modal`** - Modal behavior: `true` (full modal), `false` (non-modal), `"trap-focus"` (focus trapped only)
- **`actionsRef`** - Imperative control with `close()` method
- **`onOpenChangeComplete`** - Callback fired after open/close animations complete
- **`handle`** - Connect to `Popover.createHandle()` for detached/multiple triggers
- **`triggerId`** - For controlled mode with multiple triggers

#### New Trigger Props

- **`openOnHover`** - Open the popover on hover instead of click
- **`delay`** - Delay before opening (when using `openOnHover`)
- **`handle`** - Connect detached triggers to a popover
- **`payload`** - Pass data to the popover content (accessible via render function)
- **`id`** - Identify triggers when using multiple triggers

#### New Export

- **`Popover.createHandle()`** - Create a handle for detached triggers or multiple triggers sharing one popover

### HoverCard

#### New Content Props

- **`anchor`** - Position relative to a different element than the trigger
- **`disableAnchorTracking`** - Disable position updates when anchor moves
- **`sticky`** - Keep hover card visible at viewport edge
- **`collisionBoundary`** - Define a custom collision boundary
- **`collisionAvoidance`** - Configure flip/shift behavior

#### New Trigger Props

- **`delay`** - Delay before opening (default: 200ms)
- **`closeDelay`** - Delay before closing (default: 150ms)

#### New Root Props

- **`onOpenChangeComplete`** - Callback fired after animations complete

## Bug Fixes

- Fixed text alignment issue where content could be right-aligned when popover positioned from the right edge (added `text-align: start`)
- Fixed dark mode outline styling for both components

## Animation Changes

- Migrated from keyframe animations to CSS transitions with `data-starting-style` and `data-ending-style` attributes
- Exit animations now work correctly without requiring `keepMounted`

## Storybook

Added comprehensive demos for all new features:

- Opening on hover
- Detached triggers
- Multiple triggers with payload
- Controlled mode
- Custom anchor positioning
- Anchor tracking behavior
- Sticky positioning
- Collision boundary and avoidance
- Modal behavior
- Focus management (initialFocus, finalFocus)
- Open change callbacks
- Imperative control with actionsRef

---

## Migration Guide

```diff
// Popover
<Popover.Content
-  align="start"
+  alignment="start"
-  forceMount
+  keepMounted
>

// HoverCard - Content props
<HoverCard.Content
-  align="start"
+  alignment="start"
-  forceMount
+  keepMounted
>

// HoverCard - delay moved from Root to Trigger
- <HoverCard.Root openDelay={200} closeDelay={300}>
-   <HoverCard.Trigger>
+ <HoverCard.Root>
+   <HoverCard.Trigger delay={200} closeDelay={300}>
```

CSS variable updates (if using custom styles):

```diff
-.my-popover {
-  min-width: var(--radix-popover-trigger-width);
-  transform-origin: var(--radix-popover-content-transform-origin);
+  min-width: var(--anchor-width);
+  transform-origin: var(--transform-origin);
}
```
