### PR TITLE
feat(dropdowns, context menus): improve transitions

### DIFF
--- a/packages/frosted-ui/src/components/base-menu/base-menu.css
+++ b/packages/frosted-ui/src/components/base-menu/base-menu.css
@@ -265,3 +265,38 @@
 .fui-BaseMenuSeparator {
   background-color: var(--gray-a6);
 }
+
+/***************************************************************************************************
+ *                                                                                                 *
+ * TRANSITIONS (Base UI)                                                                           *
+ *                                                                                                 *
+ ***************************************************************************************************/
+
+@media (prefers-reduced-motion: no-preference) {
+  .fui-BaseMenuContent {
+    transform-origin: var(--transform-origin);
+
+    &[data-starting-style] {
+      opacity: 0;
+      transform: scale(0.95);
+    }
+
+    &[data-ending-style] {
+      opacity: 0;
+      transform: scale(0.95);
+      transition:
+        transform 150ms,
+        opacity 150ms;
+    }
+  }
+
+  /* No transitions for submenus */
+  .fui-BaseMenuSubContent {
+    &[data-starting-style],
+    &[data-ending-style] {
+      opacity: 1;
+      transform: none;
+      transition: none;
+    }
+  }
+}

--- a/packages/frosted-ui/src/components/context-menu/context-menu.css
+++ b/packages/frosted-ui/src/components/context-menu/context-menu.css
@@ -1,6 +1,6 @@
 @import '../base-menu/base-menu.css';
 
 .fui-ContextMenuContent {
-  max-height: var(--radix-context-menu-content-available-height);
-  transform-origin: var(--radix-context-menu-content-transform-origin);
+  /* Base UI provides --available-height and --transform-origin on the Popup */
+  max-height: var(--available-height);
 }

--- a/packages/frosted-ui/src/components/context-menu/context-menu.tsx
+++ b/packages/frosted-ui/src/components/context-menu/context-menu.tsx
@@ -90,7 +90,6 @@ const ContextMenuContent = (props: ContextMenuContentProps) => {
             data-accent-color={resolvedColor}
             {...popupProps}
             className={classNames(
-              'fui-PopperContent',
               'fui-BaseMenuContent',
               'fui-ContextMenuContent',
               `fui-variant-${variant}`,
@@ -316,7 +315,6 @@ const ContextMenuSubContent = (props: ContextMenuSubContentProps) => {
             data-accent-color={color}
             {...popupProps}
             className={classNames(
-              'fui-PopperContent',
               'fui-BaseMenuContent',
               'fui-BaseMenuSubContent',
               'fui-ContextMenuContent',

--- a/packages/frosted-ui/src/components/dropdown-menu/dropdown-menu.css
+++ b/packages/frosted-ui/src/components/dropdown-menu/dropdown-menu.css
@@ -1,6 +1,6 @@
 @import '../base-menu/base-menu.css';
 
 .fui-DropdownMenuContent {
-  max-height: var(--radix-dropdown-menu-content-available-height);
-  transform-origin: var(--radix-dropdown-menu-content-transform-origin);
+  /* Base UI provides --available-height and --transform-origin on the Popup */
+  max-height: var(--available-height);
 }

--- a/packages/frosted-ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
+++ b/packages/frosted-ui/src/components/dropdown-menu/dropdown-menu.stories.tsx
@@ -54,6 +54,24 @@ export const Default: Story = {
               <DropdownMenu.Item>Advanced options…</DropdownMenu.Item>
             </DropdownMenu.SubContent>
           </DropdownMenu.Sub>
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger>Features</DropdownMenu.SubTrigger>
+            <DropdownMenu.SubContent>
+              <DropdownMenu.Item>Move to project…</DropdownMenu.Item>
+              <DropdownMenu.Item>Move to folder…</DropdownMenu.Item>
+              <DropdownMenu.Separator />
+              <DropdownMenu.Item>Advanced options…</DropdownMenu.Item>
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
+          <DropdownMenu.Sub>
+            <DropdownMenu.SubTrigger>Options</DropdownMenu.SubTrigger>
+            <DropdownMenu.SubContent>
+              <DropdownMenu.Item>Move to project…</DropdownMenu.Item>
+              <DropdownMenu.Item>Move to folder…</DropdownMenu.Item>
+              <DropdownMenu.Separator />
+              <DropdownMenu.Item>Advanced options…</DropdownMenu.Item>
+            </DropdownMenu.SubContent>
+          </DropdownMenu.Sub>
 
           <DropdownMenu.Separator />
           <DropdownMenu.RadioGroup value={order} onValueChange={(value) => setOrder(value as Order)}>

--- a/packages/frosted-ui/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/frosted-ui/src/components/dropdown-menu/dropdown-menu.tsx
@@ -105,7 +105,6 @@ const DropdownMenuContent = (props: DropdownMenuContentProps) => {
             data-accent-color={resolvedColor}
             {...popupProps}
             className={classNames(
-              'fui-PopperContent',
               'fui-BaseMenuContent',
               'fui-DropdownMenuContent',
               `fui-variant-${variant}`,
@@ -327,7 +326,6 @@ const DropdownMenuSubContent = (props: DropdownMenuSubContentProps) => {
             data-accent-color={color}
             {...popupProps}
             className={classNames(
-              'fui-PopperContent',
               'fui-BaseMenuContent',
               'fui-BaseMenuSubContent',
               'fui-DropdownMenuContent',


### PR DESCRIPTION
Making dropdowns and context menus feel more snappy:
- no animation on open (feels instant)
- 150ms fade out animation 

This is modeled after how dropdowns and context menus behave on MacOS