### PR TITLE
feat(ScrollArea): migrate to Base UI

### DIFF
--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.css
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.css
@@ -24,10 +24,7 @@
   /* Stop Chrome back/forward two-finger swipe */
   overscroll-behavior-x: contain;
 
-  &:where(:focus-visible) + :where(.fui-ScrollAreaViewportFocusRing) {
-    position: absolute;
-    inset: 0;
-    pointer-events: none;
+  &:where(:focus-visible) {
     outline: 2px solid var(--color-focus-root);
     outline-offset: -2px;
   }

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.css
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.css
@@ -52,6 +52,9 @@
 
 .fui-ScrollAreaThumb {
   position: relative;
+  /* Base UI provides these CSS variables */
+  width: var(--scroll-area-thumb-width);
+  height: var(--scroll-area-thumb-height);
 
   &::before {
     content: '';
@@ -96,16 +99,8 @@
 .fui-ScrollAreaScrollbar {
   background-color: var(--gray-a3);
   border-radius: var(--scrollarea-scrollbar-border-radius);
+  transition: opacity 150ms ease-out;
 
-  animation-duration: 150ms;
-  animation-timing-function: ease-out;
-
-  &:where([data-state='visible']) {
-    animation-name: fui-fade-in;
-  }
-  &:where([data-state='hidden']) {
-    animation-name: fui-fade-out;
-  }
   &:where([data-orientation='horizontal']) {
     margin-top: var(--scrollarea-scrollbar-horizontal-margin-top);
     margin-bottom: var(--scrollarea-scrollbar-horizontal-margin-bottom);
@@ -128,6 +123,57 @@
   @media (hover: hover) {
     &:where(:hover) {
       background-color: var(--gray-a9);
+    }
+  }
+}
+
+/***************************************************************************************************
+ *                                                                                                 *
+ * TYPE VARIANTS - Controls scrollbar visibility behavior                                          *
+ *                                                                                                 *
+ ***************************************************************************************************/
+
+.fui-ScrollAreaScrollbar {
+  /*
+   * "auto" - visible when content is overflowing
+   * Base UI adds data-has-overflow-x/y when content overflows
+   */
+  &:where([data-type='auto']) {
+    opacity: 0;
+
+    &:where([data-has-overflow-x]),
+    &:where([data-has-overflow-y]) {
+      opacity: 1;
+    }
+  }
+
+  /*
+   * "always" - always visible regardless of overflow
+   */
+  &:where([data-type='always']) {
+    opacity: 1;
+  }
+
+  /*
+   * "scroll" - visible only when actively scrolling
+   */
+  &:where([data-type='scroll']) {
+    opacity: 0;
+
+    &:where([data-scrolling]) {
+      opacity: 1;
+    }
+  }
+
+  /*
+   * "hover" (default) - visible when scrolling or hovering over the scroll area
+   */
+  &:where([data-type='hover']) {
+    opacity: 0;
+
+    &:where([data-hovering]),
+    &:where([data-scrolling]) {
+      opacity: 1;
     }
   }
 }

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.props.ts
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.props.ts
@@ -2,13 +2,25 @@ import type { PropDef } from '../../helpers';
 
 const sizes = ['1', '2', '3'] as const;
 const scrollbarsValues = ['vertical', 'horizontal', 'both'] as const;
+const typeValues = ['auto', 'always', 'scroll', 'hover'] as const;
 
 const scrollAreaPropDefs = {
   size: { type: 'enum', values: sizes, default: '1' },
   scrollbars: { type: 'enum', values: scrollbarsValues, default: 'both' },
+  /**
+   * Describes the nature of scrollbar visibility, similar to how the scrollbar
+   * preferences in macOS control visibility of native scrollbars.
+   *
+   * - `"auto"` - scrollbars are visible when content is overflowing
+   * - `"always"` - scrollbars are always visible regardless of overflow
+   * - `"scroll"` - scrollbars are visible when the user is scrolling
+   * - `"hover"` - scrollbars are visible when scrolling or hovering over the scroll area
+   */
+  type: { type: 'enum', values: typeValues, default: 'hover' },
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
   scrollbars: PropDef<(typeof scrollbarsValues)[number]>;
+  type: PropDef<(typeof typeValues)[number]>;
 };
 
 export { scrollAreaPropDefs };

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { Code, Heading, ScrollArea, Text, scrollAreaPropDefs } from '..';
+import { Button, Code, Heading, IconButton, ScrollArea, Text, TextField, scrollAreaPropDefs } from '..';
 
 const meta = {
   title: 'Components/ScrollArea',
@@ -86,7 +86,12 @@ export const Type: Story = {
           <Text size="1" color="gray" as="div" style={{ marginBottom: 'var(--space-2)' }}>
             Visible on hover or scroll
           </Text>
-          <ScrollArea {...args} type="hover" scrollbars="vertical" style={{ height: 80, width: 200, background: 'var(--gray-a3)' }}>
+          <ScrollArea
+            {...args}
+            type="hover"
+            scrollbars="vertical"
+            style={{ height: 80, width: 200, background: 'var(--gray-a3)' }}
+          >
             <div style={{ padding: 'var(--space-2)' }}>
               <Text size="2">
                 Hover over this area or scroll to see the scrollbar appear. It fades out when you stop interacting.
@@ -102,7 +107,12 @@ export const Type: Story = {
           <Text size="1" color="gray" as="div" style={{ marginBottom: 'var(--space-2)' }}>
             Visible only while scrolling
           </Text>
-          <ScrollArea {...args} type="scroll" scrollbars="vertical" style={{ height: 80, width: 200, background: 'var(--gray-a3)' }}>
+          <ScrollArea
+            {...args}
+            type="scroll"
+            scrollbars="vertical"
+            style={{ height: 80, width: 200, background: 'var(--gray-a3)' }}
+          >
             <div style={{ padding: 'var(--space-2)' }}>
               <Text size="2">
                 The scrollbar only appears while you are actively scrolling. Try scrolling with your mouse wheel or
@@ -119,7 +129,12 @@ export const Type: Story = {
           <Text size="1" color="gray" as="div" style={{ marginBottom: 'var(--space-2)' }}>
             Visible when content overflows
           </Text>
-          <ScrollArea {...args} type="auto" scrollbars="vertical" style={{ height: 80, width: 200, background: 'var(--gray-a3)' }}>
+          <ScrollArea
+            {...args}
+            type="auto"
+            scrollbars="vertical"
+            style={{ height: 80, width: 200, background: 'var(--gray-a3)' }}
+          >
             <div style={{ padding: 'var(--space-2)' }}>
               <Text size="2">
                 The scrollbar is always visible as long as the content overflows the container. No interaction needed.
@@ -135,7 +150,12 @@ export const Type: Story = {
           <Text size="1" color="gray" as="div" style={{ marginBottom: 'var(--space-2)' }}>
             Always visible
           </Text>
-          <ScrollArea {...args} type="always" scrollbars="vertical" style={{ height: 280, width: 200, background: 'var(--gray-a3)' }}>
+          <ScrollArea
+            {...args}
+            type="always"
+            scrollbars="vertical"
+            style={{ height: 280, width: 200, background: 'var(--gray-a3)' }}
+          >
             <div style={{ padding: 'var(--space-2)' }}>
               <Text size="2">The scrollbar is always visible, even if the content doesn't overflow.</Text>
             </div>
@@ -234,4 +254,220 @@ export const BothScrollbars: Story = {
       </div>
     </ScrollArea>
   ),
+};
+
+// Icons for the chat demo
+const SendIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+    <path d="M1.5 1.5L14.5 8L1.5 14.5V9.5L10.5 8L1.5 6.5V1.5Z" />
+  </svg>
+);
+
+const ArrowDownIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor">
+    <path d="M8 12L3 7L4 6L8 10L12 6L13 7L8 12Z" />
+  </svg>
+);
+
+export const ScrollableElementRef: Story = {
+  name: 'Scrollable Element Ref',
+  render: function Render() {
+    const scrollRef = React.useRef<HTMLDivElement>(null);
+    const [messages, setMessages] = React.useState([
+      { id: 1, text: 'Hey! How are you doing?', sender: 'other', time: '10:30 AM' },
+      { id: 2, text: "I'm doing great, thanks for asking! How about you?", sender: 'me', time: '10:31 AM' },
+      { id: 3, text: 'Pretty good! Just working on some new features.', sender: 'other', time: '10:32 AM' },
+      { id: 4, text: 'That sounds exciting! What kind of features?', sender: 'me', time: '10:33 AM' },
+      {
+        id: 5,
+        text: "We're adding a new scroll area component with better ref support.",
+        sender: 'other',
+        time: '10:34 AM',
+      },
+    ]);
+    const [inputValue, setInputValue] = React.useState('');
+    const [showScrollButton, setShowScrollButton] = React.useState(false);
+
+    const scrollToBottom = React.useCallback((behavior: ScrollBehavior = 'smooth') => {
+      if (scrollRef.current) {
+        scrollRef.current.scrollTo({
+          top: scrollRef.current.scrollHeight,
+          behavior,
+        });
+      }
+    }, []);
+
+    const handleScroll = React.useCallback(() => {
+      if (scrollRef.current) {
+        const { scrollTop, scrollHeight, clientHeight } = scrollRef.current;
+        const isNearBottom = scrollHeight - scrollTop - clientHeight < 100;
+        setShowScrollButton(!isNearBottom);
+      }
+    }, []);
+
+    const sendMessage = () => {
+      if (!inputValue.trim()) return;
+
+      const newMessage = {
+        id: Date.now(),
+        text: inputValue,
+        sender: 'me' as const,
+        time: new Date().toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
+      };
+
+      setMessages((prev) => [...prev, newMessage]);
+      setInputValue('');
+
+      // Scroll to bottom after sending
+      setTimeout(() => scrollToBottom(), 50);
+
+      // Simulate a reply
+      setTimeout(() => {
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: Date.now(),
+            text: 'Thanks for the message! This is an auto-reply.',
+            sender: 'other',
+            time: new Date().toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
+          },
+        ]);
+        setTimeout(() => scrollToBottom(), 50);
+      }, 1000);
+    };
+
+    // Scroll to bottom on mount
+    React.useEffect(() => {
+      scrollToBottom('instant');
+    }, [scrollToBottom]);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+        <Text as="div" style={{ maxWidth: 400, textAlign: 'center' }}>
+          Use <Code>ref</Code> to programmatically control scroll position. This chat demo shows scroll-to-bottom
+          functionality.
+        </Text>
+
+        <div
+          style={{
+            width: 360,
+            height: '400px',
+            display: 'flex',
+            flexDirection: 'column',
+            border: '1px solid var(--color-stroke)',
+            borderRadius: 'var(--radius-3)',
+            overflow: 'hidden',
+            background: 'var(--color-panel)',
+          }}
+        >
+          {/* Chat header */}
+          <div
+            style={{
+              padding: 'var(--space-3)',
+              borderBottom: '1px solid var(--color-stroke)',
+              background: 'var(--gray-2)',
+            }}
+          >
+            <Text weight="medium">Chat Demo</Text>
+          </div>
+
+          {/* Messages area */}
+          <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
+            <ScrollArea
+              ref={scrollRef}
+              onScroll={handleScroll}
+              style={{ height: '100%' }}
+              scrollbars="vertical"
+              type="auto"
+            >
+              <div
+                style={{ padding: 'var(--space-3)', display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}
+              >
+                {messages.map((message) => (
+                  <div
+                    key={message.id}
+                    style={{
+                      display: 'flex',
+                      justifyContent: message.sender === 'me' ? 'flex-end' : 'flex-start',
+                    }}
+                  >
+                    <div
+                      style={{
+                        maxWidth: '75%',
+                        padding: 'var(--space-2) var(--space-3)',
+                        borderRadius: 'var(--radius-3)',
+                        background: message.sender === 'me' ? 'var(--accent-9)' : 'var(--gray-4)',
+                        color: message.sender === 'me' ? 'var(--accent-9-contrast)' : 'inherit',
+                      }}
+                    >
+                      <Text size="2">{message.text}</Text>
+                      <Text
+                        size="1"
+                        style={{
+                          display: 'block',
+                          marginTop: 'var(--space-1)',
+                          opacity: 0.7,
+                        }}
+                      >
+                        {message.time}
+                      </Text>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </ScrollArea>
+
+            {/* Scroll to bottom button */}
+            {showScrollButton && (
+              <IconButton
+                size="1"
+                variant="solid"
+                onClick={() => scrollToBottom()}
+                style={{
+                  position: 'absolute',
+                  bottom: 'var(--space-2)',
+                  right: 'var(--space-4)',
+                  borderRadius: '50%',
+                }}
+              >
+                <ArrowDownIcon />
+              </IconButton>
+            )}
+          </div>
+
+          {/* Input area */}
+          <div
+            style={{
+              padding: 'var(--space-2)',
+              borderTop: '1px solid var(--color-stroke)',
+              display: 'flex',
+              gap: 'var(--space-2)',
+              flexShrink: 0,
+            }}
+          >
+            <TextField.Root variant="soft" color="gray" style={{ flex: 1 }} size="3">
+              <TextField.Input
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && sendMessage()}
+                placeholder="Type a message..."
+              />
+            </TextField.Root>
+            <IconButton size="3" variant="solid" onClick={sendMessage}>
+              <SendIcon />
+            </IconButton>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+          <Button variant="soft" size="1" onClick={() => scrollToBottom()}>
+            Scroll to Bottom
+          </Button>
+          <Button variant="soft" size="1" onClick={() => scrollRef.current?.scrollTo({ top: 0, behavior: 'smooth' })}>
+            Scroll to Top
+          </Button>
+        </div>
+      </div>
+    );
+  },
 };

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.stories.tsx
@@ -1,34 +1,46 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { Heading, ScrollArea, Text, scrollAreaPropDefs } from '..';
+import { Code, Heading, ScrollArea, Text, scrollAreaPropDefs } from '..';
 
-// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
   title: 'Components/ScrollArea',
   component: ScrollArea,
   args: {
-    type: 'always' as 'auto' | 'always' | 'scroll' | 'hover' | undefined,
+    type: scrollAreaPropDefs.type.default,
+    size: scrollAreaPropDefs.size.default,
+    scrollbars: scrollAreaPropDefs.scrollbars.default,
+  },
+  argTypes: {
+    type: {
+      control: 'select',
+      options: scrollAreaPropDefs.type.values,
+      description: 'Controls scrollbar visibility behavior',
+    },
+    size: {
+      control: 'select',
+      options: scrollAreaPropDefs.size.values,
+    },
+    scrollbars: {
+      control: 'select',
+      options: scrollAreaPropDefs.scrollbars.values,
+    },
   },
   parameters: {
-    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered',
   },
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
 } satisfies Meta<typeof ScrollArea>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Default: Story = {
   args: {
-    size: scrollAreaPropDefs.size.default,
     scrollbars: 'vertical',
   },
   render: (args) => (
-    <ScrollArea type="always" scrollbars="vertical" style={{ height: 180 }} {...args}>
+    <ScrollArea style={{ height: 180 }} {...args}>
       <div style={{ padding: '8px 8px 54px 8px' }}>
         <Heading size="4" style={{ marginBottom: 8 }} trim="start">
           Principles of the typographic craft
@@ -58,11 +70,83 @@ export const Default: Story = {
   ),
 };
 
+export const Type: Story = {
+  name: 'Type (Visibility Behavior)',
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', alignItems: 'center' }}>
+      <Text as="div" style={{ maxWidth: 500, textAlign: 'center' }}>
+        The <Code>type</Code> prop controls scrollbar visibility, similar to macOS scrollbar preferences.
+      </Text>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 'var(--space-4)' }}>
+        <div>
+          <Text size="2" weight="bold" as="div" style={{ marginBottom: 'var(--space-2)' }}>
+            type="hover" (default)
+          </Text>
+          <Text size="1" color="gray" as="div" style={{ marginBottom: 'var(--space-2)' }}>
+            Visible on hover or scroll
+          </Text>
+          <ScrollArea {...args} type="hover" scrollbars="vertical" style={{ height: 80, width: 200, background: 'var(--gray-a3)' }}>
+            <div style={{ padding: 'var(--space-2)' }}>
+              <Text size="2">
+                Hover over this area or scroll to see the scrollbar appear. It fades out when you stop interacting.
+              </Text>
+            </div>
+          </ScrollArea>
+        </div>
+
+        <div>
+          <Text size="2" weight="bold" as="div" style={{ marginBottom: 'var(--space-2)' }}>
+            type="scroll"
+          </Text>
+          <Text size="1" color="gray" as="div" style={{ marginBottom: 'var(--space-2)' }}>
+            Visible only while scrolling
+          </Text>
+          <ScrollArea {...args} type="scroll" scrollbars="vertical" style={{ height: 80, width: 200, background: 'var(--gray-a3)' }}>
+            <div style={{ padding: 'var(--space-2)' }}>
+              <Text size="2">
+                The scrollbar only appears while you are actively scrolling. Try scrolling with your mouse wheel or
+                trackpad.
+              </Text>
+            </div>
+          </ScrollArea>
+        </div>
+
+        <div>
+          <Text size="2" weight="bold" as="div" style={{ marginBottom: 'var(--space-2)' }}>
+            type="auto"
+          </Text>
+          <Text size="1" color="gray" as="div" style={{ marginBottom: 'var(--space-2)' }}>
+            Visible when content overflows
+          </Text>
+          <ScrollArea {...args} type="auto" scrollbars="vertical" style={{ height: 80, width: 200, background: 'var(--gray-a3)' }}>
+            <div style={{ padding: 'var(--space-2)' }}>
+              <Text size="2">
+                The scrollbar is always visible as long as the content overflows the container. No interaction needed.
+              </Text>
+            </div>
+          </ScrollArea>
+        </div>
+
+        <div>
+          <Text size="2" weight="bold" as="div" style={{ marginBottom: 'var(--space-2)' }}>
+            type="always"
+          </Text>
+          <Text size="1" color="gray" as="div" style={{ marginBottom: 'var(--space-2)' }}>
+            Always visible
+          </Text>
+          <ScrollArea {...args} type="always" scrollbars="vertical" style={{ height: 80, width: 200, background: 'var(--gray-a3)' }}>
+            <div style={{ padding: 'var(--space-2)' }}>
+              <Text size="2">The scrollbar is always visible, even if the content doesn't overflow.</Text>
+            </div>
+          </ScrollArea>
+        </div>
+      </div>
+    </div>
+  ),
+};
+
 export const Size: Story = {
-  args: {
-    size: scrollAreaPropDefs.size.default,
-    scrollbars: 'vertical',
-  },
   render: (args) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
       <ScrollArea {...args} size="1" type="always" scrollbars="horizontal" style={{ width: 300, height: 12 }}>
@@ -81,11 +165,6 @@ export const Size: Story = {
 };
 
 export const Scrollbars: Story = {
-  args: {
-    size: scrollAreaPropDefs.size.default,
-    type: 'always',
-    scrollbars: 'vertical',
-  },
   render: (args) => (
     <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 'var(--space-2)' }}>
       <ScrollArea {...args} type="always" scrollbars="vertical" style={{ height: 150 }}>
@@ -128,5 +207,31 @@ export const Scrollbars: Story = {
         </div>
       </ScrollArea>
     </div>
+  ),
+};
+
+export const BothScrollbars: Story = {
+  name: 'Both Scrollbars',
+  render: (args) => (
+    <ScrollArea {...args} type="always" scrollbars="both" style={{ width: 300, height: 200 }}>
+      <div style={{ width: 600, padding: 'var(--space-3)' }}>
+        <Text as="div" size="2">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+            <p>
+              This scroll area has both horizontal and vertical scrollbars. The content is wider than the container
+              width, so you can scroll horizontally.
+            </p>
+            <p>
+              Vernacular architecture is building done outside any academic tradition, and without professional
+              guidance. It is not a particular architectural movement or style, but rather a broad category.
+            </p>
+            <p>
+              This type of architecture usually serves immediate, local needs, is constrained by the materials available
+              in its particular region and reflects local traditions and cultural practices.
+            </p>
+          </div>
+        </Text>
+      </div>
+    </ScrollArea>
   ),
 };

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.stories.tsx
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.stories.tsx
@@ -40,7 +40,7 @@ export const Default: Story = {
     scrollbars: 'vertical',
   },
   render: (args) => (
-    <ScrollArea style={{ height: 180 }} {...args}>
+    <ScrollArea style={{ height: 180, maxWidth: 500 }} {...args}>
       <div style={{ padding: '8px 8px 54px 8px' }}>
         <Heading size="4" style={{ marginBottom: 8 }} trim="start">
           Principles of the typographic craft
@@ -135,7 +135,7 @@ export const Type: Story = {
           <Text size="1" color="gray" as="div" style={{ marginBottom: 'var(--space-2)' }}>
             Always visible
           </Text>
-          <ScrollArea {...args} type="always" scrollbars="vertical" style={{ height: 80, width: 200, background: 'var(--gray-a3)' }}>
+          <ScrollArea {...args} type="always" scrollbars="vertical" style={{ height: 280, width: 200, background: 'var(--gray-a3)' }}>
             <div style={{ padding: 'var(--space-2)' }}>
               <Text size="2">The scrollbar is always visible, even if the content doesn't overflow.</Text>
             </div>
@@ -166,7 +166,7 @@ export const Size: Story = {
 
 export const Scrollbars: Story = {
   render: (args) => (
-    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 'var(--space-2)' }}>
+    <div style={{ display: 'grid', maxWidth: 500, gridTemplateColumns: 'repeat(2, 1fr)', gap: 'var(--space-2)' }}>
       <ScrollArea {...args} type="always" scrollbars="vertical" style={{ height: 150 }}>
         <div
           style={{

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
@@ -44,6 +44,14 @@ function ScrollArea(props: ScrollAreaProps) {
         ref={ref}
         className="fui-ScrollAreaViewport"
         style={{ overflow: viewportOverflowStyle[scrollbars] }}
+        // Base UI sets tabIndex={0} on the viewport, but we override it to restore default
+        // browser behavior. Modern browsers (Chrome 130+) automatically make scrollable
+        // containers focusable only when they have no focusable children. When focusable
+        // children exist, Tab navigates directly to them instead of the scroll container.
+        // Base UI's explicit tabIndex={0} forces the container into the tab order even
+        // when it has focusable children, which is not ideal UX.
+        // See: https://developer.chrome.com/blog/keyboard-focusable-scrollers
+        tabIndex={undefined}
       >
         <ScrollAreaPrimitive.Content style={scrollbars === 'vertical' ? { minWidth: 0, width: '100%' } : undefined}>
           {children}

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
@@ -20,6 +20,12 @@ interface ScrollAreaProps
   ref?: React.Ref<HTMLDivElement>;
 }
 
+const viewportOverflowStyle = {
+  both: 'scroll',
+  vertical: 'hidden scroll',
+  horizontal: 'scroll hidden',
+} as const;
+
 function ScrollArea(props: ScrollAreaProps) {
   const {
     className,
@@ -34,8 +40,14 @@ function ScrollArea(props: ScrollAreaProps) {
 
   return (
     <ScrollAreaPrimitive.Root {...rootProps} className={classNames('fui-ScrollAreaRoot', className)} style={style}>
-      <ScrollAreaPrimitive.Viewport ref={ref} className="fui-ScrollAreaViewport">
-        <ScrollAreaPrimitive.Content>{children}</ScrollAreaPrimitive.Content>
+      <ScrollAreaPrimitive.Viewport
+        ref={ref}
+        className="fui-ScrollAreaViewport"
+        style={{ overflow: viewportOverflowStyle[scrollbars] }}
+      >
+        <ScrollAreaPrimitive.Content style={scrollbars === 'vertical' ? { minWidth: 0, width: '100%' } : undefined}>
+          {children}
+        </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <div className="fui-ScrollAreaViewportFocusRing" />
 

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
@@ -49,7 +49,6 @@ function ScrollArea(props: ScrollAreaProps) {
           {children}
         </ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
-      <div className="fui-ScrollAreaViewportFocusRing" />
 
       {scrollbars !== 'vertical' && (
         <ScrollAreaPrimitive.Scrollbar

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
@@ -11,18 +11,21 @@ import type { GetPropDefTypes } from '../../helpers';
 type ScrollAreaOwnProps = GetPropDefTypes<typeof scrollAreaPropDefs>;
 
 interface ScrollAreaProps
-  extends Omit<React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Root>, 'className' | 'style'>,
+  extends
+    Omit<React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Root>, 'className' | 'style' | 'ref'>,
     ScrollAreaOwnProps {
   children?: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
+  ref?: React.Ref<HTMLDivElement>;
 }
 
-const ScrollArea = (props: ScrollAreaProps) => {
+function ScrollArea(props: ScrollAreaProps) {
   const {
     className,
     style,
     children,
+    ref,
     size = scrollAreaPropDefs.size.default,
     scrollbars = scrollAreaPropDefs.scrollbars.default,
     type = scrollAreaPropDefs.type.default,
@@ -30,12 +33,8 @@ const ScrollArea = (props: ScrollAreaProps) => {
   } = props;
 
   return (
-    <ScrollAreaPrimitive.Root
-      {...rootProps}
-      className={classNames('fui-ScrollAreaRoot', className)}
-      style={style}
-    >
-      <ScrollAreaPrimitive.Viewport className="fui-ScrollAreaViewport">
+    <ScrollAreaPrimitive.Root {...rootProps} className={classNames('fui-ScrollAreaRoot', className)} style={style}>
+      <ScrollAreaPrimitive.Viewport ref={ref} className="fui-ScrollAreaViewport">
         <ScrollAreaPrimitive.Content>{children}</ScrollAreaPrimitive.Content>
       </ScrollAreaPrimitive.Viewport>
       <div className="fui-ScrollAreaViewportFocusRing" />
@@ -63,9 +62,7 @@ const ScrollArea = (props: ScrollAreaProps) => {
       {scrollbars === 'both' && <ScrollAreaPrimitive.Corner className="fui-ScrollAreaCorner" />}
     </ScrollAreaPrimitive.Root>
   );
-};
-ScrollArea.displayName = 'ScrollArea';
+}
 
 export { ScrollArea };
 export type { ScrollAreaProps };
-

--- a/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
+++ b/packages/frosted-ui/src/components/scroll-area/scroll-area.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { ScrollArea as ScrollAreaPrimitive } from '@base-ui/react/scroll-area';
 import classNames from 'classnames';
-import { ScrollArea as ScrollAreaPrimitive } from 'radix-ui';
 import * as React from 'react';
 
 import { scrollAreaPropDefs } from './scroll-area.props';
@@ -9,51 +9,58 @@ import { scrollAreaPropDefs } from './scroll-area.props';
 import type { GetPropDefTypes } from '../../helpers';
 
 type ScrollAreaOwnProps = GetPropDefTypes<typeof scrollAreaPropDefs>;
+
 interface ScrollAreaProps
-  extends React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Root>,
-    Omit<React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Viewport>, 'dir'>,
-    ScrollAreaOwnProps {}
+  extends Omit<React.ComponentPropsWithRef<typeof ScrollAreaPrimitive.Root>, 'className' | 'style'>,
+    ScrollAreaOwnProps {
+  children?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
 
 const ScrollArea = (props: ScrollAreaProps) => {
   const {
     className,
     style,
-    type,
-    scrollHideDelay = type !== 'scroll' ? 0 : undefined,
-    // dir,
+    children,
     size = scrollAreaPropDefs.size.default,
     scrollbars = scrollAreaPropDefs.scrollbars.default,
-    ...viewportProps
+    type = scrollAreaPropDefs.type.default,
+    ...rootProps
   } = props;
+
   return (
     <ScrollAreaPrimitive.Root
-      type={type}
-      scrollHideDelay={scrollHideDelay}
+      {...rootProps}
       className={classNames('fui-ScrollAreaRoot', className)}
       style={style}
     >
-      <ScrollAreaPrimitive.Viewport {...viewportProps} className="fui-ScrollAreaViewport" />
+      <ScrollAreaPrimitive.Viewport className="fui-ScrollAreaViewport">
+        <ScrollAreaPrimitive.Content>{children}</ScrollAreaPrimitive.Content>
+      </ScrollAreaPrimitive.Viewport>
       <div className="fui-ScrollAreaViewportFocusRing" />
 
-      {scrollbars !== 'vertical' ? (
+      {scrollbars !== 'vertical' && (
         <ScrollAreaPrimitive.Scrollbar
           orientation="horizontal"
           className={classNames('fui-ScrollAreaScrollbar', `fui-r-size-${size}`)}
+          data-type={type}
         >
           <ScrollAreaPrimitive.Thumb className="fui-ScrollAreaThumb" />
         </ScrollAreaPrimitive.Scrollbar>
-      ) : null}
+      )}
 
-      {scrollbars !== 'horizontal' ? (
+      {scrollbars !== 'horizontal' && (
         <ScrollAreaPrimitive.Scrollbar
           orientation="vertical"
           className={classNames('fui-ScrollAreaScrollbar', `fui-r-size-${size}`)}
+          data-type={type}
         >
           <ScrollAreaPrimitive.Thumb className="fui-ScrollAreaThumb" />
         </ScrollAreaPrimitive.Scrollbar>
-      ) : null}
+      )}
 
-      {scrollbars === 'both' ? <ScrollAreaPrimitive.Corner className="fui-ScrollAreaCorner" /> : null}
+      {scrollbars === 'both' && <ScrollAreaPrimitive.Corner className="fui-ScrollAreaCorner" />}
     </ScrollAreaPrimitive.Root>
   );
 };
@@ -61,3 +68,4 @@ ScrollArea.displayName = 'ScrollArea';
 
 export { ScrollArea };
 export type { ScrollAreaProps };
+


### PR DESCRIPTION
## Summary

Migrates the `ScrollArea` component from Radix UI (`radix-ui`) to Base UI (`@base-ui/react/scroll-area`).

## Changes

### Library Migration

- Switched from `radix-ui` to `@base-ui/react/scroll-area`
- Updated component structure to use Base UI's `ScrollAreaPrimitive.Content` wrapper inside the Viewport

### New Features

- **`type` prop** is now a first-class prop with documented behavior:
  - `"hover"` (default) - visible when scrolling or hovering over the scroll area
  - `"scroll"` - visible only when actively scrolling
  - `"auto"` - visible when content overflows
  - `"always"` - always visible regardless of overflow

### Internal Changes

- Scrollbar visibility is now controlled via CSS using `data-type` attribute and Base UI's data attributes (`data-hovering`, `data-scrolling`, `data-has-overflow-x/y`)
- Replaced animation-based show/hide with CSS `opacity` transitions for smoother performance
- Thumb sizing now uses Base UI's CSS variables (`--scroll-area-thumb-width`, `--scroll-area-thumb-height`)

## Breaking Changes

- **`scrollHideDelay` prop removed** - This prop is no longer available. Base UI handles scroll visibility differently using CSS-based transitions.
- **`type` prop default changed** - The default is now explicitly `"hover"` instead of relying on the previous library's default behavior. This may cause scrollbars to appear differently on initial render if you weren't explicitly setting `type`.

## Migration Guide
