### PR TITLE
feat(radio-group): migrate to Base UI

### DIFF
--- a/packages/frosted-ui/src/components/radio-group/radio-group.css
+++ b/packages/frosted-ui/src/components/radio-group/radio-group.css
@@ -8,6 +8,11 @@
   font-size: var(--font-size);
   line-height: var(--line-height);
   letter-spacing: var(--letter-spacing);
+  cursor: pointer;
+  &:where(&:has(.fui-RadioGroupButton[data-disabled])) {
+    color: var(--gray-a8);
+    cursor: var(--cursor-disabled);
+  }
 }
 
 .fui-RadioGroupButton {
@@ -64,15 +69,15 @@
     --radio-group-item-size: var(--space-5);
   }
 
-  :where(.fui-RadioGroupButton[data-state='unchecked']) {
+  :where(.fui-RadioGroupButton[data-unchecked]) {
     background-color: var(--color-surface);
     box-shadow: inset 0 0 0 1px var(--gray-a7);
   }
-  :where(.fui-RadioGroupButton[data-state='checked']) {
+  :where(.fui-RadioGroupButton[data-checked]) {
     background-color: var(--accent-9);
     color: var(--accent-9-contrast);
   }
-  &:where(.fui-high-contrast) :where(.fui-RadioGroupButton[data-state='checked']) {
+  &:where(.fui-high-contrast) :where(.fui-RadioGroupButton[data-checked]) {
     background-color: var(--accent-12);
     color: var(--accent-1);
   }

--- a/packages/frosted-ui/src/components/radio-group/radio-group.stories.tsx
+++ b/packages/frosted-ui/src/components/radio-group/radio-group.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
-import { Code, RadioGroup, Text, radioGroupPropDefs } from '..';
+import { Button, Code, RadioGroup, Text, radioGroupPropDefs } from '..';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
@@ -213,4 +213,421 @@ export const Alignment: Story = {
       </RadioGroup.Root>
     </div>
   ),
+};
+
+export const Disabled: Story = {
+  name: 'Disabled (Group)',
+  render: (args) => (
+    <RadioGroup.Root {...args} defaultValue="1" disabled>
+      <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'column' }}>
+        <RadioGroup.Item value="1">Default</RadioGroup.Item>
+        <RadioGroup.Item value="2">Comfortable</RadioGroup.Item>
+        <RadioGroup.Item value="3">Compact</RadioGroup.Item>
+      </div>
+    </RadioGroup.Root>
+  ),
+};
+
+export const DisabledItem: Story = {
+  name: 'Disabled (Single Item)',
+  render: (args) => (
+    <RadioGroup.Root {...args} defaultValue="1">
+      <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'column' }}>
+        <RadioGroup.Item value="1">Default</RadioGroup.Item>
+        <RadioGroup.Item value="2" disabled>
+          Comfortable (disabled)
+        </RadioGroup.Item>
+        <RadioGroup.Item value="3">Compact</RadioGroup.Item>
+      </div>
+    </RadioGroup.Root>
+  ),
+};
+
+export const InputRefGroup: Story = {
+  name: 'Input Ref (Group)',
+  render: function Render(args) {
+    const inputRef = React.useRef<HTMLInputElement>(null);
+    const [error, setError] = React.useState<string | null>(null);
+    const [submitted, setSubmitted] = React.useState<string | null>(null);
+
+    const handleSubmit = (e: React.FormEvent) => {
+      e.preventDefault();
+      const input = inputRef.current;
+      if (!input) return;
+
+      if (!input.validity.valid) {
+        setError('Please select a shipping method');
+        setSubmitted(null);
+        input.focus();
+      } else {
+        setError(null);
+        setSubmitted(`Selected: ${input.value}`);
+      }
+    };
+
+    return (
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text as="div" size="2">
+          Use <Code>inputRef</Code> for form validation. Try submitting without selecting an option.
+        </Text>
+
+        <div>
+          <Text as="div" size="2" weight="medium" style={{ marginBottom: 'var(--space-2)' }}>
+            Shipping Method
+          </Text>
+          <RadioGroup.Root {...args} name="shipping" required inputRef={inputRef} onValueChange={() => setError(null)}>
+            <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'column' }}>
+              <RadioGroup.Item value="standard">Standard (5-7 days)</RadioGroup.Item>
+              <RadioGroup.Item value="express">Express (2-3 days)</RadioGroup.Item>
+              <RadioGroup.Item value="overnight">Overnight</RadioGroup.Item>
+            </div>
+          </RadioGroup.Root>
+          {error && (
+            <Text as="div" size="1" color="red" style={{ marginTop: 'var(--space-2)' }}>
+              {error}
+            </Text>
+          )}
+        </div>
+
+        <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
+          <Button size="1" type="submit">
+            Submit
+          </Button>
+          {submitted && (
+            <Text as="span" size="2" color="green">
+              ✓ {submitted}
+            </Text>
+          )}
+        </div>
+      </form>
+    );
+  },
+};
+
+export const InputRefItem: Story = {
+  name: 'Input Ref (Item)',
+  render: function Render(args) {
+    const standardRef = React.useRef<HTMLInputElement>(null);
+    const expressRef = React.useRef<HTMLInputElement>(null);
+    const overnightRef = React.useRef<HTMLInputElement>(null);
+    const [, forceUpdate] = React.useReducer((x) => x + 1, 0);
+
+    const getCheckedStates = () => ({
+      standard: standardRef.current?.checked ?? false,
+      express: expressRef.current?.checked ?? false,
+      overnight: overnightRef.current?.checked ?? false,
+    });
+
+    const states = getCheckedStates();
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text as="div" size="2">
+          Use <Code>inputRef</Code> on individual items to read their native <Code>checked</Code> state.
+        </Text>
+
+        <RadioGroup.Root {...args} defaultValue="standard" onValueChange={() => forceUpdate()}>
+          <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'column' }}>
+            <RadioGroup.Item value="standard" inputRef={standardRef}>
+              Standard (5-7 days)
+            </RadioGroup.Item>
+            <RadioGroup.Item value="express" inputRef={expressRef}>
+              Express (2-3 days)
+            </RadioGroup.Item>
+            <RadioGroup.Item value="overnight" inputRef={overnightRef}>
+              Overnight
+            </RadioGroup.Item>
+          </div>
+        </RadioGroup.Root>
+
+        <Code style={{ padding: 'var(--space-2)', background: 'var(--gray-3)', borderRadius: 'var(--radius-2)' }}>
+          {JSON.stringify(states, null, 2)}
+        </Code>
+      </div>
+    );
+  },
+};
+
+type ShippingMethod = 'standard' | 'express' | 'overnight';
+
+const shippingPrices: Record<ShippingMethod, number> = {
+  standard: 5.99,
+  express: 12.99,
+  overnight: 24.99,
+};
+
+export const OnValueChange: Story = {
+  name: 'onValueChange (TypeScript)',
+  render: function Render(args) {
+    const [selected, setSelected] = React.useState<ShippingMethod>('standard');
+
+    const handleChange: React.ComponentProps<typeof RadioGroup.Root>['onValueChange'] = (value) => {
+      setSelected(value as ShippingMethod);
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text as="div" size="2">
+          Type <Code>onValueChange</Code> with a union type for type-safe value handling.
+        </Text>
+
+        <RadioGroup.Root {...args} value={selected} onValueChange={handleChange}>
+          <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'column' }}>
+            <RadioGroup.Item value="standard">Standard (5-7 days) — $5.99</RadioGroup.Item>
+            <RadioGroup.Item value="express">Express (2-3 days) — $12.99</RadioGroup.Item>
+            <RadioGroup.Item value="overnight">Overnight — $24.99</RadioGroup.Item>
+          </div>
+        </RadioGroup.Root>
+
+        <div
+          style={{
+            padding: 'var(--space-3)',
+            background: 'var(--gray-3)',
+            borderRadius: 'var(--radius-2)',
+          }}
+        >
+          <Text as="div" size="2">
+            Selected: <Code>{selected}</Code>
+          </Text>
+          <Text as="div" size="2">
+            Price: <strong>${shippingPrices[selected].toFixed(2)}</strong>
+          </Text>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const OnValueChangeEvent: Story = {
+  name: 'onValueChange (Event Details)',
+  render: function Render(args) {
+    const [selected, setSelected] = React.useState<string>('free');
+    const [lastEvent, setLastEvent] = React.useState<{
+      type: string;
+      value: string;
+      wasCanceled: boolean;
+    } | null>(null);
+
+    const handleChange: React.ComponentProps<typeof RadioGroup.Root>['onValueChange'] = (value, eventDetails) => {
+      // Premium tier requires confirmation
+      if (value === 'premium') {
+        const confirmed = window.confirm('Premium tier costs $99/month. Continue?');
+        if (!confirmed) {
+          eventDetails.cancel();
+          setLastEvent({
+            type: eventDetails.event.type,
+            value: value as string,
+            wasCanceled: true,
+          });
+          return;
+        }
+      }
+
+      setSelected(value as string);
+      setLastEvent({
+        type: eventDetails.event.type,
+        value: value as string,
+        wasCanceled: false,
+      });
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text as="div" size="2">
+          The <Code>eventDetails</Code> parameter provides <Code>cancel()</Code> to prevent changes and{' '}
+          <Code>event</Code> for the native event. Try selecting Premium tier.
+        </Text>
+
+        <RadioGroup.Root {...args} value={selected} onValueChange={handleChange}>
+          <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'column' }}>
+            <RadioGroup.Item value="free">Free — $0/month</RadioGroup.Item>
+            <RadioGroup.Item value="pro">Pro — $19/month</RadioGroup.Item>
+            <RadioGroup.Item value="premium">Premium — $99/month (requires confirmation)</RadioGroup.Item>
+          </div>
+        </RadioGroup.Root>
+
+        <div
+          style={{
+            padding: 'var(--space-3)',
+            background: 'var(--gray-3)',
+            borderRadius: 'var(--radius-2)',
+            fontFamily: 'monospace',
+            fontSize: 'var(--font-size-1)',
+          }}
+        >
+          <Text as="div" size="2" style={{ marginBottom: 'var(--space-2)' }}>
+            Current: <Code>{selected}</Code>
+          </Text>
+          {lastEvent && (
+            <>
+              <Text as="div" size="1" color="gray">
+                Last event: {lastEvent.type}
+              </Text>
+              <Text as="div" size="1" color="gray">
+                Attempted value: {lastEvent.value}
+              </Text>
+              <Text as="div" size="1" color={lastEvent.wasCanceled ? 'red' : 'green'}>
+                {lastEvent.wasCanceled ? '✗ Change was canceled' : '✓ Change was applied'}
+              </Text>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  },
+};
+
+export const FormName: Story = {
+  name: 'Form Name',
+  render: function Render(args) {
+    const [formData, setFormData] = React.useState<Record<string, string> | null>(null);
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const data = new FormData(e.currentTarget);
+      const entries: Record<string, string> = {};
+      data.forEach((value, key) => {
+        entries[key] = value as string;
+      });
+      setFormData(entries);
+    };
+
+    return (
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text as="div" size="2">
+          Use the <Code>name</Code> prop to include the RadioGroup value in form submissions.
+        </Text>
+
+        <div>
+          <Text as="div" size="2" weight="medium" style={{ marginBottom: 'var(--space-2)' }}>
+            Subscription Plan
+          </Text>
+          <RadioGroup.Root {...args} name="plan" defaultValue="monthly">
+            <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'column' }}>
+              <RadioGroup.Item value="monthly">Monthly — $9/mo</RadioGroup.Item>
+              <RadioGroup.Item value="yearly">Yearly — $99/yr (save 8%)</RadioGroup.Item>
+              <RadioGroup.Item value="lifetime">Lifetime — $299 one-time</RadioGroup.Item>
+            </div>
+          </RadioGroup.Root>
+        </div>
+
+        <div>
+          <Text as="div" size="2" weight="medium" style={{ marginBottom: 'var(--space-2)' }}>
+            Payment Method
+          </Text>
+          <RadioGroup.Root {...args} name="payment" defaultValue="card">
+            <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'column' }}>
+              <RadioGroup.Item value="card">Credit Card</RadioGroup.Item>
+              <RadioGroup.Item value="paypal">PayPal</RadioGroup.Item>
+              <RadioGroup.Item value="crypto">Cryptocurrency</RadioGroup.Item>
+            </div>
+          </RadioGroup.Root>
+        </div>
+
+        <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'flex-start' }}>
+          <Button size="1" type="submit">
+            Submit
+          </Button>
+          <Button size="1" type="reset" variant="soft" onClick={() => setFormData(null)}>
+            Reset
+          </Button>
+        </div>
+
+        {formData && (
+          <Code
+            style={{
+              padding: 'var(--space-3)',
+              background: 'var(--gray-3)',
+              borderRadius: 'var(--radius-2)',
+              display: 'block',
+              whiteSpace: 'pre',
+            }}
+          >
+            {JSON.stringify(formData, null, 2)}
+          </Code>
+        )}
+      </form>
+    );
+  },
+};
+
+interface Product {
+  id: string;
+  name: string;
+  price: number;
+  features: string[];
+}
+
+const products: Product[] = [
+  { id: 'basic', name: 'Basic', price: 9, features: ['5 projects', '1 GB storage'] },
+  { id: 'pro', name: 'Pro', price: 29, features: ['Unlimited projects', '10 GB storage', 'Priority support'] },
+  { id: 'enterprise', name: 'Enterprise', price: 99, features: ['Everything in Pro', 'SSO', 'Dedicated support'] },
+];
+
+export const ObjectValues: Story = {
+  name: 'Object Values',
+  render: function Render(args) {
+    const [selected, setSelected] = React.useState<Product>(products[0]);
+
+    const handleChange: React.ComponentProps<typeof RadioGroup.Root>['onValueChange'] = (value) => {
+      // Parse the JSON string back to object
+      setSelected(JSON.parse(value as string) as Product);
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text as="div" size="2">
+          For object values, serialize with <Code>JSON.stringify()</Code> and parse in <Code>onValueChange</Code>.
+        </Text>
+
+        <RadioGroup.Root {...args} value={JSON.stringify(selected)} onValueChange={handleChange}>
+          <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'column' }}>
+            {products.map((product) => (
+              <RadioGroup.Item key={product.id} value={JSON.stringify(product)}>
+                {product.name} — ${product.price}/mo
+              </RadioGroup.Item>
+            ))}
+          </div>
+        </RadioGroup.Root>
+
+        <div
+          style={{
+            padding: 'var(--space-3)',
+            background: 'var(--gray-3)',
+            borderRadius: 'var(--radius-2)',
+          }}
+        >
+          <Text as="div" size="2" weight="medium" style={{ marginBottom: 'var(--space-2)' }}>
+            Selected: {selected.name}
+          </Text>
+          <Text as="div" size="2" style={{ marginBottom: 'var(--space-1)' }}>
+            Price: <strong>${selected.price}/mo</strong>
+          </Text>
+          <Text as="div" size="2">
+            Features:
+          </Text>
+          <ul style={{ margin: 0, paddingLeft: 'var(--space-4)' }}>
+            {selected.features.map((feature) => (
+              <li key={feature}>
+                <Text size="2">{feature}</Text>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        <Code
+          style={{
+            padding: 'var(--space-2)',
+            background: 'var(--gray-3)',
+            borderRadius: 'var(--radius-2)',
+            display: 'block',
+            whiteSpace: 'pre',
+            fontSize: 'var(--font-size-1)',
+          }}
+        >
+          {JSON.stringify(selected, null, 2)}
+        </Code>
+      </div>
+    );
+  },
 };

--- a/packages/frosted-ui/src/components/radio-group/radio-group.stories.tsx
+++ b/packages/frosted-ui/src/components/radio-group/radio-group.stories.tsx
@@ -361,14 +361,15 @@ export const OnValueChange: Story = {
   render: function Render(args) {
     const [selected, setSelected] = React.useState<ShippingMethod>('standard');
 
-    const handleChange: React.ComponentProps<typeof RadioGroup.Root>['onValueChange'] = (value) => {
+    const handleChange = (value: unknown) => {
       setSelected(value as ShippingMethod);
     };
 
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
         <Text as="div" size="2">
-          Type <Code>onValueChange</Code> with a union type for type-safe value handling.
+          Accept <Code>unknown</Code> and cast inside the handler. Use <Code>RadioGroup.ChangeEventDetails</Code> for
+          the second parameter if needed.
         </Text>
 
         <RadioGroup.Root {...args} value={selected} onValueChange={handleChange}>
@@ -408,7 +409,7 @@ export const OnValueChangeEvent: Story = {
       wasCanceled: boolean;
     } | null>(null);
 
-    const handleChange: React.ComponentProps<typeof RadioGroup.Root>['onValueChange'] = (value, eventDetails) => {
+    const handleChange = (value: unknown, eventDetails: RadioGroup.ChangeEventDetails) => {
       // Premium tier requires confirmation
       if (value === 'premium') {
         const confirmed = window.confirm('Premium tier costs $99/month. Continue?');
@@ -569,7 +570,7 @@ export const ObjectValues: Story = {
   render: function Render(args) {
     const [selected, setSelected] = React.useState<Product>(products[0]);
 
-    const handleChange: React.ComponentProps<typeof RadioGroup.Root>['onValueChange'] = (value) => {
+    const handleChange = (value: unknown) => {
       // Parse the JSON string back to object
       setSelected(JSON.parse(value as string) as Product);
     };

--- a/packages/frosted-ui/src/components/radio-group/radio-group.tsx
+++ b/packages/frosted-ui/src/components/radio-group/radio-group.tsx
@@ -63,5 +63,14 @@ const RadioGroupItem = (props: RadioGroupItemProps) => {
 };
 RadioGroupItem.displayName = 'RadioGroupItem';
 
+/** Re-export types from Base UI for typing onValueChange handlers */
+type ChangeEventDetails = RadioGroupPrimitive.ChangeEventDetails;
+type ChangeEventReason = RadioGroupPrimitive.ChangeEventReason;
+
 export { RadioGroupItem as Item, RadioGroupRoot as Root };
-export type { RadioGroupItemProps as ItemProps, RadioGroupRootProps as RootProps };
+export type {
+  ChangeEventDetails,
+  ChangeEventReason,
+  RadioGroupItemProps as ItemProps,
+  RadioGroupRootProps as RootProps,
+};

--- a/packages/frosted-ui/src/components/radio-group/radio-group.tsx
+++ b/packages/frosted-ui/src/components/radio-group/radio-group.tsx
@@ -1,15 +1,21 @@
 'use client';
 
+import { Radio as RadioPrimitive } from '@base-ui/react/radio';
+import { RadioGroup as RadioGroupPrimitive } from '@base-ui/react/radio-group';
 import classNames from 'classnames';
-import { RadioGroup as RadioGroupPrimitive } from 'radix-ui';
 import * as React from 'react';
 
 import { radioGroupPropDefs } from './radio-group.props';
 
-import type { GetPropDefTypes, PropsWithoutColor } from '../../helpers';
+import type { GetPropDefTypes } from '../../helpers';
 
 type RadioGroupOwnProps = GetPropDefTypes<typeof radioGroupPropDefs>;
-interface RadioGroupRootProps extends PropsWithoutColor<typeof RadioGroupPrimitive.Root>, RadioGroupOwnProps {}
+
+interface RadioGroupRootProps
+  extends Omit<React.ComponentProps<typeof RadioGroupPrimitive>, 'className' | 'style' | 'render'>, RadioGroupOwnProps {
+  className?: string;
+  style?: React.CSSProperties;
+}
 
 const RadioGroupRoot = (props: RadioGroupRootProps) => {
   const {
@@ -20,7 +26,7 @@ const RadioGroupRoot = (props: RadioGroupRootProps) => {
     ...rootProps
   } = props;
   return (
-    <RadioGroupPrimitive.Root
+    <RadioGroupPrimitive
       data-accent-color={color}
       {...rootProps}
       className={classNames('fui-RadioGroupRoot', className, `fui-r-size-${size}`, {
@@ -31,7 +37,15 @@ const RadioGroupRoot = (props: RadioGroupRootProps) => {
 };
 RadioGroupRoot.displayName = 'RadioGroupRoot';
 
-interface RadioGroupItemProps extends React.ComponentProps<typeof RadioGroupPrimitive.Item> {}
+interface RadioGroupItemProps extends Omit<
+  React.ComponentProps<typeof RadioPrimitive.Root>,
+  'children' | 'className' | 'style' | 'render'
+> {
+  /** Optional label content to display next to the radio button */
+  children?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+}
 
 const RadioGroupItem = (props: RadioGroupItemProps) => {
   const { children, className, style, ...itemProps } = props;
@@ -40,9 +54,9 @@ const RadioGroupItem = (props: RadioGroupItemProps) => {
 
   return (
     <Comp className={classNames('fui-RadioGroupItem', className)} style={style}>
-      <RadioGroupPrimitive.Item {...itemProps} className={classNames('fui-reset', 'fui-RadioGroupButton')}>
-        <RadioGroupPrimitive.Indicator className="fui-RadioGroupIndicator" />
-      </RadioGroupPrimitive.Item>
+      <RadioPrimitive.Root {...itemProps} className={classNames('fui-reset', 'fui-RadioGroupButton')}>
+        <RadioPrimitive.Indicator className="fui-RadioGroupIndicator" />
+      </RadioPrimitive.Root>
       {children}
     </Comp>
   );


### PR DESCRIPTION
## RadioGroup Migration to Base UI

Migrates the `RadioGroup` component from Radix UI to Base UI.

### Changes

**Component (`radio-group.tsx`)**
- Import: `radix-ui` → `@base-ui/react/radio` + `@base-ui/react/radio-group`
- Internal mapping: `RadioGroup.Item` → `Radio.Root`, `RadioGroup.Indicator` → `Radio.Indicator`
- Exposed full Base UI `onValueChange` signature
- Removed support for function-based `className`, `style`, and `render` props

**CSS (`radio-group.css`)**
- Updated data attribute selectors:
  - `[data-state="checked"]` → `[data-checked]`
  - `[data-state="unchecked"]` → `[data-unchecked]`

**Stories**
- Added: Disabled (Group), Disabled (Single Item)
- Added: Input Ref (Group) - form validation example
- Added: Input Ref (Item) - reading native checked states
- Added: onValueChange (TypeScript) - typing the callback
- Added: onValueChange (Event Details) - using `cancel()` and `event`
- Added: Form Name - multiple RadioGroups in a form
- Added: Object Values - handling complex values with JSON serialization

### Breaking Changes

#### CSS Selectors
```jsx
/* Before */
.fui-RadioGroupButton[data-state="checked"] { }
.fui-RadioGroupButton[data-state="unchecked"] { }

/* After */
.fui-RadioGroupButton[data-checked] { }
.fui-RadioGroupButton[data-unchecked] { }
```
`onValueChange` signature:
```jsx
// Before (Radix)
onValueChange?: (value: string) => void

// After (Base UI)
onValueChange?: (value: unknown, eventDetails: ChangeEventDetails) => void
```

Migration example:
```jsx
// Typing the handler
const handleChange: React.ComponentProps<typeof RadioGroup.Root>['onValueChange'] = (value) => {
  setSelected(value as MyValueType);
};

<RadioGroup.Root onValueChange={handleChange} />
```

New Features
- `eventDetails.cancel()` - Prevent value changes programmatically
- `eventDetails.event` - Access the native event
- `inputRef` on both `RadioGroup.Root` and `RadioGroup.Item` for native input access