### PR TITLE
Unfuck rn primitives

### DIFF
--- a/packages/frosted-ui-react-native/docs/RN_PRIMITIVES_PORTAL_ISSUE.md
+++ b/packages/frosted-ui-react-native/docs/RN_PRIMITIVES_PORTAL_ISSUE.md
@@ -1,0 +1,153 @@
+# @rn-primitives Portal Issue in Pure React Native
+
+## TL;DR
+
+`@rn-primitives` portal-based components (Dialog, DropdownMenu, Popover, etc.) don't work in **pure React Native** (non-Expo) due to two bugs:
+
+1. **Portal hostName bug**: Passing `hostName={undefined}` breaks portal routing
+2. **Context loss bug**: React context doesn't survive portal boundaries
+
+**Symptoms**: Components open (state changes to `open=true`) but nothing appears on screen. No errors.
+
+---
+
+## Bug #1: Portal hostName Prop
+
+### The Problem
+
+When `hostName` is `undefined`, the primitives pass it explicitly:
+
+```jsx
+// Inside @rn-primitives/dialog, dropdown-menu, etc.
+<Portal hostName={hostName}>  // hostName is undefined
+```
+
+This is **not equivalent** to:
+
+```jsx
+<Portal>  // Would use default "INTERNAL_PRIMITIVE_DEFAULT_HOST_NAME"
+```
+
+Passing `hostName={undefined}` explicitly sets the prop to `undefined`, bypassing the default parameter. The portal content gets stored under key `undefined` in the zustand store, but `<PortalHost>` looks for key `"INTERNAL_PRIMITIVE_DEFAULT_HOST_NAME"`.
+
+### The Fix
+
+Only pass `hostName` when it's defined:
+
+```jsx
+// Before (broken):
+<DialogPrimitive.Portal hostName={portalHost}>
+
+// After (fixed):
+<DialogPrimitive.Portal {...(portalHost && { hostName: portalHost })}>
+```
+
+---
+
+## Bug #2: Context Loss Through Portal
+
+### The Problem
+
+`@rn-primitives/portal` works by:
+1. Storing children in a **Zustand store**
+2. Rendering them at `<PortalHost />` (at app root)
+
+The children are **unmounted** from their original location and **remounted** at PortalHost. They're no longer descendants of the primitive's Root component, so context is lost:
+
+```
+DialogPrimitive.Root (provides context)
+  └── DialogPrimitive.Portal
+        ↓ teleports to PortalHost (OUTSIDE Root)
+        
+<PortalHost />
+  └── DialogPrimitive.Title 
+        ❌ Crash: "Dialog compound components cannot be rendered outside the Dialog component"
+```
+
+### The Fix
+
+Capture context **before** the portal, re-provide it inside:
+
+```jsx
+function DialogContent({ children }) {
+  // Capture BEFORE portal boundary
+  const primitiveContext = DialogPrimitive.useRootContext();
+  
+  return (
+    <DialogPrimitive.Portal {...(portalHost && { hostName: portalHost })}>
+      <OurContext.Provider value={{ 
+        nativeID: primitiveContext.nativeID,
+        onOpenChange: primitiveContext.onOpenChange 
+      }}>
+        {children}
+      </OurContext.Provider>
+    </DialogPrimitive.Portal>
+  );
+}
+
+// Then in Title, use OurContext instead of DialogPrimitive.Title:
+function DialogTitle({ children }) {
+  const { nativeID } = useContext(OurContext);
+  return <Heading nativeID={`${nativeID}_label`}>{children}</Heading>;
+}
+```
+
+---
+
+## Affected Components
+
+All portal-based primitives:
+- `@rn-primitives/dialog`
+- `@rn-primitives/alert-dialog`
+- `@rn-primitives/dropdown-menu`
+- `@rn-primitives/popover`
+- `@rn-primitives/select`
+- `@rn-primitives/context-menu`
+- `@rn-primitives/tooltip`
+- `@rn-primitives/hover-card`
+
+---
+
+## Why It Works in Expo
+
+Expo apps typically work because:
+- Different initialization timing
+- Expo's bundler may handle things differently
+- The portal store state may initialize in a way that masks the bug
+
+The bug specifically manifests in **pure React Native CLI projects**.
+
+---
+
+## Related Issues
+
+- [react-native-reusables #405](https://github.com/founded-labs/react-native-reusables/issues/405) - Same symptoms reported
+
+---
+
+## Recommended Upstream Fix
+
+The `@rn-primitives` packages should:
+
+1. **Fix hostName handling** in Portal:
+   ```jsx
+   function Portal({ hostName, children }) {
+     const resolvedHostName = hostName ?? DEFAULT_HOST;
+     // Use resolvedHostName everywhere
+   }
+   ```
+
+2. **Re-provide context inside Portal**:
+   ```jsx
+   function Portal({ children }) {
+     const rootContext = useRootContext();
+     return (
+       <PortalPrimitive>
+         <RootContext.Provider value={rootContext}>
+           {children}
+         </RootContext.Provider>
+       </PortalPrimitive>
+     );
+   }
+   ```
+

--- a/packages/frosted-ui-react-native/package.json
+++ b/packages/frosted-ui-react-native/package.json
@@ -65,7 +65,8 @@
     "@rn-primitives/tabs": "^1.2.0",
     "@rn-primitives/toggle": "^1.2.0",
     "@rn-primitives/toggle-group": "^1.2.0",
-    "@rn-primitives/tooltip": "^1.2.0"
+    "@rn-primitives/tooltip": "^1.2.0",
+    "@rn-primitives/types": "^1.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/packages/frosted-ui-react-native/src/components/alert-dialog.tsx
+++ b/packages/frosted-ui-react-native/src/components/alert-dialog.tsx
@@ -70,10 +70,6 @@ function AlertDialogOverlay({ children, primitiveContext, ...props }: AlertDialo
   // Native: AlertDialog should NOT dismiss on backdrop tap, so we use View (not Pressable)
   const nativeBackdropStyle = getDialogBackdropStyle();
 
-  // On native, re-provide context after FullWindowOverlay breaks it
-  const ContextProvider = AlertDialogPrimitive.AlertDialogContext?.Provider;
-  const shouldProvideContext = ContextProvider && primitiveContext;
-
   const overlayContent = (
     <AlertDialogPrimitive.Overlay {...props} asChild>
       <View style={overlayStyle}>
@@ -92,15 +88,19 @@ function AlertDialogOverlay({ children, primitiveContext, ...props }: AlertDialo
     </AlertDialogPrimitive.Overlay>
   );
 
-  return (
-    <FullWindowOverlay>
-      {shouldProvideContext ? (
-        <ContextProvider value={primitiveContext}>{overlayContent}</ContextProvider>
-      ) : (
-        overlayContent
-      )}
-    </FullWindowOverlay>
-  );
+  // On native, re-provide context after FullWindowOverlay breaks it
+  // (we're already in native branch after the web check above)
+  if (primitiveContext && AlertDialogPrimitive.AlertDialogContext) {
+    return (
+      <FullWindowOverlay>
+        <AlertDialogPrimitive.AlertDialogContext.Provider value={primitiveContext}>
+          {overlayContent}
+        </AlertDialogPrimitive.AlertDialogContext.Provider>
+      </FullWindowOverlay>
+    );
+  }
+
+  return <FullWindowOverlay>{overlayContent}</FullWindowOverlay>;
 }
 AlertDialogOverlay.displayName = 'AlertDialog.Overlay';
 

--- a/packages/frosted-ui-react-native/src/components/alert-dialog.tsx
+++ b/packages/frosted-ui-react-native/src/components/alert-dialog.tsx
@@ -115,7 +115,7 @@ function useAlertDialogRootContext() {
   if (Platform.OS === 'web' || !AlertDialogPrimitive.useRootContext) {
     return null;
   }
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+
   return AlertDialogPrimitive.useRootContext();
 }
 
@@ -300,5 +300,6 @@ export type {
   AlertDialogDescriptionProps as DescriptionProps,
   AlertDialogRootProps as RootProps,
   AlertDialogTitleProps as TitleProps,
-  AlertDialogTriggerProps as TriggerProps,
+  AlertDialogTriggerProps as TriggerProps
 };
+

--- a/packages/frosted-ui-react-native/src/components/context-menu.tsx
+++ b/packages/frosted-ui-react-native/src/components/context-menu.tsx
@@ -131,7 +131,7 @@ function useContextMenuRootContext() {
   if (Platform.OS === 'web' || !ContextMenuPrimitive.useRootContext) {
     return null;
   }
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+
   return ContextMenuPrimitive.useRootContext();
 }
 
@@ -764,23 +764,24 @@ export {
   ContextMenuSub,
   ContextMenuSubContent,
   ContextMenuSubTrigger,
-  ContextMenuTrigger,
+  ContextMenuTrigger
 };
 
-export type {
-  ContextMenuCheckboxItemProps,
-  ContextMenuContentProps,
-  ContextMenuGroupProps,
-  ContextMenuItemProps,
-  ContextMenuLabelProps,
-  ContextMenuRadioGroupProps,
-  ContextMenuRadioItemProps,
-  ContextMenuRootProps,
-  ContextMenuSeparatorProps,
-  ContextMenuSize,
-  ContextMenuSubContentProps,
-  ContextMenuSubProps,
-  ContextMenuSubTriggerProps,
-  ContextMenuTriggerProps,
-  ContextMenuVariant,
-};
+  export type {
+    ContextMenuCheckboxItemProps,
+    ContextMenuContentProps,
+    ContextMenuGroupProps,
+    ContextMenuItemProps,
+    ContextMenuLabelProps,
+    ContextMenuRadioGroupProps,
+    ContextMenuRadioItemProps,
+    ContextMenuRootProps,
+    ContextMenuSeparatorProps,
+    ContextMenuSize,
+    ContextMenuSubContentProps,
+    ContextMenuSubProps,
+    ContextMenuSubTriggerProps,
+    ContextMenuTriggerProps,
+    ContextMenuVariant
+  };
+

--- a/packages/frosted-ui-react-native/src/components/context-menu.tsx
+++ b/packages/frosted-ui-react-native/src/components/context-menu.tsx
@@ -186,8 +186,9 @@ function ContextMenuContent({ portalHost, children, ...props }: ContextMenuConte
   const backgroundColor = variant === 'solid' ? colors.panelSolid : colors.panelTranslucent;
 
   // On native, re-provide context after FullWindowOverlay breaks it
-  const ContextProvider = ContextMenuPrimitive.ContextMenuContext?.Provider;
-  const shouldProvideContext = Platform.OS !== 'web' && ContextProvider && primitiveContext;
+  const ContextProvider =
+    Platform.OS !== 'web' ? ContextMenuPrimitive.ContextMenuContext?.Provider : null;
+  const shouldProvideContext = ContextProvider && primitiveContext;
 
   const content = (
     <ContextMenuPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>

--- a/packages/frosted-ui-react-native/src/components/dialog.tsx
+++ b/packages/frosted-ui-react-native/src/components/dialog.tsx
@@ -81,10 +81,6 @@ function DialogOverlay({ children, primitiveContext, ...props }: DialogOverlayPr
   // The Pressable receives onPress from the primitive to close the dialog when backdrop is tapped
   const nativeBackdropStyle = getDialogBackdropStyle();
 
-  // On native, re-provide context after FullWindowOverlay breaks it
-  const ContextProvider = DialogPrimitive.DialogContext?.Provider;
-  const shouldProvideContext = ContextProvider && primitiveContext;
-
   const overlayContent = (
     <DialogPrimitive.Overlay {...props} asChild>
       <Pressable style={overlayStyle}>
@@ -103,15 +99,19 @@ function DialogOverlay({ children, primitiveContext, ...props }: DialogOverlayPr
     </DialogPrimitive.Overlay>
   );
 
-  return (
-    <FullWindowOverlay>
-      {shouldProvideContext ? (
-        <ContextProvider value={primitiveContext}>{overlayContent}</ContextProvider>
-      ) : (
-        overlayContent
-      )}
-    </FullWindowOverlay>
-  );
+  // On native, re-provide context after FullWindowOverlay breaks it
+  // (we're already in native branch after the web check above)
+  if (primitiveContext && DialogPrimitive.DialogContext) {
+    return (
+      <FullWindowOverlay>
+        <DialogPrimitive.DialogContext.Provider value={primitiveContext}>
+          {overlayContent}
+        </DialogPrimitive.DialogContext.Provider>
+      </FullWindowOverlay>
+    );
+  }
+
+  return <FullWindowOverlay>{overlayContent}</FullWindowOverlay>;
 }
 DialogOverlay.displayName = 'Dialog.Overlay';
 

--- a/packages/frosted-ui-react-native/src/components/dropdown-menu.tsx
+++ b/packages/frosted-ui-react-native/src/components/dropdown-menu.tsx
@@ -1,8 +1,8 @@
 import { NativeOnlyAnimatedView } from '@/components/native-only-animated-view';
 import { Text, TextStyleContext, type TextSize } from '@/components/text';
+import { DropdownMenuPrimitive } from '@/forked-primitives';
 import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
-import * as DropdownMenuPrimitive from '@rn-primitives/dropdown-menu';
 import * as React from 'react';
 import {
   Platform,
@@ -137,6 +137,9 @@ function DropdownMenuContent({ portalHost, children, ...props }: DropdownMenuCon
   const { height: windowHeight } = useWindowDimensions();
   const safeAreaInsets = useSafeAreaInsets();
 
+  // Capture primitive context BEFORE the portal/FullWindowOverlay
+  const primitiveContext = DropdownMenuPrimitive.useRootContext();
+
   const sizeStyles = getMenuSizeStyles(size);
 
   // Calculate available height for native
@@ -181,8 +184,10 @@ function DropdownMenuContent({ portalHost, children, ...props }: DropdownMenuCon
   return (
     <DropdownMenuPrimitive.Portal hostName={portalHost}>
       <FullWindowOverlay>
-        <DropdownMenuPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>
-          <DropdownMenuContext.Provider value={contextValue}>
+        {/* Re-provide DropdownMenuPrimitive context after FullWindowOverlay breaks context */}
+        <DropdownMenuPrimitive.DropdownMenuContext.Provider value={primitiveContext}>
+          <DropdownMenuPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>
+            <DropdownMenuContext.Provider value={contextValue}>
             <TextStyleContext.Provider value={{ size: '2', weight: 'regular', color: 'gray' }}>
               <NativeOnlyAnimatedView entering={FadeIn} exiting={FadeOut}>
                 <DropdownMenuPrimitive.Content
@@ -242,6 +247,7 @@ function DropdownMenuContent({ portalHost, children, ...props }: DropdownMenuCon
             </TextStyleContext.Provider>
           </DropdownMenuContext.Provider>
         </DropdownMenuPrimitive.Overlay>
+        </DropdownMenuPrimitive.DropdownMenuContext.Provider>
       </FullWindowOverlay>
     </DropdownMenuPrimitive.Portal>
   );
@@ -746,23 +752,24 @@ export {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
+  DropdownMenuTrigger
 };
 
-export type {
-  DropdownMenuCheckboxItemProps,
-  DropdownMenuContentProps,
-  DropdownMenuGroupProps,
-  DropdownMenuItemProps,
-  DropdownMenuLabelProps,
-  DropdownMenuRadioGroupProps,
-  DropdownMenuRadioItemProps,
-  DropdownMenuRootProps,
-  DropdownMenuSeparatorProps,
-  DropdownMenuSize,
-  DropdownMenuSubContentProps,
-  DropdownMenuSubProps,
-  DropdownMenuSubTriggerProps,
-  DropdownMenuTriggerProps,
-  DropdownMenuVariant,
-};
+  export type {
+    DropdownMenuCheckboxItemProps,
+    DropdownMenuContentProps,
+    DropdownMenuGroupProps,
+    DropdownMenuItemProps,
+    DropdownMenuLabelProps,
+    DropdownMenuRadioGroupProps,
+    DropdownMenuRadioItemProps,
+    DropdownMenuRootProps,
+    DropdownMenuSeparatorProps,
+    DropdownMenuSize,
+    DropdownMenuSubContentProps,
+    DropdownMenuSubProps,
+    DropdownMenuSubTriggerProps,
+    DropdownMenuTriggerProps,
+    DropdownMenuVariant
+  };
+

--- a/packages/frosted-ui-react-native/src/components/dropdown-menu.tsx
+++ b/packages/frosted-ui-react-native/src/components/dropdown-menu.tsx
@@ -131,14 +131,22 @@ type DropdownMenuContentProps = Omit<DropdownMenuPrimitive.ContentProps, 'childr
   children?: React.ReactNode;
 };
 
+// Helper to safely get primitive context on native (not available on web)
+function useDropdownMenuRootContext() {
+  if (Platform.OS === 'web' || !DropdownMenuPrimitive.useRootContext) {
+    return null;
+  }
+  return DropdownMenuPrimitive.useRootContext();
+}
+
 function DropdownMenuContent({ portalHost, children, ...props }: DropdownMenuContentProps) {
   const { size, variant, color } = React.useContext(DropdownMenuContext);
   const { colors, isDark } = useThemeTokens();
   const { height: windowHeight } = useWindowDimensions();
   const safeAreaInsets = useSafeAreaInsets();
 
-  // Capture primitive context BEFORE the portal/FullWindowOverlay
-  const primitiveContext = DropdownMenuPrimitive.useRootContext();
+  // Capture primitive context BEFORE the portal/FullWindowOverlay (native only)
+  const primitiveContext = useDropdownMenuRootContext();
 
   const sizeStyles = getMenuSizeStyles(size);
 
@@ -181,73 +189,82 @@ function DropdownMenuContent({ portalHost, children, ...props }: DropdownMenuCon
 
   const backgroundColor = variant === 'solid' ? colors.panelSolid : colors.panelTranslucent;
 
+  // On native, re-provide context after FullWindowOverlay breaks it
+  const ContextProvider = DropdownMenuPrimitive.DropdownMenuContext?.Provider;
+  const shouldProvideContext = Platform.OS !== 'web' && ContextProvider && primitiveContext;
+
+  const content = (
+    <DropdownMenuPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>
+      <DropdownMenuContext.Provider value={contextValue}>
+        <TextStyleContext.Provider value={{ size: '2', weight: 'regular', color: 'gray' }}>
+          <NativeOnlyAnimatedView entering={FadeIn} exiting={FadeOut}>
+            <DropdownMenuPrimitive.Content
+              align="start"
+              sideOffset={4}
+              insets={Platform.OS !== 'web' ? contentInsets : undefined}
+              style={{
+                backgroundColor,
+                borderRadius: sizeStyles.contentBorderRadius,
+                minWidth: 128,
+                ...Platform.select({
+                  web: {
+                    boxShadow: isDark
+                      ? `0 0 0 1px ${colors.palettes.gray.a6}, 0 12px 60px ${colors.palettes.black.a5}, 0 12px 32px -16px ${colors.palettes.black.a7}`
+                      : `0 0 0 1px ${colors.palettes.gray.a5}, 0 12px 60px ${colors.palettes.black.a3}, 0 12px 32px -16px ${colors.palettes.gray.a5}`,
+                    backdropFilter:
+                      variant === 'soft'
+                        ? 'saturate(1.8) blur(20px) contrast(1.05) brightness(1.05)'
+                        : undefined,
+                    overflow: 'hidden',
+                  },
+                  default: {
+                    maxHeight: nativeMaxHeight,
+                    borderWidth: 1,
+                    borderColor: isDark ? colors.palettes.gray.a6 : colors.palettes.gray.a5,
+                    shadowColor: '#000000',
+                    shadowOpacity: isDark ? 0.3 : 0.15,
+                    shadowOffset: { width: 0, height: 12 },
+                    shadowRadius: 30,
+                    elevation: 12,
+                  },
+                }),
+              }}
+              {...props}>
+              {Platform.OS === 'web' ? (
+                <View
+                  style={
+                    {
+                      padding: sizeStyles.contentPadding,
+                      maxHeight: 'var(--radix-dropdown-menu-content-available-height)',
+                      overflow: 'auto',
+                    } as unknown as ViewStyle
+                  }>
+                  {children}
+                </View>
+              ) : (
+                <ScrollView
+                  style={{ maxHeight: nativeMaxHeight - sizeStyles.contentPadding * 2 - 2 }}
+                  contentContainerStyle={{ padding: sizeStyles.contentPadding }}
+                  showsVerticalScrollIndicator
+                  bounces={false}>
+                  {children}
+                </ScrollView>
+              )}
+            </DropdownMenuPrimitive.Content>
+          </NativeOnlyAnimatedView>
+        </TextStyleContext.Provider>
+      </DropdownMenuContext.Provider>
+    </DropdownMenuPrimitive.Overlay>
+  );
+
   return (
     <DropdownMenuPrimitive.Portal hostName={portalHost}>
       <FullWindowOverlay>
-        {/* Re-provide DropdownMenuPrimitive context after FullWindowOverlay breaks context */}
-        <DropdownMenuPrimitive.DropdownMenuContext.Provider value={primitiveContext}>
-          <DropdownMenuPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>
-            <DropdownMenuContext.Provider value={contextValue}>
-            <TextStyleContext.Provider value={{ size: '2', weight: 'regular', color: 'gray' }}>
-              <NativeOnlyAnimatedView entering={FadeIn} exiting={FadeOut}>
-                <DropdownMenuPrimitive.Content
-                  align="start"
-                  sideOffset={4}
-                  insets={Platform.OS !== 'web' ? contentInsets : undefined}
-                  style={{
-                    backgroundColor,
-                    borderRadius: sizeStyles.contentBorderRadius,
-                    minWidth: 128,
-                    ...Platform.select({
-                      web: {
-                        boxShadow: isDark
-                          ? `0 0 0 1px ${colors.palettes.gray.a6}, 0 12px 60px ${colors.palettes.black.a5}, 0 12px 32px -16px ${colors.palettes.black.a7}`
-                          : `0 0 0 1px ${colors.palettes.gray.a5}, 0 12px 60px ${colors.palettes.black.a3}, 0 12px 32px -16px ${colors.palettes.gray.a5}`,
-                        backdropFilter:
-                          variant === 'soft'
-                            ? 'saturate(1.8) blur(20px) contrast(1.05) brightness(1.05)'
-                            : undefined,
-                        overflow: 'hidden',
-                      },
-                      default: {
-                        maxHeight: nativeMaxHeight,
-                        borderWidth: 1,
-                        borderColor: isDark ? colors.palettes.gray.a6 : colors.palettes.gray.a5,
-                        shadowColor: '#000000',
-                        shadowOpacity: isDark ? 0.3 : 0.15,
-                        shadowOffset: { width: 0, height: 12 },
-                        shadowRadius: 30,
-                        elevation: 12,
-                      },
-                    }),
-                  }}
-                  {...props}>
-                  {Platform.OS === 'web' ? (
-                    <View
-                      style={
-                        {
-                          padding: sizeStyles.contentPadding,
-                          maxHeight: 'var(--radix-dropdown-menu-content-available-height)',
-                          overflow: 'auto',
-                        } as unknown as ViewStyle
-                      }>
-                      {children}
-                    </View>
-                  ) : (
-                    <ScrollView
-                      style={{ maxHeight: nativeMaxHeight - sizeStyles.contentPadding * 2 - 2 }}
-                      contentContainerStyle={{ padding: sizeStyles.contentPadding }}
-                      showsVerticalScrollIndicator
-                      bounces={false}>
-                      {children}
-                    </ScrollView>
-                  )}
-                </DropdownMenuPrimitive.Content>
-              </NativeOnlyAnimatedView>
-            </TextStyleContext.Provider>
-          </DropdownMenuContext.Provider>
-        </DropdownMenuPrimitive.Overlay>
-        </DropdownMenuPrimitive.DropdownMenuContext.Provider>
+        {shouldProvideContext ? (
+          <ContextProvider value={primitiveContext}>{content}</ContextProvider>
+        ) : (
+          content
+        )}
       </FullWindowOverlay>
     </DropdownMenuPrimitive.Portal>
   );

--- a/packages/frosted-ui-react-native/src/components/dropdown-menu.tsx
+++ b/packages/frosted-ui-react-native/src/components/dropdown-menu.tsx
@@ -190,8 +190,9 @@ function DropdownMenuContent({ portalHost, children, ...props }: DropdownMenuCon
   const backgroundColor = variant === 'solid' ? colors.panelSolid : colors.panelTranslucent;
 
   // On native, re-provide context after FullWindowOverlay breaks it
-  const ContextProvider = DropdownMenuPrimitive.DropdownMenuContext?.Provider;
-  const shouldProvideContext = Platform.OS !== 'web' && ContextProvider && primitiveContext;
+  const ContextProvider =
+    Platform.OS !== 'web' ? DropdownMenuPrimitive.DropdownMenuContext?.Provider : null;
+  const shouldProvideContext = ContextProvider && primitiveContext;
 
   const content = (
     <DropdownMenuPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>

--- a/packages/frosted-ui-react-native/src/components/popover.tsx
+++ b/packages/frosted-ui-react-native/src/components/popover.tsx
@@ -94,8 +94,9 @@ function PopoverContent({
 
   // On native, re-provide context after FullWindowOverlay breaks it
   // On web, just render content directly (Radix handles its own context)
-  const ContextProvider = PopoverPrimitive.PopoverContext?.Provider;
-  const shouldProvideContext = Platform.OS !== 'web' && ContextProvider && primitiveContext;
+  const ContextProvider =
+    Platform.OS !== 'web' ? PopoverPrimitive.PopoverContext?.Provider : null;
+  const shouldProvideContext = ContextProvider && primitiveContext;
 
   return (
     <PopoverPrimitive.Portal hostName={portalHost}>

--- a/packages/frosted-ui-react-native/src/components/popover.tsx
+++ b/packages/frosted-ui-react-native/src/components/popover.tsx
@@ -52,7 +52,7 @@ function usePopoverRootContext() {
   if (Platform.OS === 'web' || !PopoverPrimitive.useRootContext) {
     return null;
   }
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+
   return PopoverPrimitive.useRootContext();
 }
 
@@ -129,3 +129,4 @@ const Popover: {
 
 export { Popover, PopoverClose, PopoverContent, PopoverRoot, PopoverTrigger };
 export type { PopoverContentProps, PopoverRootProps, PopoverSize, PopoverVariant };
+

--- a/packages/frosted-ui-react-native/src/components/select.tsx
+++ b/packages/frosted-ui-react-native/src/components/select.tsx
@@ -1,27 +1,27 @@
 import { NativeOnlyAnimatedView } from '@/components/native-only-animated-view';
 import { Text, TextStyleContext } from '@/components/text';
+import { SelectPrimitive } from '@/forked-primitives';
 import {
-  getButtonFocusStyle,
-  getButtonPressedFilter,
-  getButtonShadowStyle,
-  getButtonSizeStyle,
-  getButtonVariantStyle,
-  type ButtonSize,
-  type ButtonVariant,
+    getButtonFocusStyle,
+    getButtonPressedFilter,
+    getButtonShadowStyle,
+    getButtonSizeStyle,
+    getButtonVariantStyle,
+    type ButtonSize,
+    type ButtonVariant,
 } from '@/lib/button-styles';
 import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
-import * as SelectPrimitive from '@rn-primitives/select';
 import * as React from 'react';
 import {
-  Platform,
-  Pressable,
-  ScrollView,
-  StyleSheet,
-  useWindowDimensions,
-  View,
-  type StyleProp,
-  type ViewStyle,
+    Platform,
+    Pressable,
+    ScrollView,
+    StyleSheet,
+    useWindowDimensions,
+    View,
+    type StyleProp,
+    type ViewStyle,
 } from 'react-native';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -409,6 +409,9 @@ function SelectContent({ portalHost, position = 'popper', ...props }: SelectCont
   const selectContext = React.useContext(SelectContext);
   const { size, labelMap, value, open } = selectContext;
   const { colors, isDark } = useThemeTokens();
+
+  // Capture primitive context BEFORE the portal/FullWindowOverlay
+  const primitiveContext = SelectPrimitive.useRootContext();
   const { height: windowHeight } = useWindowDimensions();
   const safeAreaInsets = useSafeAreaInsets();
 
@@ -477,9 +480,11 @@ function SelectContent({ portalHost, position = 'popper', ...props }: SelectCont
   return (
     <SelectPrimitive.Portal hostName={portalHost}>
       <FullWindowOverlay>
-        <SelectPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>
-          {/* Re-provide context inside portal since it's lost on native */}
-          <SelectContext.Provider value={contextValue}>
+        {/* Re-provide SelectPrimitive context after FullWindowOverlay breaks context */}
+        <SelectPrimitive.SelectContext.Provider value={primitiveContext}>
+          <SelectPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>
+            {/* Re-provide our context inside portal since it's lost on native */}
+            <SelectContext.Provider value={contextValue}>
             <SelectContentContext.Provider value={contentContextValue}>
               <TextStyleContext.Provider value={{ size: '2', weight: 'regular', color: 'gray' }}>
                 <NativeOnlyAnimatedView entering={FadeIn} exiting={FadeOut}>
@@ -550,9 +555,10 @@ function SelectContent({ portalHost, position = 'popper', ...props }: SelectCont
                   </SelectPrimitive.Content>
                 </NativeOnlyAnimatedView>
               </TextStyleContext.Provider>
-            </SelectContentContext.Provider>
-          </SelectContext.Provider>
-        </SelectPrimitive.Overlay>
+              </SelectContentContext.Provider>
+            </SelectContext.Provider>
+          </SelectPrimitive.Overlay>
+        </SelectPrimitive.SelectContext.Provider>
       </FullWindowOverlay>
     </SelectPrimitive.Portal>
   );
@@ -812,24 +818,24 @@ const Select: {
 };
 
 export {
-  Select,
-  SelectContent,
-  SelectGroup,
-  SelectItem,
-  SelectLabel,
-  SelectRoot,
-  SelectSeparator,
-  SelectTrigger,
-  SelectValue,
+    Select,
+    SelectContent,
+    SelectGroup,
+    SelectItem,
+    SelectLabel,
+    SelectRoot,
+    SelectSeparator,
+    SelectTrigger,
+    SelectValue
 };
 export type {
-  SelectContentProps,
-  SelectItemProps,
-  SelectLabelProps,
-  SelectRootProps,
-  SelectSeparatorProps,
-  SelectSize,
-  SelectTriggerProps,
-  SelectTriggerVariant,
-  SelectValueProps,
+    SelectContentProps,
+    SelectItemProps,
+    SelectLabelProps,
+    SelectRootProps,
+    SelectSeparatorProps,
+    SelectSize,
+    SelectTriggerProps,
+    SelectTriggerVariant,
+    SelectValueProps
 };

--- a/packages/frosted-ui-react-native/src/components/select.tsx
+++ b/packages/frosted-ui-react-native/src/components/select.tsx
@@ -2,26 +2,26 @@ import { NativeOnlyAnimatedView } from '@/components/native-only-animated-view';
 import { Text, TextStyleContext } from '@/components/text';
 import { SelectPrimitive } from '@/forked-primitives';
 import {
-    getButtonFocusStyle,
-    getButtonPressedFilter,
-    getButtonShadowStyle,
-    getButtonSizeStyle,
-    getButtonVariantStyle,
-    type ButtonSize,
-    type ButtonVariant,
+  getButtonFocusStyle,
+  getButtonPressedFilter,
+  getButtonShadowStyle,
+  getButtonSizeStyle,
+  getButtonVariantStyle,
+  type ButtonSize,
+  type ButtonVariant,
 } from '@/lib/button-styles';
 import type { Color } from '@/lib/types';
 import { useThemeTokens } from '@/lib/use-theme-tokens';
 import * as React from 'react';
 import {
-    Platform,
-    Pressable,
-    ScrollView,
-    StyleSheet,
-    useWindowDimensions,
-    View,
-    type StyleProp,
-    type ViewStyle,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+  type StyleProp,
+  type ViewStyle,
 } from 'react-native';
 import { FadeIn, FadeOut } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -404,14 +404,23 @@ type SelectContentProps = SelectPrimitive.ContentProps & {
   position?: 'popper' | 'item-aligned';
 };
 
+// Helper to safely get primitive context on native (not available on web)
+function useSelectRootContext() {
+  if (Platform.OS === 'web' || !SelectPrimitive.useRootContext) {
+    return null;
+  }
+  
+  return SelectPrimitive.useRootContext();
+}
+
 function SelectContent({ portalHost, position = 'popper', ...props }: SelectContentProps) {
   // Get context values before portal (context is lost in portal on native)
   const selectContext = React.useContext(SelectContext);
   const { size, labelMap, value, open } = selectContext;
   const { colors, isDark } = useThemeTokens();
 
-  // Capture primitive context BEFORE the portal/FullWindowOverlay
-  const primitiveContext = SelectPrimitive.useRootContext();
+  // Capture primitive context BEFORE the portal/FullWindowOverlay (native only)
+  const primitiveContext = useSelectRootContext();
   const { height: windowHeight } = useWindowDimensions();
   const safeAreaInsets = useSafeAreaInsets();
 
@@ -477,88 +486,97 @@ function SelectContent({ portalHost, position = 'popper', ...props }: SelectCont
     [size, labelMap, value, open]
   );
 
+  // On native, re-provide context after FullWindowOverlay breaks it
+  const ContextProvider = SelectPrimitive.SelectContext?.Provider;
+  const shouldProvideContext = Platform.OS !== 'web' && ContextProvider && primitiveContext;
+
+  const content = (
+    <SelectPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>
+      {/* Re-provide our context inside portal since it's lost on native */}
+      <SelectContext.Provider value={contextValue}>
+        <SelectContentContext.Provider value={contentContextValue}>
+          <TextStyleContext.Provider value={{ size: '2', weight: 'regular', color: 'gray' }}>
+            <NativeOnlyAnimatedView entering={FadeIn} exiting={FadeOut}>
+              <SelectPrimitive.Content
+                position={position}
+                sideOffset={4}
+                insets={Platform.OS !== 'web' ? contentInsets : undefined}
+                style={{
+                  backgroundColor: colors.panelSolid,
+                  borderRadius,
+                  minWidth: 128,
+                  // Constrain max height on native to prevent overflow
+                  ...Platform.select({
+                    web: {
+                      // Shadow-5 from web: border + two shadow layers
+                      // Light: 0 0 0 1px gray-a5, 0 12px 60px black-a3, 0 12px 32px -16px gray-a5
+                      // Dark: 0 0 0 1px gray-a6, 0 12px 60px black-a5, 0 12px 32px -16px black-a7
+                      boxShadow: isDark
+                        ? `0 0 0 1px ${colors.palettes.gray.a6}, 0 12px 60px ${colors.palettes.black.a5}, 0 12px 32px -16px ${colors.palettes.black.a7}`
+                        : `0 0 0 1px ${colors.palettes.gray.a5}, 0 12px 60px ${colors.palettes.black.a3}, 0 12px 32px -16px ${colors.palettes.gray.a5}`,
+                      overflow: 'hidden',
+                    },
+                    default: {
+                      // Native approximation - can't do multiple shadows
+                      // Note: overflow: 'hidden' clips shadows on iOS, so we don't use it here
+                      maxHeight: nativeMaxHeight,
+                      borderWidth: 1,
+                      borderColor: isDark ? colors.palettes.gray.a6 : colors.palettes.gray.a5,
+                      shadowColor: '#000000',
+                      shadowOpacity: isDark ? 0.3 : 0.15,
+                      shadowOffset: { width: 0, height: 12 },
+                      shadowRadius: 30,
+                      elevation: 12,
+                    },
+                  }),
+                }}
+                {...props}>
+                <SelectPrimitive.Viewport
+                  style={{
+                    width: 'auto',
+                    borderRadius,
+                    // On web, Radix calculates available height dynamically via CSS variable
+                    ...Platform.select({
+                      web: {
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- CSS variable not in ViewStyle type
+                        maxHeight:
+                          'var(--radix-select-content-available-height)' as unknown as number,
+                        overflow: 'auto',
+                      },
+                      default: {
+                        overflow: 'hidden',
+                      },
+                    }),
+                  }}>
+                  {Platform.OS === 'web' ? (
+                    <View style={{ padding: contentPadding }}>{props.children}</View>
+                  ) : (
+                    <ScrollView
+                      ref={scrollViewRef}
+                      style={{ maxHeight: nativeMaxHeight - contentPadding * 2 - 2 }} // Account for padding and border
+                      contentContainerStyle={{ padding: contentPadding }}
+                      showsVerticalScrollIndicator
+                      bounces={false}>
+                      {props.children}
+                    </ScrollView>
+                  )}
+                </SelectPrimitive.Viewport>
+              </SelectPrimitive.Content>
+            </NativeOnlyAnimatedView>
+          </TextStyleContext.Provider>
+        </SelectContentContext.Provider>
+      </SelectContext.Provider>
+    </SelectPrimitive.Overlay>
+  );
+
   return (
     <SelectPrimitive.Portal hostName={portalHost}>
       <FullWindowOverlay>
-        {/* Re-provide SelectPrimitive context after FullWindowOverlay breaks context */}
-        <SelectPrimitive.SelectContext.Provider value={primitiveContext}>
-          <SelectPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>
-            {/* Re-provide our context inside portal since it's lost on native */}
-            <SelectContext.Provider value={contextValue}>
-            <SelectContentContext.Provider value={contentContextValue}>
-              <TextStyleContext.Provider value={{ size: '2', weight: 'regular', color: 'gray' }}>
-                <NativeOnlyAnimatedView entering={FadeIn} exiting={FadeOut}>
-                  <SelectPrimitive.Content
-                    position={position}
-                    sideOffset={4}
-                    insets={Platform.OS !== 'web' ? contentInsets : undefined}
-                    style={{
-                      backgroundColor: colors.panelSolid,
-                      borderRadius,
-                      minWidth: 128,
-                      // Constrain max height on native to prevent overflow
-                      ...Platform.select({
-                        web: {
-                          // Shadow-5 from web: border + two shadow layers
-                          // Light: 0 0 0 1px gray-a5, 0 12px 60px black-a3, 0 12px 32px -16px gray-a5
-                          // Dark: 0 0 0 1px gray-a6, 0 12px 60px black-a5, 0 12px 32px -16px black-a7
-                          boxShadow: isDark
-                            ? `0 0 0 1px ${colors.palettes.gray.a6}, 0 12px 60px ${colors.palettes.black.a5}, 0 12px 32px -16px ${colors.palettes.black.a7}`
-                            : `0 0 0 1px ${colors.palettes.gray.a5}, 0 12px 60px ${colors.palettes.black.a3}, 0 12px 32px -16px ${colors.palettes.gray.a5}`,
-                          overflow: 'hidden',
-                        },
-                        default: {
-                          // Native approximation - can't do multiple shadows
-                          // Note: overflow: 'hidden' clips shadows on iOS, so we don't use it here
-                          maxHeight: nativeMaxHeight,
-                          borderWidth: 1,
-                          borderColor: isDark ? colors.palettes.gray.a6 : colors.palettes.gray.a5,
-                          shadowColor: '#000000',
-                          shadowOpacity: isDark ? 0.3 : 0.15,
-                          shadowOffset: { width: 0, height: 12 },
-                          shadowRadius: 30,
-                          elevation: 12,
-                        },
-                      }),
-                    }}
-                    {...props}>
-                    <SelectPrimitive.Viewport
-                      style={{
-                        width: 'auto',
-                        borderRadius,
-                        // On web, Radix calculates available height dynamically via CSS variable
-                        ...Platform.select({
-                          web: {
-                            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- CSS variable not in ViewStyle type
-                            maxHeight:
-                              'var(--radix-select-content-available-height)' as unknown as number,
-                            overflow: 'auto',
-                          },
-                          default: {
-                            overflow: 'hidden',
-                          },
-                        }),
-                      }}>
-                      {Platform.OS === 'web' ? (
-                        <View style={{ padding: contentPadding }}>{props.children}</View>
-                      ) : (
-                        <ScrollView
-                          ref={scrollViewRef}
-                          style={{ maxHeight: nativeMaxHeight - contentPadding * 2 - 2 }} // Account for padding and border
-                          contentContainerStyle={{ padding: contentPadding }}
-                          showsVerticalScrollIndicator
-                          bounces={false}>
-                          {props.children}
-                        </ScrollView>
-                      )}
-                    </SelectPrimitive.Viewport>
-                  </SelectPrimitive.Content>
-                </NativeOnlyAnimatedView>
-              </TextStyleContext.Provider>
-              </SelectContentContext.Provider>
-            </SelectContext.Provider>
-          </SelectPrimitive.Overlay>
-        </SelectPrimitive.SelectContext.Provider>
+        {shouldProvideContext ? (
+          <ContextProvider value={primitiveContext}>{content}</ContextProvider>
+        ) : (
+          content
+        )}
       </FullWindowOverlay>
     </SelectPrimitive.Portal>
   );
@@ -818,24 +836,25 @@ const Select: {
 };
 
 export {
-    Select,
-    SelectContent,
-    SelectGroup,
-    SelectItem,
-    SelectLabel,
-    SelectRoot,
-    SelectSeparator,
-    SelectTrigger,
-    SelectValue
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectRoot,
+  SelectSeparator,
+  SelectTrigger,
+  SelectValue
 };
 export type {
-    SelectContentProps,
-    SelectItemProps,
-    SelectLabelProps,
-    SelectRootProps,
-    SelectSeparatorProps,
-    SelectSize,
-    SelectTriggerProps,
-    SelectTriggerVariant,
-    SelectValueProps
+  SelectContentProps,
+  SelectItemProps,
+  SelectLabelProps,
+  SelectRootProps,
+  SelectSeparatorProps,
+  SelectSize,
+  SelectTriggerProps,
+  SelectTriggerVariant,
+  SelectValueProps
 };
+

--- a/packages/frosted-ui-react-native/src/components/select.tsx
+++ b/packages/frosted-ui-react-native/src/components/select.tsx
@@ -487,8 +487,9 @@ function SelectContent({ portalHost, position = 'popper', ...props }: SelectCont
   );
 
   // On native, re-provide context after FullWindowOverlay breaks it
-  const ContextProvider = SelectPrimitive.SelectContext?.Provider;
-  const shouldProvideContext = Platform.OS !== 'web' && ContextProvider && primitiveContext;
+  const ContextProvider =
+    Platform.OS !== 'web' ? SelectPrimitive.SelectContext?.Provider : null;
+  const shouldProvideContext = ContextProvider && primitiveContext;
 
   const content = (
     <SelectPrimitive.Overlay style={Platform.select({ native: StyleSheet.absoluteFill })}>

--- a/packages/frosted-ui-react-native/src/forked-primitives/alert-dialog.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/alert-dialog.tsx
@@ -1,0 +1,323 @@
+/**
+ * Forked from @rn-primitives/alert-dialog
+ *
+ * Changes from original:
+ * - Export AlertDialogContext so it can be re-provided after FullWindowOverlay breaks context
+ * - Fix Portal to not pass hostName when undefined (bypasses default)
+ * - Use local hooks implementation to avoid bundler issues
+ * - Convert to TypeScript
+ */
+
+import { Portal as RNPortal } from '@rn-primitives/portal';
+import * as Slot from '@rn-primitives/slot';
+import React, { useEffect, useId } from 'react';
+import {
+  BackHandler,
+  Pressable,
+  Text as RNText,
+  View,
+  type GestureResponderEvent,
+  type PressableProps,
+  type TextProps,
+  type ViewProps,
+} from 'react-native';
+import { useControllableState } from './hooks';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type ViewRef = React.ElementRef<typeof View>;
+type PressableRef = React.ElementRef<typeof Pressable>;
+type TextRef = React.ElementRef<typeof RNText>;
+
+interface RootContext {
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+  nativeID: string;
+}
+
+interface RootProps extends ViewProps {
+  asChild?: boolean;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (value: boolean) => void;
+}
+
+interface PortalProps {
+  children: React.ReactNode;
+  forceMount?: true | undefined;
+  hostName?: string;
+}
+
+interface OverlayProps extends ViewProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+}
+
+interface ContentProps extends ViewProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+}
+
+interface TriggerProps extends PressableProps {
+  asChild?: boolean;
+}
+
+interface CancelProps extends PressableProps {
+  asChild?: boolean;
+}
+
+interface ActionProps extends PressableProps {
+  asChild?: boolean;
+}
+
+interface TitleProps extends TextProps {
+  asChild?: boolean;
+}
+
+interface DescriptionProps extends TextProps {
+  asChild?: boolean;
+}
+
+// ============================================================================
+// Context - EXPORTED so it can be re-provided after FullWindowOverlay
+// ============================================================================
+
+const AlertDialogContext = React.createContext<RootContext | null>(null);
+
+function useRootContext(): RootContext {
+  const context = React.useContext(AlertDialogContext);
+  if (!context) {
+    throw new Error(
+      'AlertDialog compound components cannot be rendered outside the AlertDialog component'
+    );
+  }
+  return context;
+}
+
+// ============================================================================
+// Components
+// ============================================================================
+
+const Root = React.forwardRef<ViewRef, RootProps>(
+  ({ asChild, open: openProp, defaultOpen, onOpenChange: onOpenChangeProp, ...viewProps }, ref) => {
+    const nativeID = useId();
+    const [open = false, onOpenChange] = useControllableState({
+      prop: openProp,
+      defaultProp: defaultOpen,
+      onChange: onOpenChangeProp,
+    });
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <AlertDialogContext.Provider value={{ open, onOpenChange, nativeID }}>
+        <Component ref={ref} {...viewProps} />
+      </AlertDialogContext.Provider>
+    );
+  }
+);
+Root.displayName = 'RootNativeAlertDialog';
+
+const Trigger = React.forwardRef<PressableRef, TriggerProps>(
+  ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
+    const { open: value, onOpenChange } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      onOpenChange(!value);
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        aria-disabled={disabled ?? undefined}
+        role="button"
+        onPress={onPress}
+        disabled={disabled ?? undefined}
+        {...props}
+      />
+    );
+  }
+);
+Trigger.displayName = 'TriggerNativeAlertDialog';
+
+function Portal({ forceMount, hostName, children }: PortalProps) {
+  const value = useRootContext();
+
+  if (!forceMount) {
+    if (!value.open) {
+      return null;
+    }
+  }
+
+  const portalProps = hostName ? { hostName } : {};
+
+  return (
+    <RNPortal {...portalProps} name={`${value.nativeID}_portal`}>
+      <AlertDialogContext.Provider value={value}>{children}</AlertDialogContext.Provider>
+    </RNPortal>
+  );
+}
+
+const Overlay = React.forwardRef<ViewRef, OverlayProps>(
+  ({ asChild, forceMount, ...props }, ref) => {
+    const { open: value } = useRootContext();
+
+    if (!forceMount) {
+      if (!value) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.View : View;
+
+    return <Component ref={ref} {...props} />;
+  }
+);
+Overlay.displayName = 'OverlayNativeAlertDialog';
+
+const Content = React.forwardRef<ViewRef, ContentProps>(
+  ({ asChild, forceMount, ...props }, ref) => {
+    const { open: value, nativeID, onOpenChange } = useRootContext();
+
+    useEffect(() => {
+      const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+        onOpenChange(false);
+        return true;
+      });
+      return () => {
+        backHandler.remove();
+      };
+    }, [onOpenChange]);
+
+    if (!forceMount) {
+      if (!value) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <Component
+        ref={ref}
+        role="alertdialog"
+        nativeID={nativeID}
+        aria-labelledby={`${nativeID}_label`}
+        aria-describedby={`${nativeID}_desc`}
+        aria-modal={true}
+        {...props}
+      />
+    );
+  }
+);
+Content.displayName = 'ContentNativeAlertDialog';
+
+const Cancel = React.forwardRef<PressableRef, CancelProps>(
+  ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
+    const { onOpenChange } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (disabled) return;
+      onOpenChange(false);
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        aria-disabled={disabled ?? undefined}
+        role="button"
+        onPress={onPress}
+        disabled={disabled ?? undefined}
+        {...props}
+      />
+    );
+  }
+);
+Cancel.displayName = 'CancelNativeAlertDialog';
+
+const Action = React.forwardRef<PressableRef, ActionProps>(
+  ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
+    const { onOpenChange } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (disabled) return;
+      onOpenChange(false);
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        aria-disabled={disabled ?? undefined}
+        role="button"
+        onPress={onPress}
+        disabled={disabled ?? undefined}
+        {...props}
+      />
+    );
+  }
+);
+Action.displayName = 'ActionNativeAlertDialog';
+
+const Title = React.forwardRef<TextRef, TitleProps>(({ asChild, ...props }, ref) => {
+  const { nativeID } = useRootContext();
+  const Component = asChild ? Slot.Text : RNText;
+  return <Component ref={ref} role="heading" nativeID={`${nativeID}_label`} {...props} />;
+});
+Title.displayName = 'TitleNativeAlertDialog';
+
+const Description = React.forwardRef<TextRef, DescriptionProps>(({ asChild, ...props }, ref) => {
+  const { nativeID } = useRootContext();
+  const Component = asChild ? Slot.Text : RNText;
+  return <Component ref={ref} nativeID={`${nativeID}_desc`} {...props} />;
+});
+Description.displayName = 'DescriptionNativeAlertDialog';
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export {
+  Action,
+  AlertDialogContext,
+  Cancel,
+  Content,
+  Description,
+  Overlay,
+  Portal,
+  Root,
+  Title,
+  Trigger,
+  useRootContext,
+};
+
+export type {
+  ActionProps,
+  CancelProps,
+  ContentProps,
+  DescriptionProps,
+  OverlayProps,
+  PortalProps,
+  RootContext,
+  RootProps,
+  TitleProps,
+  TriggerProps,
+  PressableRef as ActionRef,
+  PressableRef as CancelRef,
+  ViewRef as ContentRef,
+  TextRef as DescriptionRef,
+  ViewRef as OverlayRef,
+  ViewRef as RootRef,
+  TextRef as TitleRef,
+  PressableRef as TriggerRef,
+};

--- a/packages/frosted-ui-react-native/src/forked-primitives/alert-dialog.web.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/alert-dialog.web.tsx
@@ -1,0 +1,5 @@
+/**
+ * Web version - re-export from original package which uses @radix-ui/react-alert-dialog
+ * Our native fixes (portal hostName, context re-provision) are not needed on web
+ */
+export * from '@rn-primitives/alert-dialog';

--- a/packages/frosted-ui-react-native/src/forked-primitives/context-menu.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/context-menu.tsx
@@ -213,6 +213,7 @@ const Trigger = React.forwardRef<PressableRef, TriggerProps>(
       methods: {
         open: () => {
           onOpenChange(true);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (augmentedRef.current as any)?.measure?.(
             (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
               setPressPosition({ width, pageX, pageY, height });
@@ -237,6 +238,7 @@ const Trigger = React.forwardRef<PressableRef, TriggerProps>(
         });
       }
       if (relativeTo === 'trigger') {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (augmentedRef.current as any)?.measure?.(
           (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
             setPressPosition({ width, pageX, pageY, height });

--- a/packages/frosted-ui-react-native/src/forked-primitives/context-menu.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/context-menu.tsx
@@ -1,0 +1,739 @@
+/**
+ * Forked from @rn-primitives/context-menu
+ *
+ * Changes from original:
+ * - Export ContextMenuContext so it can be re-provided after FullWindowOverlay breaks context
+ * - Fix Portal to not pass hostName when undefined (bypasses default)
+ * - Use local hooks implementation to avoid bundler issues
+ * - Convert to TypeScript
+ */
+
+import { Portal as RNPortal } from '@rn-primitives/portal';
+import * as Slot from '@rn-primitives/slot';
+import type { Insets, PositionedContentProps } from '@rn-primitives/types';
+import * as React from 'react';
+import {
+  BackHandler,
+  Pressable,
+  Text as RNText,
+  View,
+  type AccessibilityActionEvent,
+  type GestureResponderEvent,
+  type LayoutChangeEvent,
+  type LayoutRectangle,
+  type PressableProps,
+  type TextProps,
+  type ViewProps,
+  type ViewStyle,
+} from 'react-native';
+import { useAugmentedRef, useControllableState, useRelativePosition } from './hooks';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type ViewRef = React.ElementRef<typeof View>;
+type PressableRef = React.ElementRef<typeof Pressable>;
+type TextRef = React.ElementRef<typeof RNText>;
+
+interface PressPosition {
+  width: number;
+  height: number;
+  pageX: number;
+  pageY: number;
+}
+
+interface RootContext {
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+  relativeTo: 'longPress' | 'trigger';
+  pressPosition: PressPosition | null;
+  setPressPosition: React.Dispatch<React.SetStateAction<PressPosition | null>>;
+  contentLayout: LayoutRectangle | null;
+  setContentLayout: React.Dispatch<React.SetStateAction<LayoutRectangle | null>>;
+  nativeID: string;
+}
+
+interface RootProps extends ViewProps {
+  asChild?: boolean;
+  onOpenChange?: (value: boolean) => void;
+  relativeTo?: 'longPress' | 'trigger';
+}
+
+interface PortalProps {
+  children: React.ReactNode;
+  forceMount?: true | undefined;
+  hostName?: string;
+}
+
+interface OverlayProps extends PressableProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+  closeOnPress?: boolean;
+}
+
+interface ContentProps
+  extends Omit<PositionedContentProps, 'style' | 'loop' | 'onCloseAutoFocus' | 'onEscapeKeyDown' | 'onPointerDownOutside' | 'onFocusOutside' | 'onInteractOutside' | 'collisionBoundary' | 'sticky' | 'hideWhenDetached'>,
+    Omit<PressableProps, 'style'> {
+  asChild?: boolean;
+  style?: ViewStyle;
+}
+
+interface TriggerProps extends PressableProps {
+  asChild?: boolean;
+}
+
+interface ItemProps extends PressableProps {
+  asChild?: boolean;
+  textValue?: string;
+  closeOnPress?: boolean;
+}
+
+interface GroupProps extends ViewProps {
+  asChild?: boolean;
+}
+
+interface LabelProps extends TextProps {
+  asChild?: boolean;
+}
+
+interface CheckboxItemProps extends PressableProps {
+  asChild?: boolean;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  textValue?: string;
+  closeOnPress?: boolean;
+}
+
+interface RadioGroupProps extends ViewProps {
+  asChild?: boolean;
+  value: string;
+  onValueChange: (value: string) => void;
+}
+
+interface RadioItemProps extends PressableProps {
+  asChild?: boolean;
+  value: string;
+  textValue?: string;
+  closeOnPress?: boolean;
+}
+
+interface ItemIndicatorProps extends ViewProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+}
+
+interface SeparatorProps extends ViewProps {
+  asChild?: boolean;
+  decorative?: boolean;
+}
+
+interface SubProps extends ViewProps {
+  asChild?: boolean;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (value: boolean) => void;
+}
+
+interface SubTriggerProps extends PressableProps {
+  asChild?: boolean;
+  textValue?: string;
+}
+
+interface SubContentProps extends PressableProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+}
+
+// ============================================================================
+// Context - EXPORTED so it can be re-provided after FullWindowOverlay
+// ============================================================================
+
+const ContextMenuContext = React.createContext<RootContext | null>(null);
+
+function useRootContext(): RootContext {
+  const context = React.useContext(ContextMenuContext);
+  if (!context) {
+    throw new Error(
+      'ContextMenu compound components cannot be rendered outside the ContextMenu component'
+    );
+  }
+  return context;
+}
+
+// ============================================================================
+// Components
+// ============================================================================
+
+const Root = React.forwardRef<ViewRef, RootProps>(
+  ({ asChild, relativeTo = 'longPress', onOpenChange: onOpenChangeProp, ...viewProps }, ref) => {
+    const nativeID = React.useId();
+    const [pressPosition, setPressPosition] = React.useState<PressPosition | null>(null);
+    const [contentLayout, setContentLayout] = React.useState<LayoutRectangle | null>(null);
+    const [open, setOpen] = React.useState(false);
+
+    // Memoize to prevent infinite re-render loops in Content's useEffect
+    const onOpenChange = React.useCallback(
+      (value: boolean) => {
+        setOpen(value);
+        onOpenChangeProp?.(value);
+      },
+      [onOpenChangeProp]
+    );
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <ContextMenuContext.Provider
+        value={{
+          open,
+          onOpenChange,
+          relativeTo,
+          contentLayout,
+          nativeID,
+          pressPosition,
+          setContentLayout,
+          setPressPosition,
+        }}>
+        <Component ref={ref} {...viewProps} />
+      </ContextMenuContext.Provider>
+    );
+  }
+);
+Root.displayName = 'RootNativeContextMenu';
+
+const accessibilityActions = [{ name: 'longpress' }];
+
+const Trigger = React.forwardRef<PressableRef, TriggerProps>(
+  ({ asChild, onLongPress: onLongPressProp, disabled = false, onAccessibilityAction: onAccessibilityActionProp, ...props }, ref) => {
+    const { open, onOpenChange, relativeTo, setPressPosition } = useRootContext();
+
+    const augmentedRef = useAugmentedRef({
+      ref,
+      methods: {
+        open: () => {
+          onOpenChange(true);
+          (augmentedRef.current as any)?.measure?.(
+            (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
+              setPressPosition({ width, pageX, pageY, height });
+            }
+          );
+        },
+        close: () => {
+          setPressPosition(null);
+          onOpenChange(false);
+        },
+      },
+    });
+
+    function onLongPress(ev: GestureResponderEvent) {
+      if (disabled) return;
+      if (relativeTo === 'longPress') {
+        setPressPosition({
+          width: 0,
+          pageX: ev.nativeEvent.pageX,
+          pageY: ev.nativeEvent.pageY,
+          height: 0,
+        });
+      }
+      if (relativeTo === 'trigger') {
+        (augmentedRef.current as any)?.measure?.(
+          (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
+            setPressPosition({ width, pageX, pageY, height });
+          }
+        );
+      }
+      onOpenChange(!open);
+      onLongPressProp?.(ev);
+    }
+
+    function onAccessibilityAction(event: AccessibilityActionEvent) {
+      if (disabled) return;
+      if (event.nativeEvent.actionName === 'longpress') {
+        setPressPosition({ width: 0, pageX: 0, pageY: 0, height: 0 });
+        onOpenChange(!open);
+      }
+      onAccessibilityActionProp?.(event);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={augmentedRef}
+        aria-disabled={disabled ?? undefined}
+        role="button"
+        onLongPress={onLongPress}
+        disabled={disabled ?? undefined}
+        aria-expanded={open}
+        accessibilityActions={accessibilityActions}
+        onAccessibilityAction={onAccessibilityAction}
+        {...props}
+      />
+    );
+  }
+);
+Trigger.displayName = 'TriggerNativeContextMenu';
+
+function Portal({ forceMount, hostName, children }: PortalProps) {
+  const value = useRootContext();
+
+  if (!value.pressPosition) {
+    return null;
+  }
+
+  if (!forceMount) {
+    if (!value.open) {
+      return null;
+    }
+  }
+
+  const portalProps = hostName ? { hostName } : {};
+
+  return (
+    <RNPortal {...portalProps} name={`${value.nativeID}_portal`}>
+      <ContextMenuContext.Provider value={value}>{children}</ContextMenuContext.Provider>
+    </RNPortal>
+  );
+}
+
+const Overlay = React.forwardRef<PressableRef, OverlayProps>(
+  ({ asChild, forceMount, onPress: OnPressProp, closeOnPress = true, ...props }, ref) => {
+    const { open, onOpenChange, setContentLayout, setPressPosition } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (closeOnPress) {
+        setPressPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }
+      OnPressProp?.(ev);
+    }
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return <Component ref={ref} onPress={onPress} {...props} />;
+  }
+);
+Overlay.displayName = 'OverlayNativeContextMenu';
+
+const Content = React.forwardRef<PressableRef, ContentProps>(
+  (
+    {
+      asChild = false,
+      forceMount,
+      align = 'start',
+      side = 'bottom',
+      sideOffset = 0,
+      alignOffset = 0,
+      avoidCollisions = true,
+      onLayout: onLayoutProp,
+      insets,
+      style,
+      disablePositioningStyle,
+      ...props
+    },
+    ref
+  ) => {
+    const {
+      open,
+      onOpenChange,
+      nativeID,
+      pressPosition,
+      setPressPosition,
+      contentLayout,
+      setContentLayout,
+    } = useRootContext();
+
+    React.useEffect(() => {
+      const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+        setPressPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+        return true;
+      });
+      return () => {
+        setContentLayout(null);
+        backHandler.remove();
+      };
+    }, [onOpenChange, setContentLayout, setPressPosition]);
+
+    const positionStyle = useRelativePosition({
+      align,
+      avoidCollisions,
+      triggerPosition: pressPosition,
+      contentLayout,
+      alignOffset,
+      insets: insets as Insets,
+      sideOffset,
+      side,
+      disablePositioningStyle,
+    });
+
+    function onLayout(event: LayoutChangeEvent) {
+      setContentLayout(event.nativeEvent.layout);
+      onLayoutProp?.(event);
+    }
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        role="menu"
+        nativeID={nativeID}
+        aria-modal={true}
+        style={[positionStyle as ViewStyle, style]}
+        onLayout={onLayout}
+        {...props}
+      />
+    );
+  }
+);
+Content.displayName = 'ContentNativeContextMenu';
+
+const Item = React.forwardRef<PressableRef, ItemProps>(
+  ({ asChild, textValue, onPress: onPressProp, disabled = false, closeOnPress = true, ...props }, ref) => {
+    const { onOpenChange, setPressPosition, setContentLayout } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (closeOnPress) {
+        setPressPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        role="menuitem"
+        onPress={onPress}
+        disabled={disabled}
+        aria-valuetext={textValue}
+        aria-disabled={!!disabled}
+        accessibilityState={{ disabled: !!disabled }}
+        {...props}
+      />
+    );
+  }
+);
+Item.displayName = 'ItemNativeContextMenu';
+
+const Group = React.forwardRef<ViewRef, GroupProps>(({ asChild, ...props }, ref) => {
+  const Component = asChild ? Slot.View : View;
+  return <Component ref={ref} role="group" {...props} />;
+});
+Group.displayName = 'GroupNativeContextMenu';
+
+const Label = React.forwardRef<TextRef, LabelProps>(({ asChild, ...props }, ref) => {
+  const Component = asChild ? Slot.Text : RNText;
+  return <Component ref={ref} {...props} />;
+});
+Label.displayName = 'LabelNativeContextMenu';
+
+interface FormItemContextValue {
+  checked?: boolean;
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+const FormItemContext = React.createContext<FormItemContextValue | null>(null);
+
+const CheckboxItem = React.forwardRef<PressableRef, CheckboxItemProps>(
+  (
+    {
+      asChild,
+      checked,
+      onCheckedChange,
+      textValue,
+      onPress: onPressProp,
+      closeOnPress = true,
+      disabled = false,
+      ...props
+    },
+    ref
+  ) => {
+    const { onOpenChange, setContentLayout, setPressPosition } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      onCheckedChange(!checked);
+      if (closeOnPress) {
+        setPressPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <FormItemContext.Provider value={{ checked }}>
+        <Component
+          ref={ref}
+          role="checkbox"
+          aria-checked={checked}
+          onPress={onPress}
+          disabled={disabled}
+          aria-disabled={!!disabled}
+          aria-valuetext={textValue}
+          accessibilityState={{ disabled: !!disabled }}
+          {...props}
+        />
+      </FormItemContext.Provider>
+    );
+  }
+);
+CheckboxItem.displayName = 'CheckboxItemNativeContextMenu';
+
+function useFormItemContext() {
+  const context = React.useContext(FormItemContext);
+  if (!context) {
+    throw new Error(
+      'CheckboxItem or RadioItem compound components cannot be rendered outside of a CheckboxItem or RadioItem component'
+    );
+  }
+  return context;
+}
+
+const RadioGroup = React.forwardRef<ViewRef, RadioGroupProps>(
+  ({ asChild, value, onValueChange, ...props }, ref) => {
+    const Component = asChild ? Slot.View : View;
+    return (
+      <FormItemContext.Provider value={{ value, onValueChange }}>
+        <Component ref={ref} role="radiogroup" {...props} />
+      </FormItemContext.Provider>
+    );
+  }
+);
+RadioGroup.displayName = 'RadioGroupNativeContextMenu';
+
+interface RadioItemContextValue {
+  itemValue?: string;
+}
+
+const RadioItemContext = React.createContext<RadioItemContextValue>({});
+
+const RadioItem = React.forwardRef<PressableRef, RadioItemProps>(
+  (
+    {
+      asChild,
+      value: itemValue,
+      textValue,
+      onPress: onPressProp,
+      disabled = false,
+      closeOnPress = true,
+      ...props
+    },
+    ref
+  ) => {
+    const { onOpenChange, setContentLayout, setPressPosition } = useRootContext();
+    const { value, onValueChange } = useFormItemContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      onValueChange?.(itemValue);
+      if (closeOnPress) {
+        setPressPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <RadioItemContext.Provider value={{ itemValue }}>
+        <Component
+          ref={ref}
+          onPress={onPress}
+          role="radio"
+          aria-checked={value === itemValue}
+          disabled={disabled ?? false}
+          accessibilityState={{
+            disabled: disabled ?? false,
+            checked: value === itemValue,
+          }}
+          aria-valuetext={textValue}
+          {...props}
+        />
+      </RadioItemContext.Provider>
+    );
+  }
+);
+RadioItem.displayName = 'RadioItemNativeContextMenu';
+
+function useItemIndicatorContext() {
+  return React.useContext(RadioItemContext);
+}
+
+const ItemIndicator = React.forwardRef<ViewRef, ItemIndicatorProps>(
+  ({ asChild, forceMount, ...props }, ref) => {
+    const { itemValue } = useItemIndicatorContext();
+    const { checked, value } = useFormItemContext();
+
+    if (!forceMount) {
+      if (itemValue == null && !checked) {
+        return null;
+      }
+      if (value !== itemValue) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.View : View;
+    return <Component ref={ref} role="presentation" {...props} />;
+  }
+);
+ItemIndicator.displayName = 'ItemIndicatorNativeContextMenu';
+
+const Separator = React.forwardRef<ViewRef, SeparatorProps>(
+  ({ asChild, decorative, ...props }, ref) => {
+    const Component = asChild ? Slot.View : View;
+    return <Component role={decorative ? 'presentation' : 'separator'} ref={ref} {...props} />;
+  }
+);
+Separator.displayName = 'SeparatorNativeContextMenu';
+
+interface SubContext {
+  nativeID: string;
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+}
+
+const SubMenuContext = React.createContext<SubContext | null>(null);
+
+const Sub = React.forwardRef<ViewRef, SubProps>(
+  ({ asChild, defaultOpen, open: openProp, onOpenChange: onOpenChangeProp, ...props }, ref) => {
+    const nativeID = React.useId();
+    const [open = false, onOpenChange] = useControllableState({
+      prop: openProp,
+      defaultProp: defaultOpen,
+      onChange: onOpenChangeProp,
+    });
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <SubMenuContext.Provider value={{ nativeID, open, onOpenChange }}>
+        <Component ref={ref} {...props} />
+      </SubMenuContext.Provider>
+    );
+  }
+);
+Sub.displayName = 'SubNativeContextMenu';
+
+function useSubContext(): SubContext {
+  const context = React.useContext(SubMenuContext);
+  if (!context) {
+    throw new Error('Sub compound components cannot be rendered outside of a Sub component');
+  }
+  return context;
+}
+
+const SubTrigger = React.forwardRef<PressableRef, SubTriggerProps>(
+  ({ asChild, textValue, onPress: onPressProp, disabled = false, ...props }, ref) => {
+    const { nativeID, open, onOpenChange } = useSubContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      onOpenChange(!open);
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        aria-valuetext={textValue}
+        role="menuitem"
+        aria-expanded={open}
+        accessibilityState={{ expanded: open, disabled: !!disabled }}
+        nativeID={nativeID}
+        onPress={onPress}
+        disabled={disabled}
+        aria-disabled={!!disabled}
+        {...props}
+      />
+    );
+  }
+);
+SubTrigger.displayName = 'SubTriggerNativeContextMenu';
+
+const SubContent = React.forwardRef<PressableRef, SubContentProps>(
+  ({ asChild = false, forceMount, ...props }, ref) => {
+    const { open, nativeID } = useSubContext();
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+    return <Component ref={ref} role="group" aria-labelledby={nativeID} {...props} />;
+  }
+);
+SubContent.displayName = 'SubContentNativeContextMenu';
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export {
+  CheckboxItem,
+  Content,
+  ContextMenuContext, // ADDED: Export context for re-providing after FullWindowOverlay
+  Group,
+  Item,
+  ItemIndicator,
+  Label,
+  Overlay,
+  Portal,
+  RadioGroup,
+  RadioItem,
+  Root,
+  Separator,
+  Sub,
+  SubContent,
+  SubTrigger,
+  Trigger,
+  useRootContext,
+  useSubContext,
+};
+
+export type {
+  CheckboxItemProps,
+  ContentProps,
+  GroupProps,
+  ItemIndicatorProps,
+  ItemProps,
+  LabelProps,
+  OverlayProps,
+  PortalProps,
+  RadioGroupProps,
+  RadioItemProps,
+  RootContext,
+  RootProps,
+  SeparatorProps,
+  SubContentProps,
+  SubProps,
+  SubTriggerProps,
+  TriggerProps,
+};

--- a/packages/frosted-ui-react-native/src/forked-primitives/context-menu.web.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/context-menu.web.tsx
@@ -1,0 +1,5 @@
+/**
+ * Web version - re-export from original package which uses @radix-ui/react-context-menu
+ * Our native fixes (portal hostName, context re-provision) are not needed on web
+ */
+export * from '@rn-primitives/context-menu';

--- a/packages/frosted-ui-react-native/src/forked-primitives/dialog.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/dialog.tsx
@@ -1,0 +1,296 @@
+/**
+ * Forked from @rn-primitives/dialog
+ *
+ * Changes from original:
+ * - Export DialogContext so it can be re-provided after FullWindowOverlay breaks context
+ * - Fix Portal to not pass hostName when undefined (bypasses default)
+ * - Use local hooks implementation to avoid bundler issues
+ * - Convert to TypeScript
+ */
+
+import { Portal as RNPortal } from '@rn-primitives/portal';
+import * as Slot from '@rn-primitives/slot';
+import React, { useEffect, useId } from 'react';
+import {
+    BackHandler,
+    Pressable,
+    Text as RNText,
+    View,
+    type GestureResponderEvent,
+    type PressableProps,
+    type TextProps,
+    type ViewProps,
+} from 'react-native';
+import { useControllableState } from './hooks';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type ViewRef = React.ElementRef<typeof View>;
+type PressableRef = React.ElementRef<typeof Pressable>;
+type TextRef = React.ElementRef<typeof RNText>;
+
+interface RootContext {
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+  nativeID: string;
+}
+
+interface RootProps extends ViewProps {
+  asChild?: boolean;
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (value: boolean) => void;
+}
+
+interface PortalProps {
+  children: React.ReactNode;
+  forceMount?: true | undefined;
+  hostName?: string;
+}
+
+interface OverlayProps extends PressableProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+  closeOnPress?: boolean;
+}
+
+interface ContentProps extends ViewProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+}
+
+interface TriggerProps extends PressableProps {
+  asChild?: boolean;
+}
+
+interface CloseProps extends PressableProps {
+  asChild?: boolean;
+}
+
+interface TitleProps extends TextProps {
+  asChild?: boolean;
+}
+
+interface DescriptionProps extends TextProps {
+  asChild?: boolean;
+}
+
+// ============================================================================
+// Context - EXPORTED so it can be re-provided after FullWindowOverlay
+// ============================================================================
+
+const DialogContext = React.createContext<RootContext | null>(null);
+
+function useRootContext(): RootContext {
+  const context = React.useContext(DialogContext);
+  if (!context) {
+    throw new Error('Dialog compound components cannot be rendered outside the Dialog component');
+  }
+  return context;
+}
+
+// ============================================================================
+// Components
+// ============================================================================
+
+const Root = React.forwardRef<ViewRef, RootProps>(
+  ({ asChild, open: openProp, defaultOpen, onOpenChange: onOpenChangeProp, ...viewProps }, ref) => {
+    const nativeID = useId();
+    const [open = false, onOpenChange] = useControllableState({
+      prop: openProp,
+      defaultProp: defaultOpen,
+      onChange: onOpenChangeProp,
+    });
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <DialogContext.Provider value={{ open, onOpenChange, nativeID }}>
+        <Component ref={ref} {...viewProps} />
+      </DialogContext.Provider>
+    );
+  }
+);
+Root.displayName = 'RootNativeDialog';
+
+const Trigger = React.forwardRef<PressableRef, TriggerProps>(
+  ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
+    const { open, onOpenChange } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (disabled) return;
+      const newValue = !open;
+      onOpenChange(newValue);
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        aria-disabled={disabled ?? undefined}
+        role="button"
+        onPress={onPress}
+        disabled={disabled ?? undefined}
+        {...props}
+      />
+    );
+  }
+);
+Trigger.displayName = 'TriggerNativeDialog';
+
+/**
+ * Portal component that wraps content for rendering in a portal.
+ * FIX: Only passes hostName when explicitly provided (not undefined)
+ */
+function Portal({ forceMount, hostName, children }: PortalProps) {
+  const value = useRootContext();
+
+  if (!forceMount) {
+    if (!value.open) {
+      return null;
+    }
+  }
+
+  // FIX: Only pass hostName if explicitly provided
+  const portalProps = hostName ? { hostName } : {};
+
+  return (
+    <RNPortal {...portalProps} name={`${value.nativeID}_portal`}>
+      <DialogContext.Provider value={value}>{children}</DialogContext.Provider>
+    </RNPortal>
+  );
+}
+
+const Overlay = React.forwardRef<PressableRef, OverlayProps>(
+  ({ asChild, forceMount, closeOnPress = true, onPress: onPressProp, ...props }, ref) => {
+    const { open, onOpenChange } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (closeOnPress) {
+        onOpenChange(!open);
+      }
+      onPressProp?.(ev);
+    }
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return <Component ref={ref} onPress={onPress} {...props} />;
+  }
+);
+Overlay.displayName = 'OverlayNativeDialog';
+
+const Content = React.forwardRef<ViewRef, ContentProps>(
+  ({ asChild, forceMount, ...props }, ref) => {
+    const { open, nativeID, onOpenChange } = useRootContext();
+
+    useEffect(() => {
+      const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+        onOpenChange(false);
+        return true;
+      });
+      return () => {
+        backHandler.remove();
+      };
+    }, [onOpenChange]);
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <Component
+        ref={ref}
+        role="dialog"
+        nativeID={nativeID}
+        aria-labelledby={`${nativeID}_label`}
+        aria-describedby={`${nativeID}_desc`}
+        aria-modal={true}
+        onStartShouldSetResponder={onStartShouldSetResponder}
+        {...props}
+      />
+    );
+  }
+);
+Content.displayName = 'ContentNativeDialog';
+
+const Close = React.forwardRef<PressableRef, CloseProps>(
+  ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
+    const { onOpenChange } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (disabled) return;
+      onOpenChange(false);
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        aria-disabled={disabled ?? undefined}
+        role="button"
+        onPress={onPress}
+        disabled={disabled ?? undefined}
+        {...props}
+      />
+    );
+  }
+);
+Close.displayName = 'CloseNativeDialog';
+
+const Title = React.forwardRef<TextRef, TitleProps>(({ asChild, ...props }, ref) => {
+  const { nativeID } = useRootContext();
+  const Component = asChild ? Slot.Text : RNText;
+  return <Component ref={ref} role="heading" nativeID={`${nativeID}_label`} {...props} />;
+});
+Title.displayName = 'TitleNativeDialog';
+
+const Description = React.forwardRef<TextRef, DescriptionProps>(({ asChild, ...props }, ref) => {
+  const { nativeID } = useRootContext();
+  const Component = asChild ? Slot.Text : RNText;
+  return <Component ref={ref} nativeID={`${nativeID}_desc`} {...props} />;
+});
+Description.displayName = 'DescriptionNativeDialog';
+
+function onStartShouldSetResponder() {
+  return true;
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export {
+    Close,
+    Content,
+    Description,
+    DialogContext, // ADDED: Export context for re-providing after FullWindowOverlay
+    Overlay,
+    Portal,
+    Root,
+    Title,
+    Trigger,
+    useRootContext
+};
+
+    export type {
+        CloseProps, PressableRef as CloseRef, ContentProps, ViewRef as ContentRef, DescriptionProps, TextRef as DescriptionRef, OverlayProps, PressableRef as OverlayRef, PortalProps,
+        RootContext,
+        RootProps, ViewRef as RootRef, TitleProps, TextRef as TitleRef, TriggerProps, PressableRef as TriggerRef
+    };
+

--- a/packages/frosted-ui-react-native/src/forked-primitives/dialog.web.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/dialog.web.tsx
@@ -1,0 +1,5 @@
+/**
+ * Web version - re-export from original package which uses @radix-ui/react-dialog
+ * Our native fixes (portal hostName, context re-provision) are not needed on web
+ */
+export * from '@rn-primitives/dialog';

--- a/packages/frosted-ui-react-native/src/forked-primitives/dropdown-menu.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/dropdown-menu.tsx
@@ -1,0 +1,721 @@
+/**
+ * Forked from @rn-primitives/dropdown-menu
+ *
+ * Changes from original:
+ * - Export DropdownMenuContext so it can be re-provided after FullWindowOverlay breaks context
+ * - Fix Portal to not pass hostName when undefined (bypasses default)
+ * - Use local hooks implementation to avoid bundler issues
+ * - Convert to TypeScript
+ */
+
+import { Portal as RNPortal } from '@rn-primitives/portal';
+import * as Slot from '@rn-primitives/slot';
+import type { Insets, PositionedContentProps } from '@rn-primitives/types';
+import * as React from 'react';
+import {
+    BackHandler,
+    Pressable,
+    Text as RNText,
+    View,
+    type GestureResponderEvent,
+    type LayoutChangeEvent,
+    type LayoutRectangle,
+    type PressableProps,
+    type TextProps,
+    type ViewProps,
+    type ViewStyle,
+} from 'react-native';
+import { useAugmentedRef, useControllableState, useRelativePosition } from './hooks';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type ViewRef = React.ElementRef<typeof View>;
+type PressableRef = React.ElementRef<typeof Pressable>;
+type TextRef = React.ElementRef<typeof RNText>;
+
+interface TriggerPosition {
+  width: number;
+  height: number;
+  pageX: number;
+  pageY: number;
+}
+
+interface RootContext {
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+  triggerPosition: TriggerPosition | null;
+  setTriggerPosition: React.Dispatch<React.SetStateAction<TriggerPosition | null>>;
+  contentLayout: LayoutRectangle | null;
+  setContentLayout: React.Dispatch<React.SetStateAction<LayoutRectangle | null>>;
+  nativeID: string;
+}
+
+interface RootProps extends ViewProps {
+  asChild?: boolean;
+  onOpenChange?: (value: boolean) => void;
+}
+
+interface PortalProps {
+  children: React.ReactNode;
+  forceMount?: true | undefined;
+  hostName?: string;
+}
+
+interface OverlayProps extends PressableProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+  closeOnPress?: boolean;
+}
+
+interface ContentProps
+  extends Omit<PositionedContentProps, 'style' | 'loop' | 'onCloseAutoFocus' | 'onEscapeKeyDown' | 'onPointerDownOutside' | 'onFocusOutside' | 'onInteractOutside' | 'collisionBoundary' | 'sticky' | 'hideWhenDetached'>,
+    Omit<PressableProps, 'style'> {
+  asChild?: boolean;
+  style?: ViewStyle;
+}
+
+interface TriggerProps extends PressableProps {
+  asChild?: boolean;
+}
+
+interface ItemProps extends PressableProps {
+  asChild?: boolean;
+  textValue?: string;
+  closeOnPress?: boolean;
+}
+
+interface GroupProps extends ViewProps {
+  asChild?: boolean;
+}
+
+interface LabelProps extends TextProps {
+  asChild?: boolean;
+}
+
+interface CheckboxItemProps extends PressableProps {
+  asChild?: boolean;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+  textValue?: string;
+  closeOnPress?: boolean;
+}
+
+interface RadioGroupProps extends ViewProps {
+  asChild?: boolean;
+  value: string;
+  onValueChange: (value: string) => void;
+}
+
+interface RadioItemProps extends PressableProps {
+  asChild?: boolean;
+  value: string;
+  textValue?: string;
+  closeOnPress?: boolean;
+}
+
+interface ItemIndicatorProps extends ViewProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+}
+
+interface SeparatorProps extends ViewProps {
+  asChild?: boolean;
+  decorative?: boolean;
+}
+
+interface SubProps extends ViewProps {
+  asChild?: boolean;
+  defaultOpen?: boolean;
+  open?: boolean;
+  onOpenChange?: (value: boolean) => void;
+}
+
+interface SubTriggerProps extends PressableProps {
+  asChild?: boolean;
+  textValue?: string;
+}
+
+interface SubContentProps extends PressableProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+}
+
+// ============================================================================
+// Context - EXPORTED so it can be re-provided after FullWindowOverlay
+// ============================================================================
+
+const DropdownMenuContext = React.createContext<RootContext | null>(null);
+
+function useRootContext(): RootContext {
+  const context = React.useContext(DropdownMenuContext);
+  if (!context) {
+    throw new Error(
+      'DropdownMenu compound components cannot be rendered outside the DropdownMenu component'
+    );
+  }
+  return context;
+}
+
+// ============================================================================
+// Components
+// ============================================================================
+
+const Root = React.forwardRef<ViewRef, RootProps>(
+  ({ asChild, onOpenChange: onOpenChangeProp, ...viewProps }, ref) => {
+    const nativeID = React.useId();
+    const [triggerPosition, setTriggerPosition] = React.useState<TriggerPosition | null>(null);
+    const [contentLayout, setContentLayout] = React.useState<LayoutRectangle | null>(null);
+    const [open, setOpen] = React.useState(false);
+
+    // Memoize to prevent infinite re-render loops in Content's useEffect
+    const onOpenChange = React.useCallback(
+      (value: boolean) => {
+        setOpen(value);
+        onOpenChangeProp?.(value);
+      },
+      [onOpenChangeProp]
+    );
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <DropdownMenuContext.Provider
+        value={{
+          open,
+          onOpenChange,
+          contentLayout,
+          setContentLayout,
+          nativeID,
+          setTriggerPosition,
+          triggerPosition,
+        }}>
+        <Component ref={ref} {...viewProps} />
+      </DropdownMenuContext.Provider>
+    );
+  }
+);
+Root.displayName = 'RootNativeDropdownMenu';
+
+const Trigger = React.forwardRef<PressableRef, TriggerProps>(
+  ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
+    const { open, onOpenChange, setTriggerPosition } = useRootContext();
+
+    const augmentedRef = useAugmentedRef({
+      ref,
+      methods: {
+        open: () => {
+          onOpenChange(true);
+          (augmentedRef.current as any)?.measure?.(
+            (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
+              setTriggerPosition({ width, pageX, pageY, height });
+            }
+          );
+        },
+        close: () => {
+          setTriggerPosition(null);
+          onOpenChange(false);
+        },
+      },
+    });
+
+    function onPress(ev: GestureResponderEvent) {
+      if (disabled) return;
+      (augmentedRef.current as any)?.measure?.(
+        (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
+          setTriggerPosition({ width, pageX, pageY, height });
+        }
+      );
+      const newValue = !open;
+      onOpenChange(newValue);
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={augmentedRef}
+        aria-disabled={disabled ?? undefined}
+        role="button"
+        onPress={onPress}
+        disabled={disabled ?? undefined}
+        aria-expanded={open}
+        {...props}
+      />
+    );
+  }
+);
+Trigger.displayName = 'TriggerNativeDropdownMenu';
+
+/**
+ * Portal component that wraps content for rendering in a portal.
+ * FIX: Only passes hostName when explicitly provided (not undefined)
+ */
+function Portal({ forceMount, hostName, children }: PortalProps) {
+  const value = useRootContext();
+
+  if (!value.triggerPosition) {
+    return null;
+  }
+
+  if (!forceMount) {
+    if (!value.open) {
+      return null;
+    }
+  }
+
+  // FIX: Only pass hostName if explicitly provided
+  const portalProps = hostName ? { hostName } : {};
+
+  return (
+    <RNPortal {...portalProps} name={`${value.nativeID}_portal`}>
+      <DropdownMenuContext.Provider value={value}>{children}</DropdownMenuContext.Provider>
+    </RNPortal>
+  );
+}
+
+const Overlay = React.forwardRef<PressableRef, OverlayProps>(
+  ({ asChild, forceMount, onPress: OnPressProp, closeOnPress = true, ...props }, ref) => {
+    const { open, onOpenChange, setContentLayout, setTriggerPosition } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (closeOnPress) {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }
+      OnPressProp?.(ev);
+    }
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return <Component ref={ref} onPress={onPress} {...props} />;
+  }
+);
+Overlay.displayName = 'OverlayNativeDropdownMenu';
+
+const Content = React.forwardRef<PressableRef, ContentProps>(
+  (
+    {
+      asChild = false,
+      forceMount,
+      align = 'start',
+      side = 'bottom',
+      sideOffset = 0,
+      alignOffset = 0,
+      avoidCollisions = true,
+      onLayout: onLayoutProp,
+      insets,
+      style,
+      disablePositioningStyle,
+      ...props
+    },
+    ref
+  ) => {
+    const {
+      open,
+      onOpenChange,
+      nativeID,
+      triggerPosition,
+      setTriggerPosition,
+      contentLayout,
+      setContentLayout,
+    } = useRootContext();
+
+    React.useEffect(() => {
+      const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+        return true;
+      });
+      return () => {
+        setContentLayout(null);
+        backHandler.remove();
+      };
+    }, [onOpenChange, setContentLayout, setTriggerPosition]);
+
+    const positionStyle = useRelativePosition({
+      align,
+      avoidCollisions,
+      triggerPosition,
+      contentLayout,
+      alignOffset,
+      insets: insets as Insets,
+      sideOffset,
+      side,
+      disablePositioningStyle,
+    });
+
+    function onLayout(event: LayoutChangeEvent) {
+      setContentLayout(event.nativeEvent.layout);
+      onLayoutProp?.(event);
+    }
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        role="menu"
+        nativeID={nativeID}
+        aria-modal={true}
+        style={[positionStyle as ViewStyle, style]}
+        onLayout={onLayout}
+        {...props}
+      />
+    );
+  }
+);
+Content.displayName = 'ContentNativeDropdownMenu';
+
+const Item = React.forwardRef<PressableRef, ItemProps>(
+  ({ asChild, textValue, onPress: onPressProp, disabled = false, closeOnPress = true, ...props }, ref) => {
+    const { onOpenChange, setTriggerPosition, setContentLayout } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (closeOnPress) {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        role="menuitem"
+        onPress={onPress}
+        disabled={disabled}
+        aria-valuetext={textValue}
+        aria-disabled={!!disabled}
+        accessibilityState={{ disabled: !!disabled }}
+        {...props}
+      />
+    );
+  }
+);
+Item.displayName = 'ItemNativeDropdownMenu';
+
+const Group = React.forwardRef<ViewRef, GroupProps>(({ asChild, ...props }, ref) => {
+  const Component = asChild ? Slot.View : View;
+  return <Component ref={ref} role="group" {...props} />;
+});
+Group.displayName = 'GroupNativeDropdownMenu';
+
+const Label = React.forwardRef<TextRef, LabelProps>(({ asChild, ...props }, ref) => {
+  const Component = asChild ? Slot.Text : RNText;
+  return <Component ref={ref} {...props} />;
+});
+Label.displayName = 'LabelNativeDropdownMenu';
+
+// Form item context for checkbox/radio
+interface FormItemContextValue {
+  checked?: boolean;
+  value?: string;
+  onValueChange?: (value: string) => void;
+}
+
+const FormItemContext = React.createContext<FormItemContextValue | null>(null);
+
+const CheckboxItem = React.forwardRef<PressableRef, CheckboxItemProps>(
+  (
+    {
+      asChild,
+      checked,
+      onCheckedChange,
+      textValue,
+      onPress: onPressProp,
+      closeOnPress = true,
+      disabled = false,
+      ...props
+    },
+    ref
+  ) => {
+    const { onOpenChange, setContentLayout, setTriggerPosition } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      onCheckedChange(!checked);
+      if (closeOnPress) {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <FormItemContext.Provider value={{ checked }}>
+        <Component
+          ref={ref}
+          role="checkbox"
+          aria-checked={checked}
+          onPress={onPress}
+          disabled={disabled}
+          aria-disabled={!!disabled}
+          aria-valuetext={textValue}
+          accessibilityState={{ disabled: !!disabled }}
+          {...props}
+        />
+      </FormItemContext.Provider>
+    );
+  }
+);
+CheckboxItem.displayName = 'CheckboxItemNativeDropdownMenu';
+
+function useFormItemContext() {
+  const context = React.useContext(FormItemContext);
+  if (!context) {
+    throw new Error(
+      'CheckboxItem or RadioItem compound components cannot be rendered outside of a CheckboxItem or RadioItem component'
+    );
+  }
+  return context;
+}
+
+const RadioGroup = React.forwardRef<ViewRef, RadioGroupProps>(
+  ({ asChild, value, onValueChange, ...props }, ref) => {
+    const Component = asChild ? Slot.View : View;
+    return (
+      <FormItemContext.Provider value={{ value, onValueChange }}>
+        <Component ref={ref} role="radiogroup" {...props} />
+      </FormItemContext.Provider>
+    );
+  }
+);
+RadioGroup.displayName = 'RadioGroupNativeDropdownMenu';
+
+interface RadioItemContextValue {
+  itemValue?: string;
+}
+
+const RadioItemContext = React.createContext<RadioItemContextValue>({});
+
+const RadioItem = React.forwardRef<PressableRef, RadioItemProps>(
+  (
+    {
+      asChild,
+      value: itemValue,
+      textValue,
+      onPress: onPressProp,
+      disabled = false,
+      closeOnPress = true,
+      ...props
+    },
+    ref
+  ) => {
+    const { onOpenChange, setContentLayout, setTriggerPosition } = useRootContext();
+    const { value, onValueChange } = useFormItemContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      onValueChange?.(itemValue);
+      if (closeOnPress) {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <RadioItemContext.Provider value={{ itemValue }}>
+        <Component
+          ref={ref}
+          onPress={onPress}
+          role="radio"
+          aria-checked={value === itemValue}
+          disabled={disabled ?? false}
+          accessibilityState={{
+            disabled: disabled ?? false,
+            checked: value === itemValue,
+          }}
+          aria-valuetext={textValue}
+          {...props}
+        />
+      </RadioItemContext.Provider>
+    );
+  }
+);
+RadioItem.displayName = 'RadioItemNativeDropdownMenu';
+
+function useItemIndicatorContext() {
+  return React.useContext(RadioItemContext);
+}
+
+const ItemIndicator = React.forwardRef<ViewRef, ItemIndicatorProps>(
+  ({ asChild, forceMount, ...props }, ref) => {
+    const { itemValue } = useItemIndicatorContext();
+    const { checked, value } = useFormItemContext();
+
+    if (!forceMount) {
+      if (itemValue == null && !checked) {
+        return null;
+      }
+      if (value !== itemValue) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.View : View;
+    return <Component ref={ref} role="presentation" {...props} />;
+  }
+);
+ItemIndicator.displayName = 'ItemIndicatorNativeDropdownMenu';
+
+const Separator = React.forwardRef<ViewRef, SeparatorProps>(
+  ({ asChild, decorative, ...props }, ref) => {
+    const Component = asChild ? Slot.View : View;
+    return <Component role={decorative ? 'presentation' : 'separator'} ref={ref} {...props} />;
+  }
+);
+Separator.displayName = 'SeparatorNativeDropdownMenu';
+
+// Sub menu context
+interface SubContext {
+  nativeID: string;
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+}
+
+const SubMenuContext = React.createContext<SubContext | null>(null);
+
+const Sub = React.forwardRef<ViewRef, SubProps>(
+  ({ asChild, defaultOpen, open: openProp, onOpenChange: onOpenChangeProp, ...props }, ref) => {
+    const nativeID = React.useId();
+    const [open = false, onOpenChange] = useControllableState({
+      prop: openProp,
+      defaultProp: defaultOpen,
+      onChange: onOpenChangeProp,
+    });
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <SubMenuContext.Provider value={{ nativeID, open, onOpenChange }}>
+        <Component ref={ref} {...props} />
+      </SubMenuContext.Provider>
+    );
+  }
+);
+Sub.displayName = 'SubNativeDropdownMenu';
+
+function useSubContext(): SubContext {
+  const context = React.useContext(SubMenuContext);
+  if (!context) {
+    throw new Error('Sub compound components cannot be rendered outside of a Sub component');
+  }
+  return context;
+}
+
+const SubTrigger = React.forwardRef<PressableRef, SubTriggerProps>(
+  ({ asChild, textValue, onPress: onPressProp, disabled = false, ...props }, ref) => {
+    const { nativeID, open, onOpenChange } = useSubContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      onOpenChange(!open);
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        aria-valuetext={textValue}
+        role="menuitem"
+        aria-expanded={open}
+        accessibilityState={{ expanded: open, disabled: !!disabled }}
+        nativeID={nativeID}
+        onPress={onPress}
+        disabled={disabled}
+        aria-disabled={!!disabled}
+        {...props}
+      />
+    );
+  }
+);
+SubTrigger.displayName = 'SubTriggerNativeDropdownMenu';
+
+const SubContent = React.forwardRef<PressableRef, SubContentProps>(
+  ({ asChild = false, forceMount, ...props }, ref) => {
+    const { open, nativeID } = useSubContext();
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+    return <Component ref={ref} role="group" aria-labelledby={nativeID} {...props} />;
+  }
+);
+SubContent.displayName = 'SubContentNativeDropdownMenu';
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export {
+    CheckboxItem,
+    Content,
+    DropdownMenuContext, // ADDED: Export context for re-providing after FullWindowOverlay
+    Group,
+    Item,
+    ItemIndicator,
+    Label,
+    Overlay,
+    Portal,
+    RadioGroup,
+    RadioItem,
+    Root,
+    Separator,
+    Sub,
+    SubContent,
+    SubTrigger,
+    Trigger,
+    useRootContext,
+    useSubContext
+};
+
+    export type {
+        CheckboxItemProps,
+        ContentProps,
+        GroupProps,
+        ItemIndicatorProps,
+        ItemProps,
+        LabelProps,
+        OverlayProps,
+        PortalProps,
+        RadioGroupProps,
+        RadioItemProps,
+        RootContext,
+        RootProps,
+        SeparatorProps,
+        SubContentProps,
+        SubProps,
+        SubTriggerProps,
+        TriggerProps
+    };
+

--- a/packages/frosted-ui-react-native/src/forked-primitives/dropdown-menu.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/dropdown-menu.tsx
@@ -207,6 +207,7 @@ const Trigger = React.forwardRef<PressableRef, TriggerProps>(
       methods: {
         open: () => {
           onOpenChange(true);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (augmentedRef.current as any)?.measure?.(
             (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
               setTriggerPosition({ width, pageX, pageY, height });
@@ -222,6 +223,7 @@ const Trigger = React.forwardRef<PressableRef, TriggerProps>(
 
     function onPress(ev: GestureResponderEvent) {
       if (disabled) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (augmentedRef.current as any)?.measure?.(
         (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
           setTriggerPosition({ width, pageX, pageY, height });

--- a/packages/frosted-ui-react-native/src/forked-primitives/dropdown-menu.web.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/dropdown-menu.web.tsx
@@ -1,0 +1,5 @@
+/**
+ * Web version - re-export from original package which uses @radix-ui/react-dropdown-menu
+ * Our native fixes (portal hostName, context re-provision) are not needed on web
+ */
+export * from '@rn-primitives/dropdown-menu';

--- a/packages/frosted-ui-react-native/src/forked-primitives/hooks.ts
+++ b/packages/frosted-ui-react-native/src/forked-primitives/hooks.ts
@@ -58,10 +58,13 @@ function useUncontrolledState<T>({
   return uncontrolledState;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
 export function useControllableState<T>({
   prop,
   defaultProp,
-  onChange = () => {},
+  onChange = noop,
 }: {
   prop?: T;
   defaultProp?: T;
@@ -118,7 +121,8 @@ export function useAugmentedRef<T = any>({
         ...methods,
       } as T;
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // deps is intentionally passed through from caller
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     deps
   );
 

--- a/packages/frosted-ui-react-native/src/forked-primitives/hooks.ts
+++ b/packages/frosted-ui-react-native/src/forked-primitives/hooks.ts
@@ -1,0 +1,248 @@
+/**
+ * Local implementations of hooks used by forked primitives.
+ * These are copied from @rn-primitives/hooks to avoid bundler issues
+ * where React resolves to null in certain configurations.
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+  type DependencyList,
+  type ForwardedRef,
+} from 'react';
+import { Dimensions, type LayoutRectangle } from 'react-native';
+
+// ============================================================================
+// useCallbackRef
+// ============================================================================
+
+export function useCallbackRef<T extends (...args: never[]) => unknown>(
+  callback: T | undefined
+): T {
+  const callbackRef = useRef(callback);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  });
+
+  return useCallback(((...args) => callbackRef.current?.(...args)) as T, []);
+}
+
+// ============================================================================
+// useControllableState
+// ============================================================================
+
+function useUncontrolledState<T>({
+  defaultProp,
+  onChange,
+}: {
+  defaultProp?: T;
+  onChange?: (value: T) => void;
+}) {
+  const uncontrolledState = useState<T | undefined>(defaultProp);
+  const [value] = uncontrolledState;
+  const prevValueRef = useRef(value);
+  const handleChange = useCallbackRef(onChange);
+
+  useEffect(() => {
+    if (prevValueRef.current !== value) {
+      handleChange(value as T);
+      prevValueRef.current = value;
+    }
+  }, [value, prevValueRef, handleChange]);
+
+  return uncontrolledState;
+}
+
+export function useControllableState<T>({
+  prop,
+  defaultProp,
+  onChange = () => {},
+}: {
+  prop?: T;
+  defaultProp?: T;
+  onChange?: (value: T) => void;
+}): [T | undefined, (value: T | ((prev: T | undefined) => T)) => void] {
+  const [uncontrolledProp, setUncontrolledProp] = useUncontrolledState({
+    defaultProp,
+    onChange,
+  });
+  const isControlled = prop !== undefined;
+  const value = isControlled ? prop : uncontrolledProp;
+  const handleChange = useCallbackRef(onChange);
+
+  const setValue = useCallback(
+    (nextValue: T | ((prev: T | undefined) => T)) => {
+      if (isControlled) {
+        const setter = nextValue as (prev: T | undefined) => T;
+        const newValue = typeof nextValue === 'function' ? setter(prop) : nextValue;
+        if (newValue !== prop) handleChange(newValue);
+      } else {
+        setUncontrolledProp(nextValue as T);
+      }
+    },
+    [isControlled, prop, setUncontrolledProp, handleChange]
+  );
+
+  return [value, setValue];
+}
+
+// ============================================================================
+// useAugmentedRef - uses useImperativeHandle like the original
+// ============================================================================
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useAugmentedRef<T = any>({
+  ref,
+  methods,
+  deps = [],
+}: {
+  ref: ForwardedRef<T>;
+  methods: Record<string, (...args: unknown[]) => unknown>;
+  deps?: DependencyList;
+}) {
+  const augmentedRef = useRef<T>(null);
+
+  useImperativeHandle(
+    ref,
+    () => {
+      if (typeof augmentedRef === 'function' || !augmentedRef?.current) {
+        return {} as T;
+      }
+      return {
+        ...augmentedRef.current,
+        ...methods,
+      } as T;
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    deps
+  );
+
+  return augmentedRef;
+}
+
+// ============================================================================
+// useRelativePosition
+// ============================================================================
+
+interface Insets {
+  top?: number;
+  bottom?: number;
+  left?: number;
+  right?: number;
+}
+
+interface TriggerPosition {
+  width: number;
+  height: number;
+  pageX: number;
+  pageY: number;
+}
+
+interface UseRelativePositionArgs {
+  align: 'start' | 'center' | 'end';
+  avoidCollisions: boolean;
+  triggerPosition: TriggerPosition | null;
+  contentLayout: LayoutRectangle | null;
+  alignOffset: number;
+  insets?: Insets;
+  sideOffset: number;
+  side: 'top' | 'bottom';
+  disablePositioningStyle?: boolean;
+}
+
+export function useRelativePosition({
+  align,
+  avoidCollisions,
+  triggerPosition,
+  contentLayout,
+  alignOffset,
+  insets,
+  sideOffset,
+  side,
+  disablePositioningStyle,
+}: UseRelativePositionArgs) {
+  // Get dimensions once and extract values to avoid object reference issues
+  const { width: screenWidth, height: screenHeight } = Dimensions.get('screen');
+
+  return useMemo(() => {
+    if (disablePositioningStyle) {
+      return {};
+    }
+
+    if (!triggerPosition || !contentLayout) {
+      return {
+        position: 'absolute' as const,
+        opacity: 0,
+      };
+    }
+
+    const { width: triggerWidth, height: triggerHeight, pageX, pageY } = triggerPosition;
+    const { width: contentWidth, height: contentHeight } = contentLayout;
+
+    const insetsTop = insets?.top ?? 0;
+    const insetsBottom = insets?.bottom ?? 0;
+    const insetsLeft = insets?.left ?? 0;
+    const insetsRight = insets?.right ?? 0;
+
+    let top = 0;
+    let left = 0;
+
+    // Calculate vertical position
+    if (side === 'bottom') {
+      top = pageY + triggerHeight + sideOffset;
+    } else {
+      top = pageY - contentHeight - sideOffset;
+    }
+
+    // Calculate horizontal position based on alignment
+    if (align === 'start') {
+      left = pageX + alignOffset;
+    } else if (align === 'center') {
+      left = pageX + triggerWidth / 2 - contentWidth / 2 + alignOffset;
+    } else {
+      left = pageX + triggerWidth - contentWidth + alignOffset;
+    }
+
+    // Avoid collisions
+    if (avoidCollisions) {
+      // Horizontal collision detection
+      if (left < insetsLeft) {
+        left = insetsLeft;
+      } else if (left + contentWidth > screenWidth - insetsRight) {
+        left = screenWidth - insetsRight - contentWidth;
+      }
+
+      // Vertical collision detection
+      if (side === 'bottom' && top + contentHeight > screenHeight - insetsBottom) {
+        // Flip to top
+        top = pageY - contentHeight - sideOffset;
+      } else if (side === 'top' && top < insetsTop) {
+        // Flip to bottom
+        top = pageY + triggerHeight + sideOffset;
+      }
+    }
+
+    return {
+      position: 'absolute' as const,
+      top,
+      left,
+    };
+  }, [
+    align,
+    avoidCollisions,
+    triggerPosition,
+    contentLayout,
+    alignOffset,
+    insets,
+    sideOffset,
+    side,
+    screenWidth,
+    screenHeight,
+    disablePositioningStyle,
+  ]);
+}

--- a/packages/frosted-ui-react-native/src/forked-primitives/index.ts
+++ b/packages/frosted-ui-react-native/src/forked-primitives/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Forked primitives from @rn-primitives
+ *
+ * These are local copies of @rn-primitives packages with fixes for:
+ * 1. Portal hostName issue - passing undefined bypasses default
+ * 2. Context loss through FullWindowOverlay - contexts are now exported
+ *
+ * As @rn-primitives fixes these issues upstream, we can gradually remove
+ * these forked versions and switch back to the original packages.
+ */
+
+export * as AlertDialogPrimitive from './alert-dialog';
+export * as ContextMenuPrimitive from './context-menu';
+export * as DialogPrimitive from './dialog';
+export * as DropdownMenuPrimitive from './dropdown-menu';
+export * as PopoverPrimitive from './popover';
+export * as SelectPrimitive from './select';
+

--- a/packages/frosted-ui-react-native/src/forked-primitives/popover.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/popover.tsx
@@ -143,6 +143,7 @@ const Trigger = React.forwardRef<PressableRef, TriggerProps>(
       methods: {
         open: () => {
           onOpenChange(true);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (augmentedRef.current as any)?.measure?.(
             (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
               setTriggerPosition({ width, pageX, pageY, height });
@@ -158,6 +159,7 @@ const Trigger = React.forwardRef<PressableRef, TriggerProps>(
 
     function onPress(ev: GestureResponderEvent) {
       if (disabled) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (augmentedRef.current as any)?.measure?.(
         (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
           setTriggerPosition({ width, pageX, pageY, height });

--- a/packages/frosted-ui-react-native/src/forked-primitives/popover.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/popover.tsx
@@ -1,0 +1,382 @@
+/**
+ * Forked from @rn-primitives/popover
+ *
+ * Changes from original:
+ * - Export PopoverContext so it can be re-provided after FullWindowOverlay breaks context
+ * - Fix Portal to not pass hostName when undefined (bypasses default)
+ * - Use local hooks implementation to avoid bundler issues
+ * - Convert to TypeScript
+ */
+
+import { Portal as RNPortal } from '@rn-primitives/portal';
+import * as Slot from '@rn-primitives/slot';
+import type { Insets, PositionedContentProps } from '@rn-primitives/types';
+import * as React from 'react';
+import {
+  BackHandler,
+  Pressable,
+  View,
+  type GestureResponderEvent,
+  type LayoutChangeEvent,
+  type LayoutRectangle,
+  type PressableProps,
+  type ViewProps,
+  type ViewStyle,
+} from 'react-native';
+import { useAugmentedRef, useRelativePosition } from './hooks';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type ViewRef = React.ElementRef<typeof View>;
+type PressableRef = React.ElementRef<typeof Pressable>;
+
+interface TriggerPosition {
+  width: number;
+  height: number;
+  pageX: number;
+  pageY: number;
+}
+
+interface RootContext {
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+  triggerPosition: TriggerPosition | null;
+  setTriggerPosition: React.Dispatch<React.SetStateAction<TriggerPosition | null>>;
+  contentLayout: LayoutRectangle | null;
+  setContentLayout: React.Dispatch<React.SetStateAction<LayoutRectangle | null>>;
+  nativeID: string;
+}
+
+interface RootProps extends ViewProps {
+  asChild?: boolean;
+  onOpenChange?: (value: boolean) => void;
+}
+
+interface PortalProps {
+  children: React.ReactNode;
+  forceMount?: true | undefined;
+  hostName?: string;
+}
+
+interface OverlayProps extends PressableProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+  closeOnPress?: boolean;
+}
+
+interface ContentProps
+  extends Omit<PositionedContentProps, 'style' | 'loop' | 'onCloseAutoFocus' | 'onEscapeKeyDown' | 'onPointerDownOutside' | 'onFocusOutside' | 'onInteractOutside' | 'collisionBoundary' | 'sticky' | 'hideWhenDetached'>,
+    ViewProps {
+  asChild?: boolean;
+}
+
+interface TriggerProps extends PressableProps {
+  asChild?: boolean;
+}
+
+interface CloseProps extends PressableProps {
+  asChild?: boolean;
+}
+
+// ============================================================================
+// Context - EXPORTED so it can be re-provided after FullWindowOverlay
+// ============================================================================
+
+const PopoverContext = React.createContext<RootContext | null>(null);
+
+function useRootContext(): RootContext {
+  const context = React.useContext(PopoverContext);
+  if (!context) {
+    throw new Error('Popover compound components cannot be rendered outside the Popover component');
+  }
+  return context;
+}
+
+// ============================================================================
+// Components
+// ============================================================================
+
+const Root = React.forwardRef<ViewRef, RootProps>(
+  ({ asChild, onOpenChange: onOpenChangeProp, ...viewProps }, ref) => {
+    const nativeID = React.useId();
+    const [triggerPosition, setTriggerPosition] = React.useState<TriggerPosition | null>(null);
+    const [contentLayout, setContentLayout] = React.useState<LayoutRectangle | null>(null);
+    const [open, setOpen] = React.useState(false);
+
+    // Memoize to prevent infinite re-render loops in Content's useEffect
+    const onOpenChange = React.useCallback(
+      (value: boolean) => {
+        setOpen(value);
+        onOpenChangeProp?.(value);
+      },
+      [onOpenChangeProp]
+    );
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <PopoverContext.Provider
+        value={{
+          open,
+          onOpenChange,
+          contentLayout,
+          nativeID,
+          setContentLayout,
+          setTriggerPosition,
+          triggerPosition,
+        }}>
+        <Component ref={ref} {...viewProps} />
+      </PopoverContext.Provider>
+    );
+  }
+);
+Root.displayName = 'RootNativePopover';
+
+const Trigger = React.forwardRef<PressableRef, TriggerProps>(
+  ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
+    const { onOpenChange, open, setTriggerPosition } = useRootContext();
+
+    const augmentedRef = useAugmentedRef({
+      ref,
+      methods: {
+        open: () => {
+          onOpenChange(true);
+          (augmentedRef.current as any)?.measure?.(
+            (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
+              setTriggerPosition({ width, pageX, pageY, height });
+            }
+          );
+        },
+        close: () => {
+          setTriggerPosition(null);
+          onOpenChange(false);
+        },
+      },
+    });
+
+    function onPress(ev: GestureResponderEvent) {
+      if (disabled) return;
+      (augmentedRef.current as any)?.measure?.(
+        (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
+          setTriggerPosition({ width, pageX, pageY, height });
+        }
+      );
+      onOpenChange(!open);
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={augmentedRef}
+        aria-disabled={disabled ?? undefined}
+        role="button"
+        onPress={onPress}
+        disabled={disabled ?? undefined}
+        {...props}
+      />
+    );
+  }
+);
+Trigger.displayName = 'TriggerNativePopover';
+
+/**
+ * Portal component that wraps content for rendering in a portal.
+ * FIX: Only passes hostName when explicitly provided (not undefined)
+ */
+function Portal({ forceMount, hostName, children }: PortalProps) {
+  const value = useRootContext();
+
+  if (!value.triggerPosition) {
+    return null;
+  }
+
+  if (!forceMount) {
+    if (!value.open) {
+      return null;
+    }
+  }
+
+  // FIX: Only pass hostName if explicitly provided
+  const portalProps = hostName ? { hostName } : {};
+
+  return (
+    <RNPortal {...portalProps} name={`${value.nativeID}_portal`}>
+      <PopoverContext.Provider value={value}>{children}</PopoverContext.Provider>
+    </RNPortal>
+  );
+}
+
+const Overlay = React.forwardRef<PressableRef, OverlayProps>(
+  ({ asChild, forceMount, onPress: OnPressProp, closeOnPress = true, ...props }, ref) => {
+    const { open, onOpenChange, setTriggerPosition, setContentLayout } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (closeOnPress) {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }
+      OnPressProp?.(ev);
+    }
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return <Component ref={ref} onPress={onPress} {...props} />;
+  }
+);
+Overlay.displayName = 'OverlayNativePopover';
+
+const Content = React.forwardRef<ViewRef, ContentProps>(
+  (
+    {
+      asChild = false,
+      forceMount,
+      align = 'start',
+      side = 'bottom',
+      sideOffset = 0,
+      alignOffset = 0,
+      avoidCollisions = true,
+      onLayout: onLayoutProp,
+      insets,
+      style,
+      disablePositioningStyle,
+      ...props
+    },
+    ref
+  ) => {
+    const {
+      open,
+      onOpenChange,
+      contentLayout,
+      nativeID,
+      setContentLayout,
+      setTriggerPosition,
+      triggerPosition,
+    } = useRootContext();
+
+    React.useEffect(() => {
+      const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+        return true;
+      });
+      return () => {
+        setContentLayout(null);
+        backHandler.remove();
+      };
+    }, [onOpenChange, setContentLayout, setTriggerPosition]);
+
+    const positionStyle = useRelativePosition({
+      align,
+      avoidCollisions,
+      triggerPosition,
+      contentLayout,
+      alignOffset,
+      insets: insets as Insets,
+      sideOffset,
+      side,
+      disablePositioningStyle,
+    });
+
+    function onLayout(event: LayoutChangeEvent) {
+      setContentLayout(event.nativeEvent.layout);
+      onLayoutProp?.(event);
+    }
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <Component
+        ref={ref}
+        role="dialog"
+        nativeID={nativeID}
+        aria-modal={true}
+        style={[positionStyle as ViewStyle, style]}
+        onLayout={onLayout}
+        onStartShouldSetResponder={onStartShouldSetResponder}
+        {...props}
+      />
+    );
+  }
+);
+Content.displayName = 'ContentNativePopover';
+
+const Close = React.forwardRef<PressableRef, CloseProps>(
+  ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
+    const { onOpenChange, setContentLayout, setTriggerPosition } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (disabled) return;
+      setTriggerPosition(null);
+      setContentLayout(null);
+      onOpenChange(false);
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={ref}
+        aria-disabled={disabled ?? undefined}
+        role="button"
+        onPress={onPress}
+        disabled={disabled ?? undefined}
+        {...props}
+      />
+    );
+  }
+);
+Close.displayName = 'CloseNativePopover';
+
+function onStartShouldSetResponder() {
+  return true;
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export {
+  Close,
+  Content,
+  Overlay,
+  PopoverContext, // ADDED: Export context for re-providing after FullWindowOverlay
+  Portal,
+  Root,
+  Trigger,
+  useRootContext,
+};
+
+export type {
+  CloseProps,
+  ContentProps,
+  OverlayProps,
+  PortalProps,
+  RootContext,
+  RootProps,
+  TriggerProps,
+  PressableRef as CloseRef,
+  ViewRef as ContentRef,
+  PressableRef as OverlayRef,
+  ViewRef as RootRef,
+  PressableRef as TriggerRef,
+};
+

--- a/packages/frosted-ui-react-native/src/forked-primitives/popover.web.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/popover.web.tsx
@@ -1,0 +1,5 @@
+/**
+ * Web version - re-export from original package which uses @radix-ui/react-popover
+ * Our native fixes (portal hostName, context re-provision) are not needed on web
+ */
+export * from '@rn-primitives/popover';

--- a/packages/frosted-ui-react-native/src/forked-primitives/select.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/select.tsx
@@ -224,6 +224,7 @@ const Trigger = React.forwardRef<PressableRef, TriggerProps>(
       methods: {
         open: () => {
           onOpenChange(true);
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           (augmentedRef.current as any)?.measure?.(
             (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
               setTriggerPosition({ width, pageX, pageY, height });
@@ -239,6 +240,7 @@ const Trigger = React.forwardRef<PressableRef, TriggerProps>(
 
     function onPress(ev: GestureResponderEvent) {
       if (disabled) return;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (augmentedRef.current as any)?.measure?.(
         (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
           setTriggerPosition({ width, pageX, pageY, height });
@@ -337,7 +339,7 @@ const Content = React.forwardRef<ViewRef, ContentProps>(
       insets,
       style,
       disablePositioningStyle,
-      position: _position,
+      position: _position, // eslint-disable-line @typescript-eslint/no-unused-vars
       ...props
     },
     ref

--- a/packages/frosted-ui-react-native/src/forked-primitives/select.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/select.tsx
@@ -1,0 +1,545 @@
+/**
+ * Forked from @rn-primitives/select
+ *
+ * Changes from original:
+ * - Export SelectContext so it can be re-provided after FullWindowOverlay breaks context
+ * - Fix Portal to not pass hostName when undefined (bypasses default)
+ * - Use local hooks implementation to avoid bundler issues
+ * - Convert to TypeScript
+ */
+
+import { Portal as RNPortal } from '@rn-primitives/portal';
+import * as Slot from '@rn-primitives/slot';
+import type { Insets, PositionedContentProps } from '@rn-primitives/types';
+import * as React from 'react';
+import {
+  BackHandler,
+  Pressable,
+  Text as RNText,
+  View,
+  type GestureResponderEvent,
+  type LayoutChangeEvent,
+  type LayoutRectangle,
+  type PressableProps,
+  type TextProps,
+  type ViewProps,
+  type ViewStyle,
+} from 'react-native';
+import { useAugmentedRef, useControllableState, useRelativePosition } from './hooks';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type ViewRef = React.ElementRef<typeof View>;
+type PressableRef = React.ElementRef<typeof Pressable>;
+type TextRef = React.ElementRef<typeof RNText>;
+
+interface TriggerPosition {
+  width: number;
+  height: number;
+  pageX: number;
+  pageY: number;
+}
+
+interface SelectValue {
+  value: string;
+  label: string;
+}
+
+interface RootContext {
+  value: SelectValue | undefined;
+  onValueChange: (value: SelectValue) => void;
+  open: boolean;
+  onOpenChange: (value: boolean) => void;
+  disabled?: boolean;
+  triggerPosition: TriggerPosition | null;
+  setTriggerPosition: React.Dispatch<React.SetStateAction<TriggerPosition | null>>;
+  contentLayout: LayoutRectangle | null;
+  setContentLayout: React.Dispatch<React.SetStateAction<LayoutRectangle | null>>;
+  nativeID: string;
+}
+
+interface RootProps extends ViewProps {
+  asChild?: boolean;
+  value?: SelectValue;
+  defaultValue?: SelectValue;
+  onValueChange?: (value: SelectValue) => void;
+  onOpenChange?: (value: boolean) => void;
+  disabled?: boolean;
+}
+
+interface PortalProps {
+  children: React.ReactNode;
+  forceMount?: true | undefined;
+  hostName?: string;
+}
+
+interface OverlayProps extends PressableProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+  closeOnPress?: boolean;
+}
+
+interface ContentProps
+  extends Omit<PositionedContentProps, 'style' | 'loop' | 'onCloseAutoFocus' | 'onEscapeKeyDown' | 'onPointerDownOutside' | 'onFocusOutside' | 'onInteractOutside' | 'collisionBoundary' | 'sticky' | 'hideWhenDetached'>,
+    ViewProps {
+  asChild?: boolean;
+  position?: 'popper' | 'item-aligned';
+}
+
+interface TriggerProps extends PressableProps {
+  asChild?: boolean;
+}
+
+interface ValueProps extends TextProps {
+  asChild?: boolean;
+  placeholder?: string;
+}
+
+interface ItemProps extends PressableProps {
+  asChild?: boolean;
+  value: string;
+  label: string;
+  closeOnPress?: boolean;
+}
+
+interface ItemTextProps extends TextProps {
+  asChild?: boolean;
+}
+
+interface ItemIndicatorProps extends ViewProps {
+  asChild?: boolean;
+  forceMount?: true | undefined;
+}
+
+interface GroupProps extends ViewProps {
+  asChild?: boolean;
+}
+
+interface LabelProps extends TextProps {
+  asChild?: boolean;
+}
+
+interface SeparatorProps extends ViewProps {
+  asChild?: boolean;
+  decorative?: boolean;
+}
+
+// ============================================================================
+// Context - EXPORTED so it can be re-provided after FullWindowOverlay
+// ============================================================================
+
+const SelectContext = React.createContext<RootContext | null>(null);
+
+function useRootContext(): RootContext {
+  const context = React.useContext(SelectContext);
+  if (!context) {
+    throw new Error('Select compound components cannot be rendered outside the Select component');
+  }
+  return context;
+}
+
+// Item context
+interface ItemContextValue {
+  itemValue: string;
+  label: string;
+}
+
+const ItemContext = React.createContext<ItemContextValue | null>(null);
+
+function useItemContext(): ItemContextValue {
+  const context = React.useContext(ItemContext);
+  if (!context) {
+    throw new Error('Item compound components cannot be rendered outside of an Item component');
+  }
+  return context;
+}
+
+// ============================================================================
+// Components
+// ============================================================================
+
+const Root = React.forwardRef<ViewRef, RootProps>(
+  (
+    {
+      asChild,
+      value: valueProp,
+      defaultValue,
+      onValueChange: onValueChangeProp,
+      onOpenChange: onOpenChangeProp,
+      disabled,
+      ...viewProps
+    },
+    ref
+  ) => {
+    const nativeID = React.useId();
+    const [value, onValueChange] = useControllableState({
+      prop: valueProp,
+      defaultProp: defaultValue,
+      onChange: onValueChangeProp,
+    });
+    const [triggerPosition, setTriggerPosition] = React.useState<TriggerPosition | null>(null);
+    const [contentLayout, setContentLayout] = React.useState<LayoutRectangle | null>(null);
+    const [open, setOpen] = React.useState(false);
+
+    // Memoize to prevent infinite re-render loops in Content's useEffect
+    const onOpenChange = React.useCallback(
+      (val: boolean) => {
+        setOpen(val);
+        onOpenChangeProp?.(val);
+      },
+      [onOpenChangeProp]
+    );
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <SelectContext.Provider
+        value={{
+          value,
+          onValueChange,
+          open,
+          onOpenChange,
+          disabled,
+          contentLayout,
+          nativeID,
+          setContentLayout,
+          setTriggerPosition,
+          triggerPosition,
+        }}>
+        <Component ref={ref} {...viewProps} />
+      </SelectContext.Provider>
+    );
+  }
+);
+Root.displayName = 'RootNativeSelect';
+
+const Trigger = React.forwardRef<PressableRef, TriggerProps>(
+  ({ asChild, onPress: onPressProp, disabled = false, ...props }, ref) => {
+    const { open, onOpenChange, disabled: disabledRoot, setTriggerPosition } = useRootContext();
+
+    const augmentedRef = useAugmentedRef({
+      ref,
+      methods: {
+        open: () => {
+          onOpenChange(true);
+          (augmentedRef.current as any)?.measure?.(
+            (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
+              setTriggerPosition({ width, pageX, pageY, height });
+            }
+          );
+        },
+        close: () => {
+          setTriggerPosition(null);
+          onOpenChange(false);
+        },
+      },
+    });
+
+    function onPress(ev: GestureResponderEvent) {
+      if (disabled) return;
+      (augmentedRef.current as any)?.measure?.(
+        (_x: number, _y: number, width: number, height: number, pageX: number, pageY: number) => {
+          setTriggerPosition({ width, pageX, pageY, height });
+        }
+      );
+      onOpenChange(!open);
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <Component
+        ref={augmentedRef}
+        aria-disabled={disabled ?? undefined}
+        role="combobox"
+        onPress={onPress}
+        disabled={disabled ?? disabledRoot}
+        aria-expanded={open}
+        {...props}
+      />
+    );
+  }
+);
+Trigger.displayName = 'TriggerNativeSelect';
+
+const Value = React.forwardRef<TextRef, ValueProps>(({ asChild, placeholder, ...props }, ref) => {
+  const { value } = useRootContext();
+  const Component = asChild ? Slot.Text : RNText;
+  return (
+    <Component ref={ref} {...props}>
+      {value?.label ?? placeholder}
+    </Component>
+  );
+});
+Value.displayName = 'ValueNativeSelect';
+
+function Portal({ forceMount, hostName, children }: PortalProps) {
+  const value = useRootContext();
+
+  if (!value.triggerPosition) {
+    return null;
+  }
+
+  if (!forceMount) {
+    if (!value.open) {
+      return null;
+    }
+  }
+
+  const portalProps = hostName ? { hostName } : {};
+
+  return (
+    <RNPortal {...portalProps} name={`${value.nativeID}_portal`}>
+      <SelectContext.Provider value={value}>{children}</SelectContext.Provider>
+    </RNPortal>
+  );
+}
+
+const Overlay = React.forwardRef<PressableRef, OverlayProps>(
+  ({ asChild, forceMount, onPress: OnPressProp, closeOnPress = true, ...props }, ref) => {
+    const { open, onOpenChange, setTriggerPosition, setContentLayout } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (closeOnPress) {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }
+      OnPressProp?.(ev);
+    }
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+    return <Component ref={ref} onPress={onPress} {...props} />;
+  }
+);
+Overlay.displayName = 'OverlayNativeSelect';
+
+const Content = React.forwardRef<ViewRef, ContentProps>(
+  (
+    {
+      asChild = false,
+      forceMount,
+      align = 'start',
+      side = 'bottom',
+      sideOffset = 0,
+      alignOffset = 0,
+      avoidCollisions = true,
+      onLayout: onLayoutProp,
+      insets,
+      style,
+      disablePositioningStyle,
+      position: _position,
+      ...props
+    },
+    ref
+  ) => {
+    const {
+      open,
+      onOpenChange,
+      contentLayout,
+      nativeID,
+      triggerPosition,
+      setContentLayout,
+      setTriggerPosition,
+    } = useRootContext();
+
+    React.useEffect(() => {
+      const backHandler = BackHandler.addEventListener('hardwareBackPress', () => {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+        return true;
+      });
+      return () => {
+        setContentLayout(null);
+        backHandler.remove();
+      };
+    }, [onOpenChange, setContentLayout, setTriggerPosition]);
+
+    const positionStyle = useRelativePosition({
+      align,
+      avoidCollisions,
+      triggerPosition,
+      contentLayout,
+      alignOffset,
+      insets: insets as Insets,
+      sideOffset,
+      side,
+      disablePositioningStyle,
+    });
+
+    function onLayout(event: LayoutChangeEvent) {
+      setContentLayout(event.nativeEvent.layout);
+      onLayoutProp?.(event);
+    }
+
+    if (!forceMount) {
+      if (!open) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.View : View;
+
+    return (
+      <Component
+        ref={ref}
+        role="list"
+        nativeID={nativeID}
+        aria-modal={true}
+        style={[positionStyle as ViewStyle, style]}
+        onLayout={onLayout}
+        onStartShouldSetResponder={onStartShouldSetResponder}
+        {...props}
+      />
+    );
+  }
+);
+Content.displayName = 'ContentNativeSelect';
+
+const Item = React.forwardRef<PressableRef, ItemProps>(
+  (
+    { asChild, value: itemValue, label, onPress: onPressProp, disabled = false, closeOnPress = true, ...props },
+    ref
+  ) => {
+    const { onOpenChange, value, onValueChange, setTriggerPosition, setContentLayout } = useRootContext();
+
+    function onPress(ev: GestureResponderEvent) {
+      if (closeOnPress) {
+        setTriggerPosition(null);
+        setContentLayout(null);
+        onOpenChange(false);
+      }
+      onValueChange({ value: itemValue, label });
+      onPressProp?.(ev);
+    }
+
+    const Component = asChild ? Slot.Pressable : Pressable;
+
+    return (
+      <ItemContext.Provider value={{ itemValue, label }}>
+        <Component
+          ref={ref}
+          role="option"
+          onPress={onPress}
+          disabled={disabled}
+          aria-checked={value?.value === itemValue}
+          aria-valuetext={label}
+          aria-disabled={!!disabled}
+          accessibilityState={{
+            disabled: !!disabled,
+            checked: value?.value === itemValue,
+          }}
+          {...props}
+        />
+      </ItemContext.Provider>
+    );
+  }
+);
+Item.displayName = 'ItemNativeSelect';
+
+const ItemText = React.forwardRef<TextRef, ItemTextProps>(({ asChild, ...props }, ref) => {
+  const { label } = useItemContext();
+  const Component = asChild ? Slot.Text : RNText;
+  return (
+    <Component ref={ref} {...props}>
+      {label}
+    </Component>
+  );
+});
+ItemText.displayName = 'ItemTextNativeSelect';
+
+const ItemIndicator = React.forwardRef<ViewRef, ItemIndicatorProps>(
+  ({ asChild, forceMount, ...props }, ref) => {
+    const { itemValue } = useItemContext();
+    const { value } = useRootContext();
+
+    if (!forceMount) {
+      if (value?.value !== itemValue) {
+        return null;
+      }
+    }
+
+    const Component = asChild ? Slot.View : View;
+    return <Component ref={ref} role="presentation" {...props} />;
+  }
+);
+ItemIndicator.displayName = 'ItemIndicatorNativeSelect';
+
+const Group = React.forwardRef<ViewRef, GroupProps>(({ asChild, ...props }, ref) => {
+  const Component = asChild ? Slot.View : View;
+  return <Component ref={ref} role="group" {...props} />;
+});
+Group.displayName = 'GroupNativeSelect';
+
+const Label = React.forwardRef<TextRef, LabelProps>(({ asChild, ...props }, ref) => {
+  const Component = asChild ? Slot.Text : RNText;
+  return <Component ref={ref} {...props} />;
+});
+Label.displayName = 'LabelNativeSelect';
+
+const Separator = React.forwardRef<ViewRef, SeparatorProps>(({ asChild, decorative, ...props }, ref) => {
+  const Component = asChild ? Slot.View : View;
+  return <Component role={decorative ? 'presentation' : 'separator'} ref={ref} {...props} />;
+});
+Separator.displayName = 'SeparatorNativeSelect';
+
+const ScrollUpButton = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+const ScrollDownButton = ({ children }: { children: React.ReactNode }) => <>{children}</>;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Viewport = ({ children }: any) => <>{children}</>;
+
+function onStartShouldSetResponder() {
+  return true;
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export {
+  Content,
+  Group,
+  Item,
+  ItemIndicator,
+  ItemText,
+  Label,
+  Overlay,
+  Portal,
+  Root,
+  ScrollDownButton,
+  ScrollUpButton,
+  SelectContext, // ADDED: Export context for re-providing after FullWindowOverlay
+  Separator,
+  Trigger,
+  useItemContext,
+  useRootContext,
+  Value,
+  Viewport,
+};
+
+export type {
+  ContentProps,
+  GroupProps,
+  ItemIndicatorProps,
+  ItemProps,
+  ItemTextProps,
+  LabelProps,
+  OverlayProps,
+  PortalProps,
+  RootContext,
+  RootProps,
+  SeparatorProps,
+  TriggerProps,
+  ValueProps,
+};
+

--- a/packages/frosted-ui-react-native/src/forked-primitives/select.web.tsx
+++ b/packages/frosted-ui-react-native/src/forked-primitives/select.web.tsx
@@ -1,0 +1,5 @@
+/**
+ * Web version - re-export from original package which uses @radix-ui/react-select
+ * Our native fixes (portal hostName, context re-provision) are not needed on web
+ */
+export * from '@rn-primitives/select';

--- a/packages/frosted-ui/tsconfig.json
+++ b/packages/frosted-ui/tsconfig.json
@@ -26,6 +26,8 @@
   "exclude": [
     "node_modules",
     "dist",
-    "scripts"
+    "scripts",
+    "**/*.stories.tsx",
+    "**/*.stories.ts"
   ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -419,6 +419,9 @@ importers:
       '@rn-primitives/tooltip':
         specifier: ^1.2.0
         version: 1.2.0(@rn-primitives/portal@1.3.0(@types/react@19.1.10)(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.0(@babel/core@7.28.5))(@types/react@19.1.10)(react@19.1.0))(react@19.1.0)(use-sync-external-store@1.6.0(react@19.1.0)))(@types/react-dom@19.1.10(@types/react@19.1.10))(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.0(@babel/core@7.28.5))(@types/react@19.1.10)(react@19.1.0))(react@19.1.0)
+      '@rn-primitives/types':
+        specifier: ^1.2.0
+        version: 1.2.0(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@react-native-community/cli@20.0.0(typescript@5.9.3))(@react-native/metro-config@0.83.0(@babel/core@7.28.5))(@types/react@19.1.10)(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@babel/core':
         specifier: ^7.26.0


### PR DESCRIPTION
## Fix Portal Components Not Rendering in Vanilla React Native (iOS)

### Problem

Portal-based components (`Dialog`, `AlertDialog`, `Popover`, `Select`, `DropdownMenu`, `ContextMenu`) were not rendering in vanilla React Native projects on iOS, while working correctly in Expo projects.

**Related issue:** https://github.com/founded-labs/react-native-reusables/issues/405

### Symptoms

- Component state updates correctly (`open` becomes `true`)
- No errors or crashes
- Content simply doesn't appear on screen
- Direct usage of `<Portal>` from `@rn-primitives/portal` works fine

### Root Cause Analysis

We identified **two issues** in `@rn-primitives`:

#### Issue 1: Portal `hostName` Prop

The primitive packages pass `hostName={hostName}` to `@rn-primitives/portal` even when `hostName` is `undefined`:

// When portalHost prop is undefined, this:
<Portal hostName={undefined} name="...">

// Is NOT equivalent to:
<Portal name="...">  // Would use default "INTERNAL_PRIMITIVE_DEFAULT_HOST_NAME"Passing `hostName={undefined}` explicitly sets the prop to `undefined`, bypassing the default parameter value. Portal content gets stored under key `undefined` in the zustand store, but `<PortalHost>` looks for `"INTERNAL_PRIMITIVE_DEFAULT_HOST_NAME"`.

#### Issue 2: Context Loss Through FullWindowOverlay

On iOS, we use `FullWindowOverlay` from `react-native-screens` to render content above all other UI (including native navigation). However, `FullWindowOverlay` creates its own portal internally, which breaks React context propagation.

Sub-components like `Dialog.Title`, `Dialog.Close`, `AlertDialog.Action` etc. need access to their parent primitive's context to function correctly. When rendered inside `FullWindowOverlay`, they lose access to this context.

### Why We Forked the Primitives

To fix Issue 2, we needed to:

1. **Capture the primitive's context** before entering the portal/`FullWindowOverlay`
2. **Re-provide the context** inside `FullWindowOverlay` to restore the context chain

This required access to:
- `useRootContext()` - to capture the context before the portal
- The context provider (e.g., `DialogContext.Provider`) - to re-provide it after `FullWindowOverlay`

These are **not exported** by the original `@rn-primitives` packages, so we created local forks that export them.

### Why It Worked in Expo But Not Vanilla RN

Expo's Metro bundler configuration and runtime environment handle module initialization differently. The portal store initialization and default parameter handling behave consistently in Expo but fail in vanilla React Native's stricter environment.

### Solution

1. **Created forked primitives** (`src/forked-primitives/`) that export:
   - `useRootContext()` hook
   - Context providers
   - Fixed portal `hostName` handling

2. **Updated components** to:
   - Capture primitive context before `FullWindowOverlay`
   - Re-provide context inside `FullWindowOverlay`
   - Conditionally pass `hostName` only when defined

3. **Created `.web.tsx` variants** that re-export from original `@rn-primitives` (Radix UI handles context correctly on web)

### Example Fix Pattern

// In component Content:
function DialogContent({ portalHost, children, ...props }) {
  // Capture context BEFORE the portal
  const primitiveContext = DialogPrimitive.useRootContext();

  return (
    <DialogPrimitive.Portal {...(portalHost && { hostName: portalHost })}>
      <FullWindowOverlay>
        {/* Re-provide context after FullWindowOverlay breaks it */}
        <DialogPrimitive.DialogContext.Provider value={primitiveContext}>
          <DialogPrimitive.Content {...props}>
            {children}
          </DialogPrimitive.Content>
        </DialogPrimitive.DialogContext.Provider>
      </FullWindowOverlay>
    </DialogPrimitive.Portal>
  );
}### Components Fixed

- `Dialog`
- `AlertDialog`
- `Popover`
- `Select`
- `DropdownMenu`
- `ContextMenu`

### Testing

- ✅ Expo projects (iOS, Android, Web)
- ✅ Vanilla React Native projects (iOS)
- ✅ All sub-components (`Title`, `Description`, `Close`, `Action`, etc.) work correctly

### Long-term Plan

Once `@rn-primitives` exports the necessary context and hooks (or fixes the portal issue upstream), we can remove the forked primitives and switch back to the original packages.

