### PR TITLE
feat(radio-button-group): migrate to Base UI

### DIFF
--- a/packages/frosted-ui/src/components/radio-button-group/radio-button-group.css
+++ b/packages/frosted-ui/src/components/radio-button-group/radio-button-group.css
@@ -17,7 +17,7 @@
     position: absolute;
     pointer-events: none;
   }
-  :where(.fui-RadioButtonGroupButton[data-state='checked'] .fui-RadioButtonGroupOverlay) {
+  :where(.fui-RadioButtonGroupButton[data-checked] .fui-RadioButtonGroupOverlay) {
     inset: calc(-1 * var(--parent-border-width));
     border-radius: var(--parent-border-radius);
     box-shadow:
@@ -33,7 +33,7 @@
     border-radius: 999px;
     color: var(--accent-9-contrast);
   }
-  :where(.fui-RadioButtonGroupButton[data-state='checked'] .fui-RadioButtonGroupIcon) {
+  :where(.fui-RadioButtonGroupButton[data-checked] .fui-RadioButtonGroupIcon) {
     visibility: visible;
     background: var(--accent-9);
   }

--- a/packages/frosted-ui/src/components/radio-button-group/radio-button-group.stories.tsx
+++ b/packages/frosted-ui/src/components/radio-button-group/radio-button-group.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { Avatar, Card, RadioButtonGroup, Text, Tooltip, radioGroupPropDefs } from '..';
+import { Avatar, Button, Card, Code, RadioButtonGroup, Text, Tooltip, radioGroupPropDefs } from '..';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
@@ -239,4 +239,409 @@ export const Color: Story = {
       ))}
     </div>
   ),
+};
+
+export const Disabled: Story = {
+  name: 'Disabled (Group)',
+  render: (args) => (
+    <RadioButtonGroup.Root {...args} defaultValue="1" disabled>
+      <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'row' }}>
+        <RadioButtonGroup.Item value="1">
+          <Card size="2" variant="classic">
+            <Text>Option 1</Text>
+          </Card>
+        </RadioButtonGroup.Item>
+        <RadioButtonGroup.Item value="2">
+          <Card size="2" variant="classic">
+            <Text>Option 2</Text>
+          </Card>
+        </RadioButtonGroup.Item>
+        <RadioButtonGroup.Item value="3">
+          <Card size="2" variant="classic">
+            <Text>Option 3</Text>
+          </Card>
+        </RadioButtonGroup.Item>
+      </div>
+    </RadioButtonGroup.Root>
+  ),
+};
+
+export const DisabledItem: Story = {
+  name: 'Disabled (Single Item)',
+  render: (args) => (
+    <RadioButtonGroup.Root {...args} defaultValue="1">
+      <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'row' }}>
+        <RadioButtonGroup.Item value="1">
+          <Card size="2" variant="classic">
+            <Text>Option 1</Text>
+          </Card>
+        </RadioButtonGroup.Item>
+        <RadioButtonGroup.Item value="2" disabled>
+          <Card size="2" variant="classic">
+            <Text color="gray">Option 2 (disabled)</Text>
+          </Card>
+        </RadioButtonGroup.Item>
+        <RadioButtonGroup.Item value="3">
+          <Card size="2" variant="classic">
+            <Text>Option 3</Text>
+          </Card>
+        </RadioButtonGroup.Item>
+      </div>
+    </RadioButtonGroup.Root>
+  ),
+};
+
+type PlanType = 'starter' | 'pro' | 'enterprise';
+
+const planPrices: Record<PlanType, number> = {
+  starter: 0,
+  pro: 29,
+  enterprise: 99,
+};
+
+export const OnValueChange: Story = {
+  name: 'onValueChange (TypeScript)',
+  render: function Render(args) {
+    const [selected, setSelected] = React.useState<PlanType>('starter');
+
+    const handleChange = (value: unknown) => {
+      setSelected(value as PlanType);
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text as="div" size="2">
+          Accept <Code>unknown</Code> and cast inside the handler. Use <Code>RadioButtonGroup.ChangeEventDetails</Code>{' '}
+          for the second parameter if needed.
+        </Text>
+
+        <RadioButtonGroup.Root {...args} value={selected} onValueChange={handleChange}>
+          <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'row' }}>
+            <RadioButtonGroup.Item value="starter">
+              <Card size="2" variant="classic" style={{ width: 140 }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+                  <Text weight="bold">Starter</Text>
+                  <Text size="1" color="gray">
+                    Free forever
+                  </Text>
+                </div>
+              </Card>
+            </RadioButtonGroup.Item>
+            <RadioButtonGroup.Item value="pro">
+              <Card size="2" variant="classic" style={{ width: 140 }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+                  <Text weight="bold">Pro</Text>
+                  <Text size="1" color="gray">
+                    $29/month
+                  </Text>
+                </div>
+              </Card>
+            </RadioButtonGroup.Item>
+            <RadioButtonGroup.Item value="enterprise">
+              <Card size="2" variant="classic" style={{ width: 140 }}>
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+                  <Text weight="bold">Enterprise</Text>
+                  <Text size="1" color="gray">
+                    $99/month
+                  </Text>
+                </div>
+              </Card>
+            </RadioButtonGroup.Item>
+          </div>
+        </RadioButtonGroup.Root>
+
+        <div
+          style={{
+            padding: 'var(--space-3)',
+            background: 'var(--gray-3)',
+            borderRadius: 'var(--radius-2)',
+          }}
+        >
+          <Text as="div" size="2">
+            Selected: <Code>{selected}</Code>
+          </Text>
+          <Text as="div" size="2">
+            Price: <strong>${planPrices[selected]}/mo</strong>
+          </Text>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const OnValueChangeEvent: Story = {
+  name: 'onValueChange (Event Details)',
+  render: function Render(args) {
+    const [selected, setSelected] = React.useState<string>('free');
+    const [lastEvent, setLastEvent] = React.useState<{
+      type: string;
+      value: string;
+      wasCanceled: boolean;
+    } | null>(null);
+
+    const handleChange = (value: unknown, eventDetails: RadioButtonGroup.ChangeEventDetails) => {
+      // Premium tier requires confirmation
+      if (value === 'premium') {
+        const confirmed = window.confirm('Premium tier costs $99/month. Continue?');
+        if (!confirmed) {
+          eventDetails.cancel();
+          setLastEvent({
+            type: eventDetails.event.type,
+            value: value as string,
+            wasCanceled: true,
+          });
+          return;
+        }
+      }
+
+      setSelected(value as string);
+      setLastEvent({
+        type: eventDetails.event.type,
+        value: value as string,
+        wasCanceled: false,
+      });
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text as="div" size="2">
+          The <Code>eventDetails</Code> parameter provides <Code>cancel()</Code> to prevent changes. Try selecting
+          Premium.
+        </Text>
+
+        <RadioButtonGroup.Root {...args} value={selected} onValueChange={handleChange}>
+          <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'row' }}>
+            <RadioButtonGroup.Item value="free">
+              <Card size="2" variant="classic" style={{ width: 120 }}>
+                <Text weight="bold">Free</Text>
+              </Card>
+            </RadioButtonGroup.Item>
+            <RadioButtonGroup.Item value="pro">
+              <Card size="2" variant="classic" style={{ width: 120 }}>
+                <Text weight="bold">Pro</Text>
+              </Card>
+            </RadioButtonGroup.Item>
+            <RadioButtonGroup.Item value="premium">
+              <Card size="2" variant="classic" style={{ width: 120 }}>
+                <Text weight="bold">Premium ⚠️</Text>
+              </Card>
+            </RadioButtonGroup.Item>
+          </div>
+        </RadioButtonGroup.Root>
+
+        <div
+          style={{
+            padding: 'var(--space-3)',
+            background: 'var(--gray-3)',
+            borderRadius: 'var(--radius-2)',
+          }}
+        >
+          <Text as="div" size="2" style={{ marginBottom: 'var(--space-2)' }}>
+            Current: <Code>{selected}</Code>
+          </Text>
+          {lastEvent && (
+            <>
+              <Text as="div" size="1" color="gray">
+                Last event: {lastEvent.type}
+              </Text>
+              <Text as="div" size="1" color="gray">
+                Attempted value: {lastEvent.value}
+              </Text>
+              <Text as="div" size="1" color={lastEvent.wasCanceled ? 'red' : 'green'}>
+                {lastEvent.wasCanceled ? '✗ Change was canceled' : '✓ Change was applied'}
+              </Text>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  },
+};
+
+export const FormName: Story = {
+  name: 'Form Name',
+  render: function Render(args) {
+    const INITIAL_PLAN = 'monthly';
+    const INITIAL_PAYMENT = 'card';
+
+    const [plan, setPlan] = React.useState(INITIAL_PLAN);
+    const [payment, setPayment] = React.useState(INITIAL_PAYMENT);
+    const [formData, setFormData] = React.useState<Record<string, string> | null>(null);
+
+    const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+      e.preventDefault();
+      const data = new FormData(e.currentTarget);
+      const entries: Record<string, string> = {};
+      data.forEach((value, key) => {
+        entries[key] = value as string;
+      });
+      setFormData(entries);
+    };
+
+    const handleReset = () => {
+      setPlan(INITIAL_PLAN);
+      setPayment(INITIAL_PAYMENT);
+      setFormData(null);
+    };
+
+    return (
+      <form
+        onSubmit={handleSubmit}
+        onReset={handleReset}
+        style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}
+      >
+        <Text as="div" size="2">
+          Use the <Code>name</Code> prop to include the RadioButtonGroup value in form submissions. Listen to the form's{' '}
+          <Code>onReset</Code> event to reset controlled state when using <Code>type="reset"</Code> buttons.
+        </Text>
+
+        <div>
+          <Text as="div" size="2" weight="medium" style={{ marginBottom: 'var(--space-2)' }}>
+            Subscription Plan
+          </Text>
+          <RadioButtonGroup.Root {...args} name="plan" value={plan} onValueChange={(v) => setPlan(v as string)}>
+            <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'row' }}>
+              <RadioButtonGroup.Item value="monthly">
+                <Card size="2" variant="classic">
+                  <Text>Monthly</Text>
+                </Card>
+              </RadioButtonGroup.Item>
+              <RadioButtonGroup.Item value="yearly">
+                <Card size="2" variant="classic">
+                  <Text>Yearly</Text>
+                </Card>
+              </RadioButtonGroup.Item>
+            </div>
+          </RadioButtonGroup.Root>
+        </div>
+
+        <div>
+          <Text as="div" size="2" weight="medium" style={{ marginBottom: 'var(--space-2)' }}>
+            Payment Method
+          </Text>
+          <RadioButtonGroup.Root
+            {...args}
+            name="payment"
+            value={payment}
+            onValueChange={(v) => setPayment(v as string)}
+          >
+            <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'row' }}>
+              <RadioButtonGroup.Item value="card">
+                <Card size="2" variant="classic">
+                  <Text>Card</Text>
+                </Card>
+              </RadioButtonGroup.Item>
+              <RadioButtonGroup.Item value="paypal">
+                <Card size="2" variant="classic">
+                  <Text>PayPal</Text>
+                </Card>
+              </RadioButtonGroup.Item>
+            </div>
+          </RadioButtonGroup.Root>
+        </div>
+
+        <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'flex-start' }}>
+          <Button size="1" type="submit">
+            Submit
+          </Button>
+          <Button size="1" type="reset" variant="soft">
+            Reset
+          </Button>
+        </div>
+
+        {formData && (
+          <Code
+            style={{
+              padding: 'var(--space-3)',
+              background: 'var(--gray-3)',
+              borderRadius: 'var(--radius-2)',
+              display: 'block',
+              whiteSpace: 'pre',
+            }}
+          >
+            {JSON.stringify(formData, null, 2)}
+          </Code>
+        )}
+      </form>
+    );
+  },
+};
+
+export const InputRefGroup: Story = {
+  name: 'Input Ref (Group)',
+  render: function Render(args) {
+    const inputRef = React.useRef<HTMLInputElement>(null);
+    const [error, setError] = React.useState<string | null>(null);
+    const [submitted, setSubmitted] = React.useState<string | null>(null);
+
+    const handleSubmit = (e: React.FormEvent) => {
+      e.preventDefault();
+      const input = inputRef.current;
+      if (!input) return;
+
+      if (!input.validity.valid) {
+        setError('Please select a plan');
+        setSubmitted(null);
+        input.focus();
+      } else {
+        setError(null);
+        setSubmitted(`Selected: ${input.value}`);
+      }
+    };
+
+    return (
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text as="div" size="2">
+          Use <Code>inputRef</Code> for form validation. Try submitting without selecting an option.
+        </Text>
+
+        <div>
+          <Text as="div" size="2" weight="medium" style={{ marginBottom: 'var(--space-2)' }}>
+            Select a Plan
+          </Text>
+          <RadioButtonGroup.Root
+            {...args}
+            name="plan"
+            required
+            inputRef={inputRef}
+            onValueChange={() => setError(null)}
+          >
+            <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'row' }}>
+              <RadioButtonGroup.Item value="basic">
+                <Card size="2" variant="classic">
+                  <Text>Basic</Text>
+                </Card>
+              </RadioButtonGroup.Item>
+              <RadioButtonGroup.Item value="pro">
+                <Card size="2" variant="classic">
+                  <Text>Pro</Text>
+                </Card>
+              </RadioButtonGroup.Item>
+              <RadioButtonGroup.Item value="enterprise">
+                <Card size="2" variant="classic">
+                  <Text>Enterprise</Text>
+                </Card>
+              </RadioButtonGroup.Item>
+            </div>
+          </RadioButtonGroup.Root>
+          {error && (
+            <Text as="div" size="1" color="red" style={{ marginTop: 'var(--space-2)' }}>
+              {error}
+            </Text>
+          )}
+        </div>
+
+        <div style={{ display: 'flex', gap: 'var(--space-2)', alignItems: 'center' }}>
+          <Button size="1" type="submit">
+            Submit
+          </Button>
+          {submitted && (
+            <Text as="span" size="2" color="green">
+              ✓ {submitted}
+            </Text>
+          )}
+        </div>
+      </form>
+    );
+  },
 };

--- a/packages/frosted-ui/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/frosted-ui/src/components/radio-button-group/radio-button-group.tsx
@@ -1,12 +1,13 @@
 'use client';
 
+import { Radio as RadioPrimitive } from '@base-ui/react/radio';
+import { RadioGroup as RadioButtonGroupPrimitive } from '@base-ui/react/radio-group';
 import classNames from 'classnames';
-import { RadioGroup as RadioButtonGroupPrimitive } from 'radix-ui';
 import * as React from 'react';
 
 import { radioButtonGroupPropDefs } from './radio-button-group.props';
 
-import { type GetPropDefTypes, type PropsWithoutColor } from '../../helpers';
+import { type GetPropDefTypes } from '../../helpers';
 import { useIsomorphicLayoutEffect } from '../../helpers/use-isomorphic-layout-effect';
 
 type RadioButtonGroupOwnProps = GetPropDefTypes<typeof radioButtonGroupPropDefs>;
@@ -15,8 +16,12 @@ type RadioButtonGroupContextValue = RadioButtonGroupOwnProps;
 const RadioButtonGroupContext = React.createContext<RadioButtonGroupContextValue>({});
 
 interface RadioButtonGroupRootProps
-  extends PropsWithoutColor<typeof RadioButtonGroupPrimitive.Root>,
-    RadioButtonGroupOwnProps {}
+  extends
+    Omit<React.ComponentProps<typeof RadioButtonGroupPrimitive>, 'className' | 'style' | 'render'>,
+    RadioButtonGroupOwnProps {
+  className?: string;
+  style?: React.CSSProperties;
+}
 
 const RadioButtonGroupRoot = (props: RadioButtonGroupRootProps) => {
   const {
@@ -27,7 +32,7 @@ const RadioButtonGroupRoot = (props: RadioButtonGroupRootProps) => {
     ...rootProps
   } = props;
   return (
-    <RadioButtonGroupPrimitive.Root
+    <RadioButtonGroupPrimitive
       data-accent-color={color}
       {...rootProps}
       className={classNames('fui-RadioButtonGroupRoot', className, { 'fui-high-contrast': highContrast })}
@@ -35,31 +40,35 @@ const RadioButtonGroupRoot = (props: RadioButtonGroupRootProps) => {
       <RadioButtonGroupContext.Provider value={React.useMemo(() => ({ color, highContrast }), [color, highContrast])}>
         {children}
       </RadioButtonGroupContext.Provider>
-    </RadioButtonGroupPrimitive.Root>
+    </RadioButtonGroupPrimitive>
   );
 };
 RadioButtonGroupRoot.displayName = 'RadioButtonGroupRoot';
 
-interface RadioButtonGroupItemProps extends React.ComponentProps<typeof RadioButtonGroupPrimitive.Item> {}
+interface RadioButtonGroupItemProps extends Omit<
+  React.ComponentProps<typeof RadioPrimitive.Root>,
+  'className' | 'style' | 'render'
+> {
+  className?: string;
+  style?: React.CSSProperties;
+}
 
 const RadioButtonGroupItem = (props: RadioButtonGroupItemProps) => {
   const { children, className, style, ...itemProps } = props;
 
   const updatedChildren = addOverlayToChildren(children);
   return (
-    <RadioButtonGroupPrimitive.Item
+    <RadioPrimitive.Root
       style={style}
       {...itemProps}
       className={classNames('fui-reset', 'fui-RadioButtonGroupButton', 'fui-RadioButtonGroupItem', className)}
-      asChild
-    >
-      {updatedChildren}
-    </RadioButtonGroupPrimitive.Item>
+      render={updatedChildren as React.ReactElement}
+    />
   );
 };
 RadioButtonGroupItem.displayName = 'RadioButtonGroupItem';
 
-interface RadioButtonGroupIconProps extends Omit<PropsWithoutColor<'div'>, 'children'> {}
+interface RadioButtonGroupIconProps extends Omit<React.ComponentProps<'div'>, 'children' | 'color'> {}
 
 const RadioButtonGroupIcon = (props: RadioButtonGroupIconProps) => {
   const { color, highContrast } = React.useContext(RadioButtonGroupContext);
@@ -117,8 +126,14 @@ const RadioButtonGroupOverlay = () => {
   return <div ref={ref} className="fui-RadioButtonGroupOverlay" aria-hidden />;
 };
 
+/** Re-export types from Base UI for typing onValueChange handlers */
+type ChangeEventDetails = RadioButtonGroupPrimitive.ChangeEventDetails;
+type ChangeEventReason = RadioButtonGroupPrimitive.ChangeEventReason;
+
 export { RadioButtonGroupIcon as Icon, RadioButtonGroupItem as Item, RadioButtonGroupRoot as Root };
 export type {
+  ChangeEventDetails,
+  ChangeEventReason,
   RadioButtonGroupIconProps as IconProps,
   RadioButtonGroupItemProps as ItemProps,
   RadioButtonGroupRootProps as RootProps,

--- a/packages/frosted-ui/src/components/radio-group/radio-group.stories.tsx
+++ b/packages/frosted-ui/src/components/radio-group/radio-group.stories.tsx
@@ -481,6 +481,11 @@ export const OnValueChangeEvent: Story = {
 export const FormName: Story = {
   name: 'Form Name',
   render: function Render(args) {
+    const INITIAL_PLAN = 'monthly';
+    const INITIAL_PAYMENT = 'card';
+
+    const [plan, setPlan] = React.useState(INITIAL_PLAN);
+    const [payment, setPayment] = React.useState(INITIAL_PAYMENT);
     const [formData, setFormData] = React.useState<Record<string, string> | null>(null);
 
     const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
@@ -493,17 +498,28 @@ export const FormName: Story = {
       setFormData(entries);
     };
 
+    const handleReset = () => {
+      setPlan(INITIAL_PLAN);
+      setPayment(INITIAL_PAYMENT);
+      setFormData(null);
+    };
+
     return (
-      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+      <form
+        onSubmit={handleSubmit}
+        onReset={handleReset}
+        style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}
+      >
         <Text as="div" size="2">
-          Use the <Code>name</Code> prop to include the RadioGroup value in form submissions.
+          Use the <Code>name</Code> prop to include the RadioGroup value in form submissions. Listen to the form's{' '}
+          <Code>onReset</Code> event to reset controlled state when using <Code>type="reset"</Code> buttons.
         </Text>
 
         <div>
           <Text as="div" size="2" weight="medium" style={{ marginBottom: 'var(--space-2)' }}>
             Subscription Plan
           </Text>
-          <RadioGroup.Root {...args} name="plan" defaultValue="monthly">
+          <RadioGroup.Root {...args} name="plan" value={plan} onValueChange={(v) => setPlan(v as string)}>
             <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'column' }}>
               <RadioGroup.Item value="monthly">Monthly — $9/mo</RadioGroup.Item>
               <RadioGroup.Item value="yearly">Yearly — $99/yr (save 8%)</RadioGroup.Item>
@@ -516,7 +532,7 @@ export const FormName: Story = {
           <Text as="div" size="2" weight="medium" style={{ marginBottom: 'var(--space-2)' }}>
             Payment Method
           </Text>
-          <RadioGroup.Root {...args} name="payment" defaultValue="card">
+          <RadioGroup.Root {...args} name="payment" value={payment} onValueChange={(v) => setPayment(v as string)}>
             <div style={{ display: 'flex', gap: 'var(--space-2)', flexDirection: 'column' }}>
               <RadioGroup.Item value="card">Credit Card</RadioGroup.Item>
               <RadioGroup.Item value="paypal">PayPal</RadioGroup.Item>
@@ -529,7 +545,7 @@ export const FormName: Story = {
           <Button size="1" type="submit">
             Submit
           </Button>
-          <Button size="1" type="reset" variant="soft" onClick={() => setFormData(null)}>
+          <Button size="1" type="reset" variant="soft">
             Reset
           </Button>
         </div>


### PR DESCRIPTION
# RadioButtonGroup Migration Notes (Radix UI → Base UI)

## Overview

The RadioButtonGroup component has been migrated from Radix UI to Base UI. The external API remains largely compatible, but there are internal changes and some CSS selector updates needed for custom styling.

## Breaking Changes

### CSS Selectors

The data attributes used for styling checked/unchecked states have changed:

| Before (Radix)              | After (Base UI)         |
| --------------------------- | ----------------------- |
| `[data-state="checked"]`    | `[data-checked]`        |
| `[data-state="unchecked"]`  | `[data-unchecked]`      |

If you have custom CSS targeting these selectors, update them accordingly.

### `onValueChange` Signature

```tsx
// Before (Radix)
onValueChange?: (value: string) => void

// After (Base UI)
onValueChange?: (value: unknown, eventDetails: ChangeEventDetails) => void
```

**Handler pattern:**

```tsx
const handleChange = (value: unknown) => {
  setSelected(value as MyValueType);
};

// With eventDetails
const handleChange = (value: unknown, eventDetails: RadioButtonGroup.ChangeEventDetails) => {
  if (shouldCancel) eventDetails.cancel();
  setSelected(value as MyValueType);
};
```

### `asChild` → `render`

Internally, the Item component now uses Base UI's `render` prop instead of Radix's `asChild` pattern. This is handled internally and should not affect usage.

## Exported Types

- `RadioButtonGroup.ChangeEventDetails` - type for the second `onValueChange` parameter
- `RadioButtonGroup.ChangeEventReason` - union type for event reasons
- `RadioButtonGroup.RootProps`
- `RadioButtonGroup.ItemProps`
- `RadioButtonGroup.IconProps`

## Internal Component Mapping

| frosted-ui Component          | Radix Primitive         | Base UI Primitive     |
| ----------------------------- | ----------------------- | --------------------- |
| `RadioButtonGroup.Root`       | `RadioGroup.Root`       | `RadioGroup`          |
| `RadioButtonGroup.Item`       | `RadioGroup.Item`       | `Radio.Root`          |

## Import Changes (Internal)

```tsx
// Before
import { RadioGroup as RadioButtonGroupPrimitive } from 'radix-ui';

// After
import { Radio as RadioPrimitive } from '@base-ui/react/radio';
import { RadioGroup as RadioButtonGroupPrimitive } from '@base-ui/react/radio-group';
```

## No Changes Required

The following props work the same as before:
- `defaultValue`
- `value`
- `disabled`
- `name`
- `required`
- `color`
- `highContrast`
