### PR TITLE
fix(context-menu): fix spacing and sub menu alignment

### DIFF
--- a/packages/frosted-ui/src/components/context-menu/context-menu.stories.tsx
+++ b/packages/frosted-ui/src/components/context-menu/context-menu.stories.tsx
@@ -8,7 +8,18 @@ const meta = {
   title: 'Controls/ContextMenu',
   component: ContextMenu.Content,
   args: {
+    size: contextMenuContentPropDefs.size.default,
     variant: contextMenuContentPropDefs.variant.default,
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: contextMenuContentPropDefs.size.values,
+    },
+    variant: {
+      control: 'select',
+      options: contextMenuContentPropDefs.variant.values,
+    },
   },
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout

--- a/packages/frosted-ui/src/components/context-menu/context-menu.tsx
+++ b/packages/frosted-ui/src/components/context-menu/context-menu.tsx
@@ -189,7 +189,9 @@ const ContextMenuSubTrigger = (props: ContextMenuSubTriggerProps) => {
       )}
     >
       <Slot.Slottable>{children}</Slot.Slottable>
-      <ThickChevronRightIcon className="fui-BaseMenuSubTriggerIcon fui-ContextMenuSubTriggerIcon" />
+      <div className="fui-BaseMenuShortcut fui-ContextMenuShortcut">
+        <ThickChevronRightIcon className="fui-BaseMenuSubTriggerIcon fui-ContextMenuSubTriggerIcon" />
+      </div>
     </ContextMenuPrimitive.SubTrigger>
   );
 };
@@ -206,7 +208,8 @@ const ContextMenuSubContent = (props: ContextMenuSubContentProps) => {
       <Theme asChild>
         <ContextMenuPrimitive.SubContent
           data-accent-color={color}
-          alignOffset={-Number(size) * 4}
+          alignOffset={-4}
+          sideOffset={2}
           collisionPadding={10}
           {...contentProps}
           className={classNames(


### PR DESCRIPTION
Context menu was missing spacing between the sub menu chevron and text label and applied wrong vertical offset for the sub menu