### PR TITLE
feat(Tooltip): migrate to Base UI

### DIFF
--- a/packages/frosted-ui/src/components/drawer/drawer.stories.tsx
+++ b/packages/frosted-ui/src/components/drawer/drawer.stories.tsx
@@ -25,6 +25,7 @@ import {
   Text,
   TextArea,
   TextField,
+  Tooltip,
 } from '..';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
@@ -1294,6 +1295,7 @@ export const WithPopoverAndHoverCard: Story = {
 
                 {/* Section with ContextMenu */}
                 <ContextMenu.Root>
+                  <Tooltip content="Right-click here to open context menu">
                   <ContextMenu.Trigger>
                     <div
                       style={{
@@ -1317,6 +1319,7 @@ export const WithPopoverAndHoverCard: Story = {
                       <Badge color="gray">Right-click</Badge>
                     </div>
                   </ContextMenu.Trigger>
+                  </Tooltip>
                   <ContextMenu.Content>
                     <ContextMenu.Item>Copy</ContextMenu.Item>
                     <ContextMenu.Item>Cut</ContextMenu.Item>

--- a/packages/frosted-ui/src/components/stacked-horizontal-bar-chart/stacked-horizontal-bar-chart.tsx
+++ b/packages/frosted-ui/src/components/stacked-horizontal-bar-chart/stacked-horizontal-bar-chart.tsx
@@ -36,7 +36,7 @@ const StackedHorizontalBarChart = (props: StackedHorizontalBarChartProps) => {
           <Tooltip
             content={label}
             key={i}
-            delayDuration={150}
+            delay={150}
             className="fui-StackedHorizontalBarChartTooltip"
             data-accent-color={dataPoint.color}
           >
@@ -57,3 +57,4 @@ StackedHorizontalBarChart.displayName = 'StackedHorizontalBarChart';
 
 export { StackedHorizontalBarChart };
 export type { StackedHorizontalBarChartProps };
+

--- a/packages/frosted-ui/src/components/tooltip/tooltip.css
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.css
@@ -1,7 +1,6 @@
 .fui-TooltipPositioner {
   outline: none;
   pointer-events: none;
-  z-index: 1000;
 }
 
 .fui-TooltipContent {

--- a/packages/frosted-ui/src/components/tooltip/tooltip.css
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.css
@@ -7,7 +7,7 @@
   padding: var(--space-1) var(--space-2);
   background-color: var(--color-background);
   pointer-events: auto;
-
+  max-width: 320px;
   border-radius: var(--radius-4);
 
   box-shadow:

--- a/packages/frosted-ui/src/components/tooltip/tooltip.css
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.css
@@ -1,6 +1,13 @@
+.fui-TooltipPositioner {
+  outline: none;
+  pointer-events: none;
+  z-index: 1000;
+}
+
 .fui-TooltipContent {
   padding: var(--space-1) var(--space-2);
   background-color: var(--color-background);
+  pointer-events: auto;
 
   border-radius: var(--radius-4);
 
@@ -9,26 +16,52 @@
     0 3px 12px -4px rgba(0, 0, 0, 0.05),
     0 2px 3px -2px rgba(0, 0, 61, 0.05);
 
-  transform-origin: var(--radix-tooltip-content-transform-origin);
+  transform-origin: var(--transform-origin);
 
-  animation-duration: 100ms;
-  animation-timing-function: ease-out;
+  /* Default state - hidden */
+  opacity: 0;
+  transform: scale(0.95);
+  transition:
+    opacity 100ms ease-out,
+    transform 100ms ease-out;
 
+  &[data-open] {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+  &[data-starting-style] {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+
+  /* Slide animations based on side */
   @media (prefers-reduced-motion: no-preference) {
-    &:where([data-state='delayed-open']) {
-      &:where([data-side='top']) {
-        animation-name: fui-slide-from-top, fui-fade-in;
-      }
-      &:where([data-side='bottom']) {
-        animation-name: fui-slide-from-bottom, fui-fade-in;
-      }
-      &:where([data-side='left']) {
-        animation-name: fui-slide-from-left, fui-fade-in;
-      }
-      &:where([data-side='right']) {
-        animation-name: fui-slide-from-right, fui-fade-in;
+    &[data-open]:where([data-side='top']) {
+      &[data-starting-style] {
+        transform: translateY(4px) scale(0.95);
       }
     }
+    &[data-open]:where([data-side='bottom']) {
+      &[data-starting-style] {
+        transform: translateY(-4px) scale(0.95);
+      }
+    }
+    &[data-open]:where([data-side='left']) {
+      &[data-starting-style] {
+        transform: translateX(4px) scale(0.95);
+      }
+    }
+    &[data-open]:where([data-side='right']) {
+      &[data-starting-style] {
+        transform: translateX(-4px) scale(0.95);
+      }
+    }
+  }
+
+  /* Instant open (when hovering between tooltips in a group) */
+  &[data-instant] {
+    transition-duration: 0ms;
   }
 }
 

--- a/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
@@ -266,3 +266,41 @@ export const SideOffset: Story = {
     </div>
   ),
 };
+
+export const TrackCursorAxis: Story = {
+  name: 'Track Cursor Axis',
+  args: {
+    content: 'Tooltip',
+  },
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+      <Text as="div" style={{ maxWidth: 400, textAlign: 'center' }}>
+        Make the tooltip follow your cursor with <Code>trackCursorAxis</Code>. Move your mouse over the buttons to see
+        the effect.
+      </Text>
+
+      <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
+        <Tooltip content="I stay in place" trackCursorAxis="none" delay={0}>
+          <Button variant="soft" style={{ width: 140 }}>
+            none (default)
+          </Button>
+        </Tooltip>
+        <Tooltip content="Following X" trackCursorAxis="x" delay={0}>
+          <Button variant="soft" style={{ width: 140 }}>
+            x
+          </Button>
+        </Tooltip>
+        <Tooltip content="Following Y" trackCursorAxis="y" delay={0} side="right">
+          <Button variant="soft" style={{ width: 140 }}>
+            y
+          </Button>
+        </Tooltip>
+        <Tooltip content="Following cursor" trackCursorAxis="both" delay={0}>
+          <Button variant="soft" style={{ width: 140 }}>
+            both
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  ),
+};

--- a/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { Button, Code, IconButton, Text, Tooltip } from '..';
+import { Button, Code, IconButton, Kbd, Text, Tooltip, type TooltipActions } from '..';
 
 const ExampleIcon = ({ size }: { size: number }) => (
   <svg width={size} height={size} viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -368,6 +368,41 @@ export const OnOpenChangeComplete: Story = {
             ))
           )}
         </div>
+      </div>
+    );
+  },
+};
+
+export const ActionsRef: Story = {
+  name: 'Actions Ref',
+  args: {
+    content: 'Tooltip',
+  },
+  render: function Render() {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const actionsRef = React.useRef<TooltipActions>(null!);
+    const [isOpen, setIsOpen] = React.useState(true);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+        <Text as="div" style={{ maxWidth: 400, textAlign: 'center' }}>
+          Use <Code>actionsRef</Code> to imperatively control the tooltip. The <Code>close()</Code> method closes the
+          tooltip programmatically.
+        </Text>
+
+        <Tooltip
+          content="This tooltip can be closed programmatically"
+          actionsRef={actionsRef}
+          defaultOpen
+          delay={0}
+          onOpenChange={setIsOpen}
+        >
+          <Button variant="soft">Hover me</Button>
+        </Tooltip>
+
+        <Text size="2" color="gray">
+          Press <Kbd>Esc</Kbd> to close. Tooltip is {isOpen ? 'open' : 'closed'}.
+        </Text>
       </div>
     );
   },

--- a/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { IconButton, Tooltip } from '..';
+import { Button, Code, IconButton, Text, Tooltip } from '..';
 
 const ExampleIcon = ({ size }: { size: number }) => (
   <svg width={size} height={size} viewBox="0 0 15 15" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -13,23 +13,41 @@ const ExampleIcon = ({ size }: { size: number }) => (
     ></path>
   </svg>
 );
-// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
+
+const BoldIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentcolor">
+    <path d="M3.73353 2.13333C3.4386 2.13333 3.2002 2.37226 3.2002 2.66666C3.2002 2.96106 3.4386 3.2 3.73353 3.2H4.26686V12.8H3.73353C3.4386 12.8 3.2002 13.0389 3.2002 13.3333C3.2002 13.6277 3.4386 13.8667 3.73353 13.8667H9.86686C11.7783 13.8667 13.3335 12.3115 13.3335 10.4C13.3335 8.9968 12.4945 7.78881 11.2929 7.24375C11.8897 6.70615 12.2669 5.93066 12.2669 5.06666C12.2669 3.44906 10.9506 2.13333 9.33353 2.13333H3.73353ZM6.93353 3.2H8.26686C9.29619 3.2 10.1335 4.03733 10.1335 5.06666C10.1335 6.096 9.29619 6.93333 8.26686 6.93333H6.93353V3.2ZM6.93353 8H7.73353H8.26686C9.59006 8 10.6669 9.0768 10.6669 10.4C10.6669 11.7232 9.59006 12.8 8.26686 12.8H6.93353V8Z" />
+  </svg>
+);
+
+const ItalicIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentcolor">
+    <path d="M8.52599 2.12186C8.48583 2.12267 8.44578 2.1265 8.4062 2.13332H6.93328C6.63835 2.13332 6.39995 2.37226 6.39995 2.66665C6.39995 2.96106 6.63835 3.19999 6.93328 3.19999H7.70099L6.69057 12.8H5.86661C5.57168 12.8 5.33328 13.0389 5.33328 13.3333C5.33328 13.6277 5.57168 13.8667 5.86661 13.8667H9.06661C9.36155 13.8667 9.59995 13.6277 9.59995 13.3333C9.59995 13.0389 9.36155 12.8 9.06661 12.8H8.29891L9.30932 3.19999H10.1333C10.4282 3.19999 10.6666 2.96106 10.6666 2.66665C10.6666 2.37226 10.4282 2.13332 10.1333 2.13332H8.59995C8.57519 2.12584 8.55061 2.12189 8.52599 2.12186Z" />
+  </svg>
+);
+
+const UnderlineIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="currentcolor">
+    <path d="M4.00005 2.66667C4.00005 2.29848 3.7016 2 3.33341 2C2.96522 2 2.66677 2.29848 2.66677 2.66667V7.33333C2.66677 10.2789 5.05453 12.6667 8.00013 12.6667C10.9457 12.6667 13.3335 10.2789 13.3335 7.33333V2.66667C13.3335 2.29848 13.035 2 12.6668 2C12.2986 2 12.0002 2.29848 12.0002 2.66667V7.33333C12.0002 9.54248 10.2092 11.3333 8.00013 11.3333C5.79099 11.3333 4.00005 9.54248 4.00005 7.33333V2.66667ZM2.66671 14C2.29852 14 2.00005 14.2985 2.00005 14.6667C2.00005 15.0349 2.29853 15.3333 2.66672 15.3333H13.3334C13.7016 15.3333 14 15.0349 14 14.6667C14 14.2985 13.7016 14 13.3334 14H2.66671Z" />
+  </svg>
+);
+
 const meta = {
   title: 'Components/Tooltip',
   component: Tooltip,
-  args: {},
+  args: {
+    content: 'Tooltip content',
+    children: <button>Trigger</button>,
+  },
   parameters: {
-    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered',
   },
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
 } satisfies Meta<typeof Tooltip>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Default: Story = {
   args: {
     content: 'Add to library',
@@ -40,5 +58,211 @@ export const Default: Story = {
         <ExampleIcon size={16} />
       </IconButton>
     </Tooltip>
+  ),
+};
+
+export const WithProvider: Story = {
+  name: 'With Provider (Group Delay)',
+  args: {
+    content: 'Tooltip',
+  },
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+      <Text as="div" style={{ maxWidth: 400, textAlign: 'center' }}>
+        Wrap tooltips in <Code>Tooltip.Provider</Code> for shared delay behavior. After hovering one tooltip, subsequent
+        tooltips in the group open instantly.
+      </Text>
+
+      <Tooltip.Provider>
+        <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+          <Tooltip content="Bold">
+            <IconButton aria-label="Bold">
+              <BoldIcon />
+            </IconButton>
+          </Tooltip>
+
+          <Tooltip content="Italic">
+            <IconButton aria-label="Italic">
+              <ItalicIcon />
+            </IconButton>
+          </Tooltip>
+
+          <Tooltip content="Underline">
+            <IconButton aria-label="Underline">
+              <UnderlineIcon />
+            </IconButton>
+          </Tooltip>
+        </div>
+      </Tooltip.Provider>
+    </div>
+  ),
+};
+
+export const Positioning: Story = {
+  name: 'Positioning',
+  args: {
+    content: 'Tooltip',
+  },
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+      <Text as="div" style={{ maxWidth: 400, textAlign: 'center' }}>
+        Use <Code>side</Code> and <Code>align</Code> props to control tooltip positioning.
+      </Text>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 'var(--space-2)' }}>
+        <Tooltip content="Top Start" side="top" align="start">
+          <Button variant="soft" size="1">
+            Top Start
+          </Button>
+        </Tooltip>
+        <Tooltip content="Top Center" side="top" align="center">
+          <Button variant="soft" size="1">
+            Top Center
+          </Button>
+        </Tooltip>
+        <Tooltip content="Top End" side="top" align="end">
+          <Button variant="soft" size="1">
+            Top End
+          </Button>
+        </Tooltip>
+
+        <Tooltip content="Left" side="left">
+          <Button variant="soft" size="1">
+            Left
+          </Button>
+        </Tooltip>
+        <div />
+        <Tooltip content="Right" side="right">
+          <Button variant="soft" size="1">
+            Right
+          </Button>
+        </Tooltip>
+
+        <Tooltip content="Bottom Start" side="bottom" align="start">
+          <Button variant="soft" size="1">
+            Bottom Start
+          </Button>
+        </Tooltip>
+        <Tooltip content="Bottom Center" side="bottom" align="center">
+          <Button variant="soft" size="1">
+            Bottom Center
+          </Button>
+        </Tooltip>
+        <Tooltip content="Bottom End" side="bottom" align="end">
+          <Button variant="soft" size="1">
+            Bottom End
+          </Button>
+        </Tooltip>
+      </div>
+    </div>
+  ),
+};
+
+export const CustomDelay: Story = {
+  name: 'Custom Delay',
+  args: {
+    content: 'Tooltip',
+  },
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+      <Text as="div" style={{ maxWidth: 400, textAlign: 'center' }}>
+        Customize open and close delays with <Code>delay</Code> and <Code>closeDelay</Code> props.
+      </Text>
+
+      <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
+        <Tooltip content="Instant open" delay={0}>
+          <Button variant="soft">delay: 0</Button>
+        </Tooltip>
+        <Tooltip content="Default delay (400ms)" delay={400}>
+          <Button variant="soft">delay: 400</Button>
+        </Tooltip>
+        <Tooltip content="Slow open" delay={1000}>
+          <Button variant="soft">delay: 1000</Button>
+        </Tooltip>
+        <Tooltip content="Stays visible for 500ms" delay={0} closeDelay={500}>
+          <Button variant="soft">closeDelay: 500</Button>
+        </Tooltip>
+      </div>
+    </div>
+  ),
+};
+
+export const DisableHoverablePopup: Story = {
+  name: 'Disable Hoverable Popup',
+  args: {
+    content: 'Tooltip',
+  },
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+      <Text as="div" style={{ maxWidth: 400, textAlign: 'center' }}>
+        By default, tooltips stay open when the cursor moves to the tooltip content. Set{' '}
+        <Code>disableHoverablePopup=true</Code> to disable this behavior.
+      </Text>
+
+      <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
+        <Tooltip content="You can hover over me!" disableHoverablePopup={false} delay={0}>
+          <Button variant="soft">disableHoverablePopup: false (default)</Button>
+        </Tooltip>
+        <Tooltip content="I close immediately when you leave the trigger" disableHoverablePopup={true} delay={0}>
+          <Button variant="soft">disableHoverablePopup: true</Button>
+        </Tooltip>
+      </div>
+    </div>
+  ),
+};
+
+export const ControlledMode: Story = {
+  name: 'Controlled Mode',
+  args: {
+    content: 'Tooltip',
+  },
+  render: function Render() {
+    const [open, setOpen] = React.useState(false);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+        <Text as="div" style={{ maxWidth: 400, textAlign: 'center' }}>
+          Control tooltip visibility programmatically with <Code>open</Code> and <Code>onOpenChange</Code> props.
+        </Text>
+
+        <div style={{ display: 'flex', gap: 'var(--space-3)', alignItems: 'center' }}>
+          <Button variant="soft" onClick={() => setOpen((prev) => !prev)}>
+            Toggle Tooltip ({open ? 'Open' : 'Closed'})
+          </Button>
+
+          <Tooltip content="Controlled tooltip" open={open} onOpenChange={setOpen}>
+            <IconButton>
+              <ExampleIcon size={16} />
+            </IconButton>
+          </Tooltip>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const SideOffset: Story = {
+  name: 'Side Offset',
+  args: {
+    content: 'Tooltip',
+  },
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+      <Text as="div" style={{ maxWidth: 400, textAlign: 'center' }}>
+        Adjust the distance from the trigger with <Code>sideOffset</Code>.
+      </Text>
+
+      <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
+        <Tooltip content="Close to trigger" sideOffset={0}>
+          <Button variant="soft">sideOffset: 0</Button>
+        </Tooltip>
+        <Tooltip content="Default distance" sideOffset={4}>
+          <Button variant="soft">sideOffset: 4 (default)</Button>
+        </Tooltip>
+        <Tooltip content="Far from trigger" sideOffset={16}>
+          <Button variant="soft">sideOffset: 16</Button>
+        </Tooltip>
+      </div>
+    </div>
   ),
 };

--- a/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.stories.tsx
@@ -304,3 +304,71 @@ export const TrackCursorAxis: Story = {
     </div>
   ),
 };
+
+export const OnOpenChangeComplete: Story = {
+  name: 'Open Change Complete Callback',
+  args: {
+    content: 'Tooltip',
+  },
+  render: function Render() {
+    const [events, setEvents] = React.useState<{ time: string; event: string }[]>([]);
+
+    const formatTime = () => {
+      const now = new Date();
+      return (
+        now.toLocaleTimeString('en-US', {
+          hour12: false,
+          hour: '2-digit',
+          minute: '2-digit',
+          second: '2-digit',
+        }) + `.${now.getMilliseconds().toString().padStart(3, '0')}`
+      );
+    };
+
+    const addEvent = (event: string) => {
+      setEvents((prev) => [...prev.slice(-5), { time: formatTime(), event }]);
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+        <Text as="div" style={{ maxWidth: 450, textAlign: 'center' }}>
+          <Code>onOpenChange</Code> fires immediately when the tooltip starts opening/closing.{' '}
+          <Code>onOpenChangeComplete</Code> fires after animations finish.
+        </Text>
+
+        <Tooltip
+          content="Hover me!"
+          delay={0}
+          onOpenChange={(open) => addEvent(`onOpenChange: ${open}`)}
+          onOpenChangeComplete={(open) => addEvent(`onOpenChangeComplete: ${open}`)}
+        >
+          <Button variant="soft">Hover me</Button>
+        </Tooltip>
+
+        <div
+          style={{
+            fontFamily: 'monospace',
+            fontSize: 12,
+            padding: 'var(--space-3)',
+            background: 'var(--gray-a3)',
+            borderRadius: 'var(--radius-2)',
+            minHeight: 140,
+            width: 340,
+          }}
+        >
+          {events.length === 0 ? (
+            <Text color="gray" size="1">
+              Hover the button to see events...
+            </Text>
+          ) : (
+            events.map((entry, i) => (
+              <div key={i} style={{ opacity: 0.5 + (i / events.length) * 0.5, marginBottom: 2 }}>
+                <span style={{ color: 'var(--gray-11)' }}>{entry.time}</span> <span>{entry.event}</span>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    );
+  },
+};

--- a/packages/frosted-ui/src/components/tooltip/tooltip.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.tsx
@@ -10,6 +10,11 @@ import { tooltipPropDefs } from './tooltip.props';
 import type { GetPropDefTypes } from '../../helpers';
 
 type TooltipOwnProps = GetPropDefTypes<typeof tooltipPropDefs>;
+type TooltipActions = React.ComponentProps<typeof TooltipPrimitive.Root>['actionsRef'] extends
+  | React.RefObject<infer T>
+  | undefined
+  ? T
+  : never;
 
 interface TooltipProps extends TooltipOwnProps {
   children: React.ReactElement;
@@ -36,6 +41,12 @@ interface TooltipProps extends TooltipOwnProps {
    * @default 'none'
    */
   trackCursorAxis?: 'none' | 'x' | 'y' | 'both';
+  /**
+   * A ref to imperative actions.
+   * - `close`: Closes the tooltip imperatively when called.
+   * - `unmount`: Unmounts the tooltip manually (useful with external animation libraries).
+   */
+  actionsRef?: React.RefObject<TooltipActions>;
   // Portal props
   container?: React.ComponentProps<typeof TooltipPrimitive.Portal>['container'];
   keepMounted?: boolean;
@@ -60,6 +71,7 @@ const TooltipImpl = (props: TooltipProps) => {
     closeDelay,
     disableHoverablePopup,
     trackCursorAxis,
+    actionsRef,
     content,
     container,
     keepMounted,
@@ -80,6 +92,7 @@ const TooltipImpl = (props: TooltipProps) => {
     onOpenChangeComplete,
     disableHoverablePopup,
     trackCursorAxis,
+    actionsRef,
   };
 
   const triggerProps = {
@@ -121,5 +134,5 @@ const Tooltip = Object.assign(TooltipImpl, {
   Provider: TooltipPrimitive.Provider,
 });
 
-export { Tooltip };
+export { Tooltip, type TooltipActions };
 export type { TooltipProps };

--- a/packages/frosted-ui/src/components/tooltip/tooltip.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.tsx
@@ -27,6 +27,11 @@ interface TooltipProps extends TooltipOwnProps {
    * @default false
    */
   disableHoverablePopup?: boolean;
+  /**
+   * Determines which axis the tooltip should track the cursor on.
+   * @default 'none'
+   */
+  trackCursorAxis?: 'none' | 'x' | 'y' | 'both';
   // Portal props
   container?: React.ComponentProps<typeof TooltipPrimitive.Portal>['container'];
   keepMounted?: boolean;
@@ -49,6 +54,7 @@ const TooltipImpl = (props: TooltipProps) => {
     delay = 400,
     closeDelay,
     disableHoverablePopup,
+    trackCursorAxis,
     content,
     container,
     keepMounted,
@@ -67,6 +73,7 @@ const TooltipImpl = (props: TooltipProps) => {
     defaultOpen,
     onOpenChange,
     disableHoverablePopup,
+    trackCursorAxis,
   };
 
   const triggerProps = {

--- a/packages/frosted-ui/src/components/tooltip/tooltip.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.tsx
@@ -1,7 +1,7 @@
 'use client';
 
+import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
 import classNames from 'classnames';
-import { Tooltip as TooltipPrimitive } from 'radix-ui';
 import * as React from 'react';
 import { ReversedTheme } from '../../theme';
 import { Text } from '../text';
@@ -10,58 +10,103 @@ import { tooltipPropDefs } from './tooltip.props';
 import type { GetPropDefTypes } from '../../helpers';
 
 type TooltipOwnProps = GetPropDefTypes<typeof tooltipPropDefs>;
-interface TooltipProps
-  extends React.ComponentProps<typeof TooltipPrimitive.Root>,
-    Omit<React.ComponentProps<typeof TooltipPrimitive.Content>, 'content'>,
-    TooltipOwnProps {
+
+interface TooltipProps extends TooltipOwnProps {
+  children: React.ReactElement;
   // TODO: See if we can automate making prop defs with `required: true` non nullable
   content: NonNullable<TooltipOwnProps['content']>;
+  className?: string;
+  // Root props
+  open?: boolean;
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  delay?: number;
+  closeDelay?: number;
+  /**
+   * Whether the tooltip contents can be hovered without closing the tooltip.
+   * @default false
+   */
+  disableHoverablePopup?: boolean;
+  // Portal props
   container?: React.ComponentProps<typeof TooltipPrimitive.Portal>['container'];
+  keepMounted?: boolean;
+  // Positioner props
+  side?: React.ComponentProps<typeof TooltipPrimitive.Positioner>['side'];
+  sideOffset?: React.ComponentProps<typeof TooltipPrimitive.Positioner>['sideOffset'];
+  align?: React.ComponentProps<typeof TooltipPrimitive.Positioner>['align'];
+  alignOffset?: React.ComponentProps<typeof TooltipPrimitive.Positioner>['alignOffset'];
+  collisionPadding?: React.ComponentProps<typeof TooltipPrimitive.Positioner>['collisionPadding'];
+  sticky?: React.ComponentProps<typeof TooltipPrimitive.Positioner>['sticky'];
 }
 
-const Tooltip = (props: TooltipProps) => {
+const TooltipImpl = (props: TooltipProps) => {
   const {
     children,
     className,
     open,
     defaultOpen,
     onOpenChange,
-    delayDuration = 400,
-    disableHoverableContent,
+    delay = 400,
+    closeDelay,
+    disableHoverablePopup,
     content,
     container,
-    forceMount,
-    ...tooltipContentProps
+    keepMounted,
+    // Positioner props
+    side,
+    sideOffset = 4,
+    align,
+    alignOffset,
+    collisionPadding = 10,
+    sticky,
+    ...tooltipProps
   } = props;
+
   const rootProps = {
     open,
     defaultOpen,
     onOpenChange,
-    delayDuration,
-    disableHoverableContent,
+    disableHoverablePopup,
   };
+
+  const triggerProps = {
+    delay,
+    closeDelay,
+  };
+
+  const positionerProps = {
+    side,
+    sideOffset,
+    align,
+    alignOffset,
+    collisionPadding,
+    sticky,
+  };
+
   return (
     <TooltipPrimitive.Root {...rootProps}>
-      <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
-      <TooltipPrimitive.Portal container={container} forceMount={forceMount}>
-        <ReversedTheme asChild>
-          <TooltipPrimitive.Content
-            sideOffset={4}
-            collisionPadding={10}
-            {...tooltipContentProps}
-            className={classNames('fui-TooltipContent', className)}
-          >
-            <Text as="p" className="fui-TooltipText" size="2">
-              {content}
-            </Text>
-            <TooltipPrimitive.Arrow className="fui-TooltipArrow" />
-          </TooltipPrimitive.Content>
-        </ReversedTheme>
+      <TooltipPrimitive.Trigger render={children} {...triggerProps} />
+      <TooltipPrimitive.Portal container={container} keepMounted={keepMounted}>
+        <TooltipPrimitive.Positioner className="fui-TooltipPositioner" {...positionerProps}>
+          <ReversedTheme asChild>
+            <TooltipPrimitive.Popup {...tooltipProps} className={classNames('fui-TooltipContent', className)}>
+              <Text as="p" className="fui-TooltipText" size="2">
+                {content}
+              </Text>
+              <TooltipPrimitive.Arrow className="fui-TooltipArrow" />
+            </TooltipPrimitive.Popup>
+          </ReversedTheme>
+        </TooltipPrimitive.Positioner>
       </TooltipPrimitive.Portal>
     </TooltipPrimitive.Root>
   );
 };
-Tooltip.displayName = 'Tooltip';
+TooltipImpl.displayName = 'Tooltip';
+
+// Create compound component with Provider
+const Tooltip = Object.assign(TooltipImpl, {
+  Provider: TooltipPrimitive.Provider,
+});
 
 export { Tooltip };
 export type { TooltipProps };

--- a/packages/frosted-ui/src/components/tooltip/tooltip.tsx
+++ b/packages/frosted-ui/src/components/tooltip/tooltip.tsx
@@ -20,6 +20,10 @@ interface TooltipProps extends TooltipOwnProps {
   open?: boolean;
   defaultOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
+  /**
+   * Event handler called after any animations complete when the tooltip is opened or closed.
+   */
+  onOpenChangeComplete?: (open: boolean) => void;
   delay?: number;
   closeDelay?: number;
   /**
@@ -51,6 +55,7 @@ const TooltipImpl = (props: TooltipProps) => {
     open,
     defaultOpen,
     onOpenChange,
+    onOpenChangeComplete,
     delay = 400,
     closeDelay,
     disableHoverablePopup,
@@ -72,6 +77,7 @@ const TooltipImpl = (props: TooltipProps) => {
     open,
     defaultOpen,
     onOpenChange,
+    onOpenChangeComplete,
     disableHoverablePopup,
     trackCursorAxis,
   };

--- a/packages/frosted-ui/src/theme.tsx
+++ b/packages/frosted-ui/src/theme.tsx
@@ -2,8 +2,9 @@
 
 import { DirectionProvider } from '@radix-ui/react-direction';
 
+import { Tooltip as TooltipPrimitive } from '@base-ui/react/tooltip';
 import classNames from 'classnames';
-import { Slot, Tooltip as TooltipPrimitive } from 'radix-ui';
+import { Slot } from 'radix-ui';
 import * as React from 'react';
 import { getMatchingGrayColor, themePropDefs } from './theme-options';
 


### PR DESCRIPTION
## Summary

This PR migrates the `Tooltip` component from Radix UI (`radix-ui`) to Base UI (`@base-ui/react/tooltip`) and adds several new features enabled by the new primitive.

## Changes

### Breaking Changes

- **Library migration**: Switched from `radix-ui` to `@base-ui/react/tooltip`
- **Renamed props**:
  - `delayDuration` → `delay` (default remains 400ms)
  - `disableHoverableContent` → `disableHoverablePopup`
  - `forceMount` → `keepMounted`

### New Features

- **`trackCursorAxis`** - Make the tooltip follow the cursor along a specified axis
  - Options: `'none'` (default), `'x'`, `'y'`, `'both'`

- **`onOpenChangeComplete`** - Callback that fires after open/close animations complete
  - Complements `onOpenChange` which fires immediately when state changes

- **`actionsRef`** - Imperative actions ref for programmatic control
  - `close()`: Closes the tooltip programmatically
  - `unmount()`: Manually unmounts the tooltip (useful with external animation libraries)
  - Exported `TooltipActions` type for typing the ref

- **`Tooltip.Provider`** - Exposed as a compound component for shared tooltip state

- **`closeDelay`** - New prop to control the delay before closing

- **Explicit positioner props** - Now directly exposed on the component:
  - `side`, `sideOffset`, `align`, `alignOffset`, `collisionPadding`, `sticky`