### PR TITLE
Base UI select

### DIFF
--- a/packages/frosted-ui/src/components/calendar/calendar.tsx
+++ b/packages/frosted-ui/src/components/calendar/calendar.tsx
@@ -183,7 +183,6 @@ function RangeCalendar({ className, ...props }: RangeCalendarProps) {
 }
 
 function MonthDropdown({ state }: { state: CalendarState | RangeCalendarState }) {
-  const months: Array<string> = [];
   const formatter = useDateFormatter({
     month: 'long',
     timeZone: state.timeZone,
@@ -194,12 +193,16 @@ function MonthDropdown({ state }: { state: CalendarState | RangeCalendarState })
   // systems, such as the Hebrew, the number of months may differ
   // between years.
   const numMonths = state.focusedDate.calendar.getMonthsInYear(state.focusedDate);
+  const monthItems: Array<{ value: string; label: string }> = [];
   for (let i = 1; i <= numMonths; i++) {
     const date = state.focusedDate.set({ month: i });
-    months.push(formatter.format(date.toDate(state.timeZone)));
+    monthItems.push({
+      value: i.toString(),
+      label: formatter.format(date.toDate(state.timeZone)),
+    });
   }
 
-  const onChange = (newValue: string) => {
+  const onChange = (newValue: unknown) => {
     const value = Number(newValue);
     const date = state.focusedDate.set({ month: value });
     state.setFocusedDate(date);
@@ -213,12 +216,13 @@ function MonthDropdown({ state }: { state: CalendarState | RangeCalendarState })
       value={state.focusedDate.month.toString()}
       disabled={state.isDisabled}
       size="1"
+      items={monthItems}
     >
       <Select.Trigger variant="surface" />
       <Select.Content>
-        {months.map((month, i) => (
-          <Select.Item key={i} value={(i + 1).toString()}>
-            {month}
+        {monthItems.map((month) => (
+          <Select.Item key={month.value} value={month.value}>
+            {month.label}
           </Select.Item>
         ))}
       </Select.Content>
@@ -226,13 +230,13 @@ function MonthDropdown({ state }: { state: CalendarState | RangeCalendarState })
   );
 }
 
-type YearItem = {
-  value: CalendarDate;
+type YearData = {
+  date: CalendarDate;
   formatted: string;
 };
 
 function YearDropdown({ state }: { state: CalendarState | RangeCalendarState }) {
-  const years: Array<YearItem> = [];
+  const yearsData: Array<YearData> = [];
   const formatter = useDateFormatter({
     year: 'numeric',
     timeZone: state.timeZone,
@@ -255,21 +259,27 @@ function YearDropdown({ state }: { state: CalendarState | RangeCalendarState }) 
   // Format years according to the calculated range
   for (let i = startYear; i <= endYear; i++) {
     const date = state.focusedDate.add({ years: i });
-    years.push({
-      value: date,
+    yearsData.push({
+      date,
       formatted: formatter.format(date.toDate(state.timeZone)),
     });
   }
 
-  const onChange = (newValue: string) => {
+  // Create items for Select with value-label mapping
+  const yearItems = yearsData.map((year, i) => ({
+    value: i.toString(),
+    label: year.formatted,
+  }));
+
+  const onChange = (newValue: unknown) => {
     const index = Number(newValue);
-    const date = years[index].value;
+    const date = yearsData[index].date;
     state.setFocusedDate(date);
     state.setFocused(false);
   };
 
   // Find the index of the current focused year
-  const currentYearIndex = years.findIndex((year) => year.value.year === state.focusedDate.year);
+  const currentYearIndex = yearsData.findIndex((year) => year.date.year === state.focusedDate.year);
 
   return (
     <Select.Root
@@ -278,12 +288,13 @@ function YearDropdown({ state }: { state: CalendarState | RangeCalendarState }) 
       onValueChange={onChange}
       disabled={state.isDisabled}
       size="1"
+      items={yearItems}
     >
       <Select.Trigger variant="surface" onClick={(e) => e.stopPropagation()} />
       <Select.Content>
-        {years.map((year, i) => (
-          <Select.Item key={i} value={i.toString()}>
-            {year.formatted}
+        {yearItems.map((year) => (
+          <Select.Item key={year.value} value={year.value}>
+            {year.label}
           </Select.Item>
         ))}
       </Select.Content>

--- a/packages/frosted-ui/src/components/select/MIGRATION_NOTES.md
+++ b/packages/frosted-ui/src/components/select/MIGRATION_NOTES.md
@@ -1,0 +1,168 @@
+# Select Migration: Radix UI → Base UI
+
+## Component Mapping
+
+| Radix UI           | Base UI                                                                | Notes                                  |
+| ------------------ | ---------------------------------------------------------------------- | -------------------------------------- |
+| `Select.Root`      | `Select.Root`                                                          | Adds `items` prop for value formatting |
+| `Select.Trigger`   | `Select.Trigger` + `Select.Value` + `Select.Icon`                      | Compound structure                     |
+| `Select.Content`   | `Select.Portal` + `Select.Positioner` + `Select.Popup` + `Select.List` | Internal structure change              |
+| `Select.Item`      | `Select.Item` + `Select.ItemIndicator` + `Select.ItemText`             | Explicit children                      |
+| `Select.Group`     | `Select.Group`                                                         | Similar                                |
+| `Select.Label`     | `Select.GroupLabel`                                                    | Must be inside Group                   |
+| `Select.Separator` | `Select.Separator`                                                     | Similar                                |
+| `Select.Viewport`  | `Select.List`                                                          | Renamed                                |
+| N/A                | `Select.ScrollUpArrow` / `Select.ScrollDownArrow`                      | New scroll helpers                     |
+| N/A                | `Select.Backdrop`                                                      | New optional backdrop                  |
+
+## Breaking Changes
+
+### 1. `asChild` → `render`
+
+```tsx
+// Before (Radix)
+<Select.Trigger asChild>
+  <button>Custom</button>
+</Select.Trigger>
+
+// After (Base UI) - handled internally
+<Select.Trigger>
+  <Select.Value />
+</Select.Trigger>
+```
+
+### 2. `position` prop removed
+
+```tsx
+// Before (Radix)
+<Select.Content position="popper">
+
+// After (Base UI)
+<Select.Content alignItemWithTrigger={false}>
+```
+
+The `position="item-aligned"` (Radix default) corresponds to `alignItemWithTrigger={true}` (Base UI default).
+The `position="popper"` corresponds to `alignItemWithTrigger={false}`.
+
+### 3. `Label` must be inside `Group`
+
+```tsx
+// Before (Radix) - could be standalone
+<Select.Label>Category</Select.Label>
+<Select.Item value="1">Item</Select.Item>
+
+// After (Base UI) - must be in Group
+<Select.Group>
+  <Select.Label>Category</Select.Label>
+  <Select.Item value="1">Item</Select.Item>
+</Select.Group>
+```
+
+### 4. `onValueChange` signature
+
+```tsx
+// Before (Radix)
+onValueChange={(value: string) => void}
+
+// After (Base UI)
+onValueChange={(value, event) => void}
+```
+
+## New Features
+
+### 1. `items` prop for value formatting
+
+```tsx
+const items = [
+  { value: 'light', label: 'Light Mode' },
+  { value: 'dark', label: 'Dark Mode' },
+];
+
+<Select.Root items={items}>
+  <Select.Trigger>
+    <Select.Value /> {/* Automatically shows label for selected value */}
+  </Select.Trigger>
+</Select.Root>;
+```
+
+### 2. `alignItemWithTrigger` positioning
+
+By default, Base UI Select overlaps the trigger so the selected item aligns with the trigger text.
+Set `alignItemWithTrigger={false}` on Positioner for standard dropdown behavior.
+
+### 3. Multiple selection
+
+```tsx
+<Select.Root multiple>{/* Items can be selected/deselected */}</Select.Root>
+```
+
+### 4. Object values
+
+```tsx
+const themes = [
+  { name: 'Light', settings: { brightness: 100 } },
+  { name: 'Dark', settings: { brightness: 0 } },
+];
+
+<Select.Root items={themes} value={selectedTheme} onValueChange={setSelectedTheme}>
+```
+
+### 5. Scroll Arrows
+
+```tsx
+<Select.Popup>
+  <Select.ScrollUpArrow />
+  <Select.List>{/* items */}</Select.List>
+  <Select.ScrollDownArrow />
+</Select.Popup>
+```
+
+## Data Attribute Changes
+
+| Radix                 | Base UI               |
+| --------------------- | --------------------- |
+| `data-state="open"`   | `data-open`           |
+| `data-state="closed"` | (no attribute)        |
+| `data-highlighted`    | `data-highlighted`    |
+| `data-disabled`       | `data-disabled`       |
+| N/A                   | `data-starting-style` |
+| N/A                   | `data-ending-style`   |
+| N/A                   | `data-side`           |
+
+## CSS Variable Changes
+
+| Radix                                     | Base UI              |
+| ----------------------------------------- | -------------------- |
+| `--radix-select-trigger-width`            | `--anchor-width`     |
+| `--radix-select-content-available-height` | `--available-height` |
+| `--radix-select-content-transform-origin` | `--transform-origin` |
+
+## Internal Structure Change
+
+Our `Select.Content` will internally render:
+
+```tsx
+<Select.Portal>
+  <Select.Positioner>
+    <Select.Popup>
+      <Select.List>{children}</Select.List>
+    </Select.Popup>
+  </Select.Positioner>
+</Select.Portal>
+```
+
+## Migration Checklist
+
+- [x] Create migration notes
+- [x] Update Select.Root with items support
+- [x] Update Select.Trigger structure (Value + Icon)
+- [x] Update Select.Content to use Portal/Positioner/Popup/List
+- [x] Update Select.Item with ItemText/ItemIndicator
+- [x] Update Select.Group
+- [x] Rename Select.Label to Select.GroupLabel (also exported as Label for backwards compat)
+- [x] Update Select.Separator
+- [x] Update CSS for Base UI data attributes
+- [x] Add positioning props (side, align, sideOffset, alignOffset)
+- [x] Add alignItemWithTrigger prop
+- [x] Update stories
+- [ ] Test all existing functionality

--- a/packages/frosted-ui/src/components/select/select.css
+++ b/packages/frosted-ui/src/components/select/select.css
@@ -28,6 +28,17 @@
   }
 }
 
+.fui-SelectPositioner {
+  outline: none;
+  pointer-events: none;
+  z-index: 1000;
+
+  &:where([data-side]) {
+    min-width: var(--anchor-width);
+    max-height: var(--available-height);
+  }
+}
+
 .fui-SelectContent {
   --scrollarea-scrollbar-vertical-margin-top: var(--select-content-padding);
   --scrollarea-scrollbar-vertical-margin-bottom: var(--select-content-padding);
@@ -36,16 +47,63 @@
 
   overflow: hidden;
   background-color: var(--color-panel-solid);
+  pointer-events: auto;
+  transform-origin: var(--transform-origin);
 
-  &:where([data-side]) {
-    min-width: var(--radix-select-trigger-width);
-    max-height: var(--radix-select-content-available-height);
-    transform-origin: var(--radix-select-content-transform-origin);
+  /* Animation */
+  opacity: 1;
+  transform: scale(1);
+  transition:
+    opacity 150ms cubic-bezier(0.16, 1, 0.3, 1),
+    transform 150ms cubic-bezier(0.16, 1, 0.3, 1);
+
+  &[data-starting-style],
+  &[data-ending-style] {
+    opacity: 0;
+    transform: scale(0.97);
   }
 
-  & :where(.fui-SelectItem[data-highlighted]) {
+  & :where(.fui-SelectItem[data-highlighted]:not([data-disabled])) {
     background-color: var(--gray-a4);
   }
+}
+
+.fui-SelectScrollArrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 20px;
+  color: var(--gray-11);
+  cursor: default;
+
+  &:where(:not([data-visible])) {
+    display: none;
+  }
+
+  & svg {
+    width: 12px;
+    height: 12px;
+  }
+}
+
+.fui-SelectScrollUpArrow::before {
+  content: '';
+  display: block;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-bottom: 5px solid currentColor;
+}
+
+.fui-SelectScrollDownArrow::before {
+  content: '';
+  display: block;
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 5px solid currentColor;
 }
 
 .fui-SelectViewport {
@@ -308,7 +366,7 @@
         0px 1px 2px 0px rgba(0, 0, 0, 0.05);
     }
   }
-  &:where([data-state='open']) {
+  &:where([data-popup-open]) {
     box-shadow: inset 0 0 0 1px var(--gray-a7);
   }
   &:where(:disabled) {
@@ -381,7 +439,7 @@
       }
     }
   }
-  &:where([data-state='open']) {
+  &:where([data-popup-open]) {
     box-shadow:
       inset 0 0 0 1px var(--gray-a3),
       var(--select-trigger-classic-box-shadow);
@@ -432,7 +490,7 @@
       background-color: var(--accent-a4);
     }
   }
-  &:where([data-state='open']) {
+  &:where([data-popup-open]) {
     background-color: var(--accent-a4);
   }
   &:where(:focus-visible) {
@@ -452,7 +510,7 @@
       background-color: var(--accent-a3);
     }
   }
-  &:where([data-state='open']) {
+  &:where([data-popup-open]) {
     background-color: var(--accent-a3);
   }
   &:where(:disabled) {
@@ -486,6 +544,7 @@
 
 .fui-SelectItem:where([data-disabled]) {
   color: var(--gray-a8);
+  cursor: var(--cursor-disabled);
 }
 
 .fui-SelectSeparator {

--- a/packages/frosted-ui/src/components/select/select.css
+++ b/packages/frosted-ui/src/components/select/select.css
@@ -68,44 +68,6 @@
   }
 }
 
-.fui-SelectScrollArrow {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 20px;
-  color: var(--gray-11);
-  cursor: default;
-
-  &:where(:not([data-visible])) {
-    display: none;
-  }
-
-  & svg {
-    width: 12px;
-    height: 12px;
-  }
-}
-
-.fui-SelectScrollUpArrow::before {
-  content: '';
-  display: block;
-  width: 0;
-  height: 0;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-bottom: 5px solid currentColor;
-}
-
-.fui-SelectScrollDownArrow::before {
-  content: '';
-  display: block;
-  width: 0;
-  height: 0;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-top: 5px solid currentColor;
-}
-
 .fui-SelectViewport {
   box-sizing: border-box;
   padding: var(--select-content-padding);

--- a/packages/frosted-ui/src/components/select/select.css
+++ b/packages/frosted-ui/src/components/select/select.css
@@ -22,9 +22,8 @@
 
 .fui-SelectIcon {
   flex-shrink: 0;
-
-  :where(.fui-SelectTrigger:not(.fui-variant-ghost)) & {
-    opacity: 0.9;
+  &:where(:not(.fui-SelectTrigger[data-disabled] &)) {
+    color: var(--accent-a12);
   }
 }
 
@@ -456,10 +455,10 @@
 
 .fui-SelectTrigger:where(.fui-variant-soft),
 .fui-SelectTrigger:where(.fui-variant-ghost) {
-  color: var(--accent-a11);
+  color: var(--accent-a12);
 
   &:where([data-placeholder]) {
-    color: var(--accent-a8);
+    color: var(--accent-a10);
   }
 }
 

--- a/packages/frosted-ui/src/components/select/select.css
+++ b/packages/frosted-ui/src/components/select/select.css
@@ -33,9 +33,15 @@
   pointer-events: none;
   z-index: 1000;
 
-  &:where([data-side]) {
+  /* Only apply max-height when NOT in alignItemWithTrigger mode (data-side != "none") */
+  &:where([data-side]:not([data-side='none'])) {
     min-width: var(--anchor-width);
     max-height: var(--available-height);
+  }
+
+  /* In alignItemWithTrigger mode, Base UI manages height dynamically */
+  &:where([data-side='none']) {
+    min-width: var(--anchor-width);
   }
 }
 
@@ -45,7 +51,6 @@
   --scrollarea-scrollbar-horizontal-margin-left: var(--select-content-padding);
   --scrollarea-scrollbar-horizontal-margin-right: var(--select-content-padding);
 
-  overflow: hidden;
   background-color: var(--color-panel-solid);
   pointer-events: auto;
   transform-origin: var(--transform-origin);
@@ -71,6 +76,16 @@
 .fui-SelectViewport {
   box-sizing: border-box;
   padding: var(--select-content-padding);
+
+  /* 
+   * In alignItemWithTrigger mode (data-side="none"), Base UI applies inline styles:
+   * position: relative; max-height: 100%; overflow-x: hidden; overflow-y: auto;
+   * In normal mode, the Positioner handles max-height via --available-height
+   */
+  :where(.fui-SelectPositioner:not([data-side='none'])) & {
+    max-height: var(--available-height);
+    overflow-y: auto;
+  }
 
   :where(.fui-SelectContent:has(.fui-ScrollAreaScrollbar[data-orientation='vertical'])) & {
     padding-right: var(--space-3);

--- a/packages/frosted-ui/src/components/select/select.css
+++ b/packages/frosted-ui/src/components/select/select.css
@@ -31,7 +31,6 @@
 .fui-SelectPositioner {
   outline: none;
   pointer-events: none;
-  z-index: 1000;
 
   /* Only apply max-height when NOT in alignItemWithTrigger mode (data-side != "none") */
   &:where([data-side]:not([data-side='none'])) {

--- a/packages/frosted-ui/src/components/select/select.css
+++ b/packages/frosted-ui/src/components/select/select.css
@@ -51,6 +51,8 @@
   --scrollarea-scrollbar-horizontal-margin-left: var(--select-content-padding);
   --scrollarea-scrollbar-horizontal-margin-right: var(--select-content-padding);
 
+  /* Trigger width + space for checkmark indicator */
+  min-width: calc(var(--anchor-width) + var(--select-item-indicator-width));
   overflow: hidden;
   background-color: var(--color-panel-solid);
   pointer-events: auto;

--- a/packages/frosted-ui/src/components/select/select.css
+++ b/packages/frosted-ui/src/components/select/select.css
@@ -14,7 +14,7 @@
   }
 }
 
-.fui-SelectTriggerInner {
+.fui-SelectTriggerValue {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -337,7 +337,10 @@
 /* surface */
 
 .fui-SelectTrigger:where(.fui-variant-surface) {
-  color: var(--gray-12);
+  color: var(--accent-a11);
+  &:where([data-accent-color='gray']) {
+    color: var(--gray-12);
+  }
   background-color: var(--color-surface);
   box-shadow:
     inset 0 0 0 1px var(--gray-a5),
@@ -353,16 +356,14 @@
   &:where([data-popup-open]) {
     box-shadow: inset 0 0 0 1px var(--gray-a7);
   }
+  &:where([data-placeholder]) {
+    color: var(--accent-a10);
+  }
   &:where(:disabled) {
     cursor: var(--cursor-disabled);
     color: var(--gray-a8);
     background-color: var(--gray-a2);
     box-shadow: inset 0 0 0 1px var(--gray-a6);
-  }
-  &:where([data-placeholder]) {
-    & :where(.fui-SelectTriggerInner) {
-      color: var(--gray-a10);
-    }
   }
 }
 
@@ -446,7 +447,7 @@
     }
   }
   &:where([data-placeholder]) {
-    & :where(.fui-SelectTriggerInner) {
+    & :where(.fui-SelectTriggerValue) {
       color: var(--gray-a10);
     }
   }
@@ -456,13 +457,10 @@
 
 .fui-SelectTrigger:where(.fui-variant-soft),
 .fui-SelectTrigger:where(.fui-variant-ghost) {
-  color: var(--accent-12);
+  color: var(--accent-a11);
 
   &:where([data-placeholder]) {
-    & :where(.fui-SelectTriggerInner) {
-      color: var(--accent-12);
-      opacity: 0.6;
-    }
+    color: var(--accent-a8);
   }
 }
 

--- a/packages/frosted-ui/src/components/select/select.css
+++ b/packages/frosted-ui/src/components/select/select.css
@@ -51,6 +51,7 @@
   --scrollarea-scrollbar-horizontal-margin-left: var(--select-content-padding);
   --scrollarea-scrollbar-horizontal-margin-right: var(--select-content-padding);
 
+  overflow: hidden;
   background-color: var(--color-panel-solid);
   pointer-events: auto;
   transform-origin: var(--transform-origin);
@@ -73,19 +74,26 @@
   }
 }
 
-.fui-SelectViewport {
-  box-sizing: border-box;
-  padding: var(--select-content-padding);
+/* ScrollArea integration for Select */
+.fui-SelectContent > .fui-ScrollAreaRoot {
+  height: 100%;
+}
 
+.fui-SelectContent .fui-ScrollAreaViewport {
   /* 
-   * In alignItemWithTrigger mode (data-side="none"), Base UI applies inline styles:
+   * In alignItemWithTrigger mode (data-side="none"), Base UI applies inline styles
+   * to SelectList (now ScrollAreaViewport):
    * position: relative; max-height: 100%; overflow-x: hidden; overflow-y: auto;
-   * In normal mode, the Positioner handles max-height via --available-height
+   * In normal mode, limit height to available space.
    */
   :where(.fui-SelectPositioner:not([data-side='none'])) & {
     max-height: var(--available-height);
-    overflow-y: auto;
   }
+}
+
+.fui-SelectViewport {
+  box-sizing: border-box;
+  padding: var(--select-content-padding);
 
   :where(.fui-SelectContent:has(.fui-ScrollAreaScrollbar[data-orientation='vertical'])) & {
     padding-right: var(--space-3);

--- a/packages/frosted-ui/src/components/select/select.css
+++ b/packages/frosted-ui/src/components/select/select.css
@@ -59,14 +59,11 @@
   /* Animation */
   opacity: 1;
   transform: scale(1);
-  transition:
-    opacity 150ms cubic-bezier(0.16, 1, 0.3, 1),
-    transform 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  transition: opacity 150ms cubic-bezier(0.16, 1, 0.3, 1);
 
   &[data-starting-style],
   &[data-ending-style] {
     opacity: 0;
-    transform: scale(0.97);
   }
 
   & :where(.fui-SelectItem[data-highlighted]:not([data-disabled])) {

--- a/packages/frosted-ui/src/components/select/select.props.ts
+++ b/packages/frosted-ui/src/components/select/select.props.ts
@@ -10,7 +10,7 @@ const selectRootPropDefs = {
   size: PropDef<(typeof sizes)[number]>;
 };
 
-const triggerVariants = ['surface', 'soft', 'ghost'] as const;
+const triggerVariants = ['classic', 'surface', 'soft', 'ghost'] as const;
 
 const selectTriggerPropDefs = {
   variant: { type: 'enum', values: triggerVariants, default: 'surface' },

--- a/packages/frosted-ui/src/components/select/select.stories.tsx
+++ b/packages/frosted-ui/src/components/select/select.stories.tsx
@@ -557,21 +557,50 @@ export const ManyItems: Story = {
     const items = Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`);
 
     return (
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
-        <Text as="div" style={{ maxWidth: 500, textAlign: 'center' }}>
-          Select with many items scrolls when content overflows.
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', alignItems: 'center' }}>
+        <Text as="div" style={{ maxWidth: 600, textAlign: 'center' }}>
+          Select with many items. Compare <Code>alignItemWithTrigger</Code> behavior.
         </Text>
 
-        <Select.Root defaultValue="Item 2">
-          <Select.Trigger {...args} />
-          <Select.Content>
-            {items.map((item) => (
-              <Select.Item key={item} value={item}>
-                {item}
-              </Select.Item>
-            ))}
-          </Select.Content>
-        </Select.Root>
+        <div style={{ display: 'flex', gap: 'var(--space-6)', flexWrap: 'wrap', justifyContent: 'center' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', alignItems: 'center' }}>
+            <Text size="2" weight="medium">
+              alignItemWithTrigger={'{true}'} (default)
+            </Text>
+            <Select.Root defaultValue="Item 25">
+              <Select.Trigger {...args} />
+              <Select.Content>
+                {items.map((item) => (
+                  <Select.Item key={item} value={item}>
+                    {item}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+            <Text size="1" color="gray" style={{ maxWidth: 200, textAlign: 'center' }}>
+              Selected item aligns with trigger. Popup expands as you scroll.
+            </Text>
+          </div>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', alignItems: 'center' }}>
+            <Text size="2" weight="medium">
+              alignItemWithTrigger={'{false}'}
+            </Text>
+            <Select.Root defaultValue="Item 25">
+              <Select.Trigger {...args} />
+              <Select.Content alignItemWithTrigger={false}>
+                {items.map((item) => (
+                  <Select.Item key={item} value={item}>
+                    {item}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+            <Text size="1" color="gray" style={{ maxWidth: 200, textAlign: 'center' }}>
+              Standard dropdown positioning below trigger.
+            </Text>
+          </div>
+        </div>
       </div>
     );
   },

--- a/packages/frosted-ui/src/components/select/select.stories.tsx
+++ b/packages/frosted-ui/src/components/select/select.stories.tsx
@@ -10,6 +10,7 @@ const meta = {
   args: {
     variant: selectTriggerPropDefs.variant.default,
     color: selectTriggerPropDefs.color.default,
+    disabled: false,
   },
   argTypes: {
     variant: {
@@ -19,6 +20,9 @@ const meta = {
     color: {
       control: 'select',
       options: selectTriggerPropDefs.color.values,
+    },
+    disabled: {
+      control: 'boolean',
     },
   },
   parameters: {
@@ -37,8 +41,8 @@ export const Default: Story = {
     variant: selectTriggerPropDefs.variant.default,
     color: selectTriggerPropDefs.color.default,
   },
-  render: (args) => (
-    <Select.Root defaultValue="Apple" size="2">
+  render: ({ disabled, ...args }) => (
+    <Select.Root defaultValue="Apple" size="2" disabled={disabled}>
       <Select.Trigger {...args} />
       <Select.Content>
         <Select.Group>

--- a/packages/frosted-ui/src/components/select/select.stories.tsx
+++ b/packages/frosted-ui/src/components/select/select.stories.tsx
@@ -718,6 +718,125 @@ export const MultipleSelection: Story = {
   },
 };
 
+export const Controlled: Story = {
+  name: 'Controlled',
+  args: {
+    variant: selectTriggerPropDefs.variant.default,
+    color: selectTriggerPropDefs.color.default,
+  },
+  render: (args) => {
+    const [singleValue, setSingleValue] = React.useState<string>('Apple');
+    const [multipleValue, setMultipleValue] = React.useState<string[]>(['javascript', 'typescript']);
+
+    const fruits = ['Apple', 'Orange', 'Banana', 'Grape', 'Mango'];
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)' }}>
+        <Text as="div" style={{ maxWidth: 600 }}>
+          Use <Code>value</Code> and <Code>onValueChange</Code> props to control the Select. When <Code>multiple</Code>{' '}
+          is set, value types automatically become arrays. Use generics like <Code>{'Select.Root<string>'}</Code> or{' '}
+          <Code>{'Select.Root<string, true>'}</Code> for full type safety.
+        </Text>
+
+        <div style={{ display: 'flex', gap: 'var(--space-6)', flexWrap: 'wrap' }}>
+          {/* Single Selection - value is typed as string */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+            <Text size="2" weight="bold">
+              Single Selection
+            </Text>
+            <Select.Root<string>
+              value={singleValue}
+              onValueChange={(value) => {
+                // value is typed as string | null
+                if (value !== null) setSingleValue(value);
+              }}
+            >
+              <Select.Trigger {...args} style={{ width: 180 }} />
+              <Select.Content>
+                {fruits.map((fruit) => (
+                  <Select.Item key={fruit} value={fruit}>
+                    {fruit}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+            <Code size="1">value: "{singleValue}"</Code>
+          </div>
+
+          {/* Multiple Selection - value is typed as string[] */}
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
+            <Text size="2" weight="bold">
+              Multiple Selection
+            </Text>
+            <Select.Root<string, true>
+              multiple
+              value={multipleValue}
+              onValueChange={(value) => {
+                // value is typed as string[] when multiple={true}
+                setMultipleValue(value);
+              }}
+            >
+              <Select.Trigger
+                {...args}
+                style={{ width: 220 }}
+                renderValue={(value) => {
+                  const arr = value as string[];
+                  if (arr.length === 0) return 'Select languages...';
+                  if (arr.length === 1) return languages[arr[0] as Language];
+                  return `${languages[arr[0] as Language]} (+${arr.length - 1} more)`;
+                }}
+              />
+              <Select.Content alignItemWithTrigger={false}>
+                {(Object.keys(languages) as Language[]).map((key) => (
+                  <Select.Item key={key} value={key}>
+                    {languages[key]}
+                  </Select.Item>
+                ))}
+              </Select.Content>
+            </Select.Root>
+            <Code size="1">value: [{multipleValue.map((v) => `"${v}"`).join(', ')}]</Code>
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+          <button
+            type="button"
+            onClick={() => {
+              setSingleValue('Mango');
+              setMultipleValue(['python', 'rust', 'go']);
+            }}
+            style={{
+              padding: '6px 12px',
+              borderRadius: 6,
+              border: '1px solid var(--gray-6)',
+              background: 'var(--gray-3)',
+              cursor: 'pointer',
+            }}
+          >
+            Set programmatically
+          </button>
+          <button
+            type="button"
+            onClick={() => {
+              setSingleValue('Apple');
+              setMultipleValue(['javascript', 'typescript']);
+            }}
+            style={{
+              padding: '6px 12px',
+              borderRadius: 6,
+              border: '1px solid var(--gray-6)',
+              background: 'var(--gray-3)',
+              cursor: 'pointer',
+            }}
+          >
+            Reset
+          </button>
+        </div>
+      </div>
+    );
+  },
+};
+
 interface ShippingMethod {
   id: string;
   name: string;

--- a/packages/frosted-ui/src/components/select/select.stories.tsx
+++ b/packages/frosted-ui/src/components/select/select.stories.tsx
@@ -559,7 +559,7 @@ export const ManyItems: Story = {
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
         <Text as="div" style={{ maxWidth: 500, textAlign: 'center' }}>
-          Select with many items shows scroll arrows when content overflows.
+          Select with many items scrolls when content overflows.
         </Text>
 
         <Select.Root defaultValue="Item 25">

--- a/packages/frosted-ui/src/components/select/select.stories.tsx
+++ b/packages/frosted-ui/src/components/select/select.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { Select, selectTriggerPropDefs } from '..';
+import { Code, Select, selectTriggerPropDefs, Text } from '..';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
@@ -25,7 +25,7 @@ export const Default: Story = {
     color: selectTriggerPropDefs.color.default,
   },
   render: (args) => (
-    <Select.Root defaultValue="apple" size="4">
+    <Select.Root defaultValue="apple" size="2">
       <Select.Trigger {...args} />
       <Select.Content>
         <Select.Group>
@@ -247,19 +247,467 @@ export const HighContrast: Story = {
   ),
 };
 
-export const AlternativePositioning: Story = {
-  name: 'Alternative positioning',
+const fontItems = [
+  { value: 'system', label: 'System font' },
+  { value: 'arial', label: 'Arial' },
+  { value: 'roboto', label: 'Roboto' },
+  { value: 'inter', label: 'Inter' },
+  { value: 'open-sans', label: 'Open Sans' },
+];
+
+const currencyItems = {
+  USD: 'US Dollar',
+  EUR: 'Euro',
+  GBP: 'British Pound',
+  JPY: 'Japanese Yen',
+  CAD: 'Canadian Dollar',
+};
+
+export const FormattingTheValue: Story = {
+  name: 'Formatting the Value',
   args: {
     variant: selectTriggerPropDefs.variant.default,
     color: selectTriggerPropDefs.color.default,
   },
   render: (args) => (
-    <Select.Root defaultValue="apple">
-      <Select.Trigger {...args} />
-      <Select.Content position="popper">
-        <Select.Item value="apple">Apple</Select.Item>
-        <Select.Item value="orange">Orange</Select.Item>
-      </Select.Content>
-    </Select.Root>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', alignItems: 'center' }}>
+      <Text as="div" style={{ maxWidth: 600, textAlign: 'center' }}>
+        By default, <Code>Select.Value</Code> renders the raw value. Use <Code>items</Code> prop on Root for automatic
+        label lookup, or pass a custom render function to <Code>renderValue</Code> on Trigger for full control.
+      </Text>
+
+      <div style={{ display: 'flex', gap: 'var(--space-6)', flexWrap: 'wrap', justifyContent: 'center' }}>
+        {/* Default: Raw value */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', alignItems: 'center' }}>
+          <Text size="1" color="gray">
+            Default (raw value)
+          </Text>
+          <Select.Root defaultValue="roboto">
+            <Select.Trigger {...args} style={{ width: 150 }} />
+            <Select.Content>
+              {fontItems.map((item) => (
+                <Select.Item key={item.value} value={item.value}>
+                  {item.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </div>
+
+        {/* With items prop for label lookup */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', alignItems: 'center' }}>
+          <Text size="1" color="gray">
+            With items prop
+          </Text>
+          <Select.Root defaultValue="roboto" items={fontItems}>
+            <Select.Trigger {...args} style={{ width: 150 }} />
+            <Select.Content>
+              {fontItems.map((item) => (
+                <Select.Item key={item.value} value={item.value}>
+                  {item.label}
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </div>
+
+        {/* Custom render function */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', alignItems: 'center' }}>
+          <Text size="1" color="gray">
+            Custom renderValue
+          </Text>
+          <Select.Root defaultValue="EUR">
+            <Select.Trigger
+              {...args}
+              style={{ width: 180 }}
+              renderValue={(value: string) => (
+                <span>
+                  💰 {currencyItems[value as keyof typeof currencyItems]} ({value})
+                </span>
+              )}
+            />
+            <Select.Content>
+              {Object.entries(currencyItems).map(([code, name]) => (
+                <Select.Item key={code} value={code}>
+                  {name} ({code})
+                </Select.Item>
+              ))}
+            </Select.Content>
+          </Select.Root>
+        </div>
+      </div>
+    </div>
   ),
+};
+
+export const DropdownPositioning: Story = {
+  name: 'Dropdown Positioning',
+  args: {
+    variant: selectTriggerPropDefs.variant.default,
+    color: selectTriggerPropDefs.color.default,
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+      <Text as="div" style={{ maxWidth: 500, textAlign: 'center' }}>
+        By default, Base UI Select aligns the selected item with the trigger (native select behavior). Set{' '}
+        <Code>alignItemWithTrigger=&#123;false&#125;</Code> for standard dropdown positioning.
+      </Text>
+
+      <div style={{ display: 'flex', gap: 'var(--space-4)' }}>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', alignItems: 'center' }}>
+          <Text size="1" color="gray">
+            Default (item-aligned)
+          </Text>
+          <Select.Root defaultValue="banana">
+            <Select.Trigger {...args} />
+            <Select.Content>
+              <Select.Item value="apple">Apple</Select.Item>
+              <Select.Item value="banana">Banana</Select.Item>
+              <Select.Item value="cherry">Cherry</Select.Item>
+              <Select.Item value="date">Date</Select.Item>
+              <Select.Item value="elderberry">Elderberry</Select.Item>
+            </Select.Content>
+          </Select.Root>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', alignItems: 'center' }}>
+          <Text size="1" color="gray">
+            alignItemWithTrigger=false
+          </Text>
+          <Select.Root defaultValue="banana">
+            <Select.Trigger {...args} />
+            <Select.Content alignItemWithTrigger={false}>
+              <Select.Item value="apple">Apple</Select.Item>
+              <Select.Item value="banana">Banana</Select.Item>
+              <Select.Item value="cherry">Cherry</Select.Item>
+              <Select.Item value="date">Date</Select.Item>
+              <Select.Item value="elderberry">Elderberry</Select.Item>
+            </Select.Content>
+          </Select.Root>
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+export const SideAndAlign: Story = {
+  name: 'Side and Align',
+  args: {
+    variant: selectTriggerPropDefs.variant.default,
+    color: selectTriggerPropDefs.color.default,
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', alignItems: 'center' }}>
+      <Text as="div" style={{ maxWidth: 500, textAlign: 'center' }}>
+        Control where the popup appears using <Code>side</Code> and <Code>align</Code> props. These only take effect
+        when <Code>alignItemWithTrigger=&#123;false&#125;</Code>.
+      </Text>
+
+      <div style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap', justifyContent: 'center' }}>
+        <Select.Root defaultValue="apple">
+          <Select.Trigger {...args} placeholder="Bottom Start" />
+          <Select.Content alignItemWithTrigger={false} side="bottom" align="start">
+            <Select.Item value="apple">Apple</Select.Item>
+            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="banana">Banana</Select.Item>
+          </Select.Content>
+        </Select.Root>
+
+        <Select.Root defaultValue="apple">
+          <Select.Trigger {...args} placeholder="Bottom Center" />
+          <Select.Content alignItemWithTrigger={false} side="bottom" align="center">
+            <Select.Item value="apple">Apple</Select.Item>
+            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="banana">Banana</Select.Item>
+          </Select.Content>
+        </Select.Root>
+
+        <Select.Root defaultValue="apple">
+          <Select.Trigger {...args} placeholder="Bottom End" />
+          <Select.Content alignItemWithTrigger={false} side="bottom" align="end">
+            <Select.Item value="apple">Apple</Select.Item>
+            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="banana">Banana</Select.Item>
+          </Select.Content>
+        </Select.Root>
+      </div>
+
+      <div style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap', justifyContent: 'center' }}>
+        <Select.Root defaultValue="apple">
+          <Select.Trigger {...args} placeholder="Top Start" />
+          <Select.Content alignItemWithTrigger={false} side="top" align="start">
+            <Select.Item value="apple">Apple</Select.Item>
+            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="banana">Banana</Select.Item>
+          </Select.Content>
+        </Select.Root>
+
+        <Select.Root defaultValue="apple">
+          <Select.Trigger {...args} placeholder="Right Start" />
+          <Select.Content alignItemWithTrigger={false} side="right" align="start">
+            <Select.Item value="apple">Apple</Select.Item>
+            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="banana">Banana</Select.Item>
+          </Select.Content>
+        </Select.Root>
+
+        <Select.Root defaultValue="apple">
+          <Select.Trigger {...args} placeholder="Left Start" />
+          <Select.Content alignItemWithTrigger={false} side="left" align="start">
+            <Select.Item value="apple">Apple</Select.Item>
+            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="banana">Banana</Select.Item>
+          </Select.Content>
+        </Select.Root>
+      </div>
+    </div>
+  ),
+};
+
+export const SideOffsetAndAlignOffset: Story = {
+  name: 'Side Offset and Align Offset',
+  args: {
+    variant: selectTriggerPropDefs.variant.default,
+    color: selectTriggerPropDefs.color.default,
+  },
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', alignItems: 'center' }}>
+      <Text as="div" style={{ maxWidth: 500, textAlign: 'center' }}>
+        Fine-tune positioning with <Code>sideOffset</Code> (distance from trigger) and <Code>alignOffset</Code> (shift
+        along the alignment axis). Requires <Code>alignItemWithTrigger=&#123;false&#125;</Code>.
+      </Text>
+
+      <div style={{ display: 'flex', gap: 'var(--space-4)', flexWrap: 'wrap', justifyContent: 'center' }}>
+        <Select.Root defaultValue="apple">
+          <Select.Trigger {...args} placeholder="Default (4px)" />
+          <Select.Content alignItemWithTrigger={false}>
+            <Select.Item value="apple">Apple</Select.Item>
+            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="banana">Banana</Select.Item>
+          </Select.Content>
+        </Select.Root>
+
+        <Select.Root defaultValue="apple">
+          <Select.Trigger {...args} placeholder="sideOffset: 16" />
+          <Select.Content alignItemWithTrigger={false} sideOffset={16}>
+            <Select.Item value="apple">Apple</Select.Item>
+            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="banana">Banana</Select.Item>
+          </Select.Content>
+        </Select.Root>
+
+        <Select.Root defaultValue="apple">
+          <Select.Trigger {...args} placeholder="alignOffset: 20" />
+          <Select.Content alignItemWithTrigger={false} alignOffset={20}>
+            <Select.Item value="apple">Apple</Select.Item>
+            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="banana">Banana</Select.Item>
+          </Select.Content>
+        </Select.Root>
+      </div>
+    </div>
+  ),
+};
+
+export const ControlledMode: Story = {
+  name: 'Controlled Mode',
+  args: {
+    variant: selectTriggerPropDefs.variant.default,
+    color: selectTriggerPropDefs.color.default,
+  },
+  render: function Render(args) {
+    const [value, setValue] = React.useState<string | null>('apple');
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+        <Text as="div" style={{ maxWidth: 500, textAlign: 'center' }}>
+          Control the select's value externally with <Code>value</Code> and <Code>onValueChange</Code> props.
+        </Text>
+
+        <Select.Root value={value} onValueChange={(newValue) => setValue(newValue as string | null)}>
+          <Select.Trigger {...args} placeholder="Pick a fruit" />
+          <Select.Content>
+            <Select.Item value="apple">Apple</Select.Item>
+            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="banana">Banana</Select.Item>
+            <Select.Item value="cherry">Cherry</Select.Item>
+          </Select.Content>
+        </Select.Root>
+
+        <Text size="2" color="gray">
+          Selected: <Code>{value ?? 'none'}</Code>
+        </Text>
+
+        <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+          <button onClick={() => setValue('cherry')}>Set to Cherry</button>
+          <button onClick={() => setValue(null)}>Clear</button>
+        </div>
+      </div>
+    );
+  },
+};
+
+export const ManyItems: Story = {
+  name: 'Many Items',
+  args: {
+    variant: selectTriggerPropDefs.variant.default,
+    color: selectTriggerPropDefs.color.default,
+  },
+  render: (args) => {
+    const items = Array.from({ length: 50 }, (_, i) => `Item ${i + 1}`);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+        <Text as="div" style={{ maxWidth: 500, textAlign: 'center' }}>
+          Select with many items shows scroll arrows when content overflows.
+        </Text>
+
+        <Select.Root defaultValue="Item 25">
+          <Select.Trigger {...args} />
+          <Select.Content>
+            {items.map((item) => (
+              <Select.Item key={item} value={item}>
+                {item}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Root>
+      </div>
+    );
+  },
+};
+
+const languages = {
+  javascript: 'JavaScript',
+  typescript: 'TypeScript',
+  python: 'Python',
+  java: 'Java',
+  csharp: 'C#',
+  php: 'PHP',
+  cpp: 'C++',
+  rust: 'Rust',
+  go: 'Go',
+  swift: 'Swift',
+} as const;
+
+type Language = keyof typeof languages;
+
+export const MultipleSelection: Story = {
+  name: 'Multiple Selection',
+  args: {
+    variant: selectTriggerPropDefs.variant.default,
+    color: selectTriggerPropDefs.color.default,
+  },
+  render: (args) => {
+    const languageKeys = Object.keys(languages) as Language[];
+
+    const renderValue = (value: Language[]) => {
+      if (value.length === 0) {
+        return 'Select languages...';
+      }
+      const firstLanguage = languages[value[0]];
+      const additionalCount = value.length > 1 ? ` (+${value.length - 1} more)` : '';
+      return firstLanguage + additionalCount;
+    };
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+        <Text as="div" style={{ maxWidth: 500, textAlign: 'center' }}>
+          Add the <Code>multiple</Code> prop to <Code>Select.Root</Code> to allow multiple selections. Use the{' '}
+          <Code>renderValue</Code> prop on the Trigger to customize how the selection is displayed.
+        </Text>
+
+        <Select.Root multiple defaultValue={['javascript', 'typescript']}>
+          <Select.Trigger {...args} renderValue={renderValue} />
+          <Select.Content alignItemWithTrigger={false}>
+            {languageKeys.map((key) => (
+              <Select.Item key={key} value={key}>
+                {languages[key]}
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Root>
+      </div>
+    );
+  },
+};
+
+interface ShippingMethod {
+  id: string;
+  name: string;
+  duration: string;
+  price: string;
+}
+
+export const ObjectValues: Story = {
+  name: 'Object Values',
+  args: {
+    variant: selectTriggerPropDefs.variant.default,
+    color: selectTriggerPropDefs.color.default,
+  },
+  render: (args) => {
+    const shippingMethods: ShippingMethod[] = [
+      {
+        id: 'standard',
+        name: 'Standard',
+        duration: 'Delivers in 4-6 business days',
+        price: '$4.99',
+      },
+      {
+        id: 'express',
+        name: 'Express',
+        duration: 'Delivers in 2-3 business days',
+        price: '$9.99',
+      },
+      {
+        id: 'overnight',
+        name: 'Overnight',
+        duration: 'Delivers next business day',
+        price: '$19.99',
+      },
+    ];
+
+    const renderShippingValue = (method: ShippingMethod) => (
+      <span style={{ display: 'flex', flexDirection: 'column', gap: 2, textAlign: 'left' }}>
+        <span style={{ fontWeight: 500 }}>{method.name}</span>
+        <span style={{ fontSize: '0.85em', color: 'var(--gray-11)' }}>
+          {method.duration} ({method.price})
+        </span>
+      </span>
+    );
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'center' }}>
+        <Text as="div" style={{ maxWidth: 500, textAlign: 'center' }}>
+          Select items can use objects as values instead of primitives. Use <Code>itemToStringValue</Code> to convert
+          objects to strings for comparison, and <Code>renderValue</Code> to display the full object. Note:{' '}
+          <Code>alignItemWithTrigger=&#123;false&#125;</Code> is recommended for variable-height items.
+        </Text>
+
+        <Select.Root
+          defaultValue={shippingMethods[0]}
+          itemToStringValue={(item) => (item as ShippingMethod).id}
+          size="3"
+        >
+          <Select.Trigger
+            {...args}
+            renderValue={renderShippingValue}
+            style={{ height: 'auto', minHeight: 'var(--space-8)', paddingTop: 8, paddingBottom: 8 }}
+          />
+          <Select.Content alignItemWithTrigger={false}>
+            {shippingMethods.map((method) => (
+              <Select.Item key={method.id} value={method} style={{ height: 'auto', paddingTop: 8, paddingBottom: 8 }}>
+                <span style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+                  <span style={{ fontWeight: 500 }}>{method.name}</span>
+                  <span style={{ fontSize: '0.85em', color: 'var(--gray-11)' }}>
+                    {method.duration} ({method.price})
+                  </span>
+                </span>
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Root>
+      </div>
+    );
+  },
 };

--- a/packages/frosted-ui/src/components/select/select.stories.tsx
+++ b/packages/frosted-ui/src/components/select/select.stories.tsx
@@ -29,7 +29,7 @@ export const Default: Story = {
       <Select.Trigger {...args} />
       <Select.Content>
         <Select.Group>
-          <Select.Label>Fruits</Select.Label>
+          <Select.GroupLabel>Fruits</Select.GroupLabel>
           <Select.Item value="Orange">Orange</Select.Item>
           <Select.Item value="Apple">Apple</Select.Item>
           <Select.Item value="Grape" disabled>
@@ -38,7 +38,7 @@ export const Default: Story = {
         </Select.Group>
         <Select.Separator />
         <Select.Group>
-          <Select.Label>Vegetables</Select.Label>
+          <Select.GroupLabel>Vegetables</Select.GroupLabel>
           <Select.Item value="Carrot">Carrot</Select.Item>
           <Select.Item value="Potato">Potato</Select.Item>
         </Select.Group>
@@ -202,7 +202,7 @@ export const Placeholder: Story = {
       <Select.Trigger {...args} placeholder="Pick a fruit" />
       <Select.Content>
         <Select.Group>
-          <Select.Label>Fruits</Select.Label>
+          <Select.GroupLabel>Fruits</Select.GroupLabel>
           <Select.Item value="Orange">Orange</Select.Item>
           <Select.Item value="Apple">Apple</Select.Item>
           <Select.Item value="Grape" disabled>
@@ -211,7 +211,7 @@ export const Placeholder: Story = {
         </Select.Group>
         <Select.Separator />
         <Select.Group>
-          <Select.Label>Vegetables</Select.Label>
+          <Select.GroupLabel>Vegetables</Select.GroupLabel>
           <Select.Item value="Carrot">Carrot</Select.Item>
           <Select.Item value="Potato">Potato</Select.Item>
         </Select.Group>

--- a/packages/frosted-ui/src/components/select/select.stories.tsx
+++ b/packages/frosted-ui/src/components/select/select.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
 import { Code, Select, selectTriggerPropDefs, Text } from '..';
+import { InfoCircledIcon } from '../../icons';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
@@ -368,8 +369,11 @@ export const FormattingTheValue: Story = {
               {...args}
               style={{ width: 200 }}
               renderValue={(value) => (
-                <span>
-                  💰 {currencyItems[value as keyof typeof currencyItems]} ({value as string})
+                <span style={{ display: 'flex', alignItems: 'center', gap: 6, minWidth: 0 }}>
+                  <InfoCircledIcon style={{ width: 14, height: 14, flexShrink: 0 }} />
+                  <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                    {currencyItems[value as keyof typeof currencyItems]} ({value as string})
+                  </span>
                 </span>
               )}
             />

--- a/packages/frosted-ui/src/components/select/select.stories.tsx
+++ b/packages/frosted-ui/src/components/select/select.stories.tsx
@@ -25,22 +25,22 @@ export const Default: Story = {
     color: selectTriggerPropDefs.color.default,
   },
   render: (args) => (
-    <Select.Root defaultValue="apple" size="2">
+    <Select.Root defaultValue="Apple" size="2">
       <Select.Trigger {...args} />
       <Select.Content>
         <Select.Group>
           <Select.Label>Fruits</Select.Label>
-          <Select.Item value="orange">Orange</Select.Item>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="grape" disabled>
+          <Select.Item value="Orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Grape" disabled>
             Grape
           </Select.Item>
         </Select.Group>
         <Select.Separator />
         <Select.Group>
           <Select.Label>Vegetables</Select.Label>
-          <Select.Item value="carrot">Carrot</Select.Item>
-          <Select.Item value="potato">Potato</Select.Item>
+          <Select.Item value="Carrot">Carrot</Select.Item>
+          <Select.Item value="Potato">Potato</Select.Item>
         </Select.Group>
       </Select.Content>
     </Select.Root>
@@ -54,35 +54,35 @@ export const Size: Story = {
   },
   render: (args) => (
     <div style={{ display: 'flex', gap: 'var(--space-3)', alignItems: 'center' }}>
-      <Select.Root size="1" defaultValue="apple">
+      <Select.Root size="1" defaultValue="Apple">
         <Select.Trigger {...args} />
         <Select.Content>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Orange">Orange</Select.Item>
         </Select.Content>
       </Select.Root>
 
-      <Select.Root size="2" defaultValue="apple">
+      <Select.Root size="2" defaultValue="Apple">
         <Select.Trigger {...args} />
         <Select.Content>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Orange">Orange</Select.Item>
         </Select.Content>
       </Select.Root>
 
-      <Select.Root size="3" defaultValue="apple">
+      <Select.Root size="3" defaultValue="Apple">
         <Select.Trigger {...args} />
         <Select.Content>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Orange">Orange</Select.Item>
         </Select.Content>
       </Select.Root>
 
-      <Select.Root size="4" defaultValue="apple">
+      <Select.Root size="4" defaultValue="Apple">
         <Select.Trigger {...args} />
         <Select.Content>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Orange">Orange</Select.Item>
         </Select.Content>
       </Select.Root>
     </div>
@@ -97,52 +97,52 @@ export const TriggerVariant: Story = {
   render: (args) => (
     <div style={{ display: 'flex', gap: 'var(--space-3)', alignItems: 'center', flexDirection: 'column' }}>
       <div style={{ display: 'flex', gap: 'var(--space-3)', alignItems: 'center' }}>
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} variant="surface" />
           <Select.Content>
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
           </Select.Content>
         </Select.Root>
 
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} variant="soft" />
           <Select.Content>
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
           </Select.Content>
         </Select.Root>
 
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} variant="ghost" />
           <Select.Content>
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
           </Select.Content>
         </Select.Root>
       </div>
       <div style={{ display: 'flex', gap: 'var(--space-3)', alignItems: 'center' }}>
-        <Select.Root defaultValue="apple" disabled>
+        <Select.Root defaultValue="Apple" disabled>
           <Select.Trigger {...args} variant="surface" />
           <Select.Content>
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
           </Select.Content>
         </Select.Root>
 
-        <Select.Root defaultValue="apple" disabled>
+        <Select.Root defaultValue="Apple" disabled>
           <Select.Trigger {...args} variant="soft" />
           <Select.Content>
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
           </Select.Content>
         </Select.Root>
 
-        <Select.Root defaultValue="apple" disabled>
+        <Select.Root defaultValue="Apple" disabled>
           <Select.Trigger {...args} variant="ghost" />
           <Select.Content>
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
           </Select.Content>
         </Select.Root>
       </div>
@@ -157,35 +157,35 @@ export const Color: Story = {
   },
   render: (args) => (
     <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
-      <Select.Root defaultValue="apple">
+      <Select.Root defaultValue="Apple">
         <Select.Trigger {...args} color="indigo" />
         <Select.Content>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Orange">Orange</Select.Item>
         </Select.Content>
       </Select.Root>
 
-      <Select.Root defaultValue="apple">
+      <Select.Root defaultValue="Apple">
         <Select.Trigger {...args} color="cyan" />
         <Select.Content>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Orange">Orange</Select.Item>
         </Select.Content>
       </Select.Root>
 
-      <Select.Root defaultValue="apple">
+      <Select.Root defaultValue="Apple">
         <Select.Trigger {...args} color="orange" />
         <Select.Content>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Orange">Orange</Select.Item>
         </Select.Content>
       </Select.Root>
 
-      <Select.Root defaultValue="apple">
+      <Select.Root defaultValue="Apple">
         <Select.Trigger {...args} color="crimson" />
         <Select.Content>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Orange">Orange</Select.Item>
         </Select.Content>
       </Select.Root>
     </div>
@@ -203,17 +203,17 @@ export const Placeholder: Story = {
       <Select.Content>
         <Select.Group>
           <Select.Label>Fruits</Select.Label>
-          <Select.Item value="orange">Orange</Select.Item>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="grape" disabled>
+          <Select.Item value="Orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Grape" disabled>
             Grape
           </Select.Item>
         </Select.Group>
         <Select.Separator />
         <Select.Group>
           <Select.Label>Vegetables</Select.Label>
-          <Select.Item value="carrot">Carrot</Select.Item>
-          <Select.Item value="potato">Potato</Select.Item>
+          <Select.Item value="Carrot">Carrot</Select.Item>
+          <Select.Item value="Potato">Potato</Select.Item>
         </Select.Group>
       </Select.Content>
     </Select.Root>
@@ -228,19 +228,19 @@ export const HighContrast: Story = {
   },
   render: (args) => (
     <div style={{ display: 'flex', gap: 'var(--space-3)' }}>
-      <Select.Root defaultValue="apple">
+      <Select.Root defaultValue="Apple">
         <Select.Trigger {...args} />
         <Select.Content>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Orange">Orange</Select.Item>
         </Select.Content>
       </Select.Root>
 
-      <Select.Root defaultValue="apple">
+      <Select.Root defaultValue="Apple">
         <Select.Trigger {...args} />
         <Select.Content highContrast>
-          <Select.Item value="apple">Apple</Select.Item>
-          <Select.Item value="orange">Orange</Select.Item>
+          <Select.Item value="Apple">Apple</Select.Item>
+          <Select.Item value="Orange">Orange</Select.Item>
         </Select.Content>
       </Select.Root>
     </div>
@@ -270,21 +270,21 @@ export const FormattingTheValue: Story = {
     color: selectTriggerPropDefs.color.default,
   },
   render: (args) => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', alignItems: 'center' }}>
-      <Text as="div" style={{ maxWidth: 600, textAlign: 'center' }}>
-        By default, <Code>Select.Value</Code> renders the raw value. Use <Code>items</Code> prop on Root for automatic
-        label lookup, or pass a custom render function to <Code>renderValue</Code> on Trigger for full control.
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)' }}>
+      <Text as="div" style={{ maxWidth: 700 }}>
+        By default, <Code>Select.Value</Code> displays the raw <Code>value</Code>, not the label text. Here are
+        different ways to show a formatted label in the trigger.
       </Text>
 
-      <div style={{ display: 'flex', gap: 'var(--space-6)', flexWrap: 'wrap', justifyContent: 'center' }}>
+      <div style={{ display: 'flex', gap: 'var(--space-6)', flexWrap: 'wrap' }}>
         {/* Default: Raw value */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', alignItems: 'center' }}>
-          <Text size="1" color="gray">
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+          <Text size="2" weight="bold">
             Default (raw value)
           </Text>
           <Select.Root defaultValue="roboto">
-            <Select.Trigger {...args} style={{ width: 150 }} />
-            <Select.Content>
+            <Select.Trigger {...args} style={{ width: 160 }} />
+            <Select.Content alignItemWithTrigger={false}>
               {fontItems.map((item) => (
                 <Select.Item key={item.value} value={item.value}>
                   {item.label}
@@ -292,16 +292,19 @@ export const FormattingTheValue: Story = {
               ))}
             </Select.Content>
           </Select.Root>
+          <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+            Shows "roboto" instead of "Roboto". This is the default Base UI behavior.
+          </Text>
         </div>
 
         {/* With items prop for label lookup */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', alignItems: 'center' }}>
-          <Text size="1" color="gray">
-            With items prop
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+          <Text size="2" weight="bold">
+            Using <Code>items</Code> prop
           </Text>
           <Select.Root defaultValue="roboto" items={fontItems}>
-            <Select.Trigger {...args} style={{ width: 150 }} />
-            <Select.Content>
+            <Select.Trigger {...args} style={{ width: 160 }} />
+            <Select.Content alignItemWithTrigger={false}>
               {fontItems.map((item) => (
                 <Select.Item key={item.value} value={item.value}>
                   {item.label}
@@ -309,24 +312,51 @@ export const FormattingTheValue: Story = {
               ))}
             </Select.Content>
           </Select.Root>
+          <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+            Pass <Code>{`{ value, label }`}</Code> objects to Root. Base UI automatically maps values to labels.
+          </Text>
+        </div>
+
+        {/* Using itemToStringLabel */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+          <Text size="2" weight="bold">
+            Using <Code>itemToStringLabel</Code>
+          </Text>
+          <Select.Root
+            defaultValue="roboto"
+            itemToStringLabel={(value) => {
+              const labels: Record<string, string> = { roboto: 'Roboto', inter: 'Inter', poppins: 'Poppins' };
+              return labels[value as string] ?? String(value);
+            }}
+          >
+            <Select.Trigger {...args} style={{ width: 160 }} />
+            <Select.Content alignItemWithTrigger={false}>
+              <Select.Item value="roboto">Roboto</Select.Item>
+              <Select.Item value="inter">Inter</Select.Item>
+              <Select.Item value="poppins">Poppins</Select.Item>
+            </Select.Content>
+          </Select.Root>
+          <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+            Provide a function to transform any value into its display label.
+          </Text>
         </div>
 
         {/* Custom render function */}
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)', alignItems: 'center' }}>
-          <Text size="1" color="gray">
-            Custom renderValue
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+          <Text size="2" weight="bold">
+            Using <Code>renderValue</Code>
           </Text>
           <Select.Root defaultValue="EUR">
             <Select.Trigger
               {...args}
-              style={{ width: 180 }}
-              renderValue={(value: string) => (
+              style={{ width: 200 }}
+              renderValue={(value) => (
                 <span>
-                  💰 {currencyItems[value as keyof typeof currencyItems]} ({value})
+                  💰 {currencyItems[value as keyof typeof currencyItems]} ({value as string})
                 </span>
               )}
             />
-            <Select.Content>
+            <Select.Content alignItemWithTrigger={false}>
               {Object.entries(currencyItems).map(([code, name]) => (
                 <Select.Item key={code} value={code}>
                   {name} ({code})
@@ -334,8 +364,35 @@ export const FormattingTheValue: Story = {
               ))}
             </Select.Content>
           </Select.Root>
+          <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+            Full control via render function. Great for icons or complex formatting.
+          </Text>
+        </div>
+
+        {/* Value equals label */}
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+          <Text size="2" weight="bold">
+            Value = Label
+          </Text>
+          <Select.Root defaultValue="Roboto">
+            <Select.Trigger {...args} style={{ width: 160 }} />
+            <Select.Content alignItemWithTrigger={false}>
+              <Select.Item value="Roboto">Roboto</Select.Item>
+              <Select.Item value="Inter">Inter</Select.Item>
+              <Select.Item value="Poppins">Poppins</Select.Item>
+            </Select.Content>
+          </Select.Root>
+          <Text size="1" color="gray" style={{ maxWidth: 180 }}>
+            Simplest: use display text as value. Works for simple cases.
+          </Text>
         </div>
       </div>
+
+      <Text as="div" size="2" color="gray" style={{ maxWidth: 700, marginTop: 'var(--space-2)' }}>
+        <strong>Recommendation:</strong> Use <Code>items</Code> prop for data-driven selects, or{' '}
+        <Code>renderValue</Code> for custom formatting. Using value=label works for simple cases but can be problematic
+        if you need stable IDs for form submission.
+      </Text>
     </div>
   ),
 };
@@ -361,7 +418,7 @@ export const DropdownPositioning: Story = {
           <Select.Root defaultValue="banana">
             <Select.Trigger {...args} />
             <Select.Content>
-              <Select.Item value="apple">Apple</Select.Item>
+              <Select.Item value="Apple">Apple</Select.Item>
               <Select.Item value="banana">Banana</Select.Item>
               <Select.Item value="cherry">Cherry</Select.Item>
               <Select.Item value="date">Date</Select.Item>
@@ -377,7 +434,7 @@ export const DropdownPositioning: Story = {
           <Select.Root defaultValue="banana">
             <Select.Trigger {...args} />
             <Select.Content alignItemWithTrigger={false}>
-              <Select.Item value="apple">Apple</Select.Item>
+              <Select.Item value="Apple">Apple</Select.Item>
               <Select.Item value="banana">Banana</Select.Item>
               <Select.Item value="cherry">Cherry</Select.Item>
               <Select.Item value="date">Date</Select.Item>
@@ -404,58 +461,58 @@ export const SideAndAlign: Story = {
       </Text>
 
       <div style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap', justifyContent: 'center' }}>
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} placeholder="Bottom Start" />
           <Select.Content alignItemWithTrigger={false} side="bottom" align="start">
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
             <Select.Item value="banana">Banana</Select.Item>
           </Select.Content>
         </Select.Root>
 
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} placeholder="Bottom Center" />
           <Select.Content alignItemWithTrigger={false} side="bottom" align="center">
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
             <Select.Item value="banana">Banana</Select.Item>
           </Select.Content>
         </Select.Root>
 
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} placeholder="Bottom End" />
           <Select.Content alignItemWithTrigger={false} side="bottom" align="end">
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
             <Select.Item value="banana">Banana</Select.Item>
           </Select.Content>
         </Select.Root>
       </div>
 
       <div style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap', justifyContent: 'center' }}>
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} placeholder="Top Start" />
           <Select.Content alignItemWithTrigger={false} side="top" align="start">
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
             <Select.Item value="banana">Banana</Select.Item>
           </Select.Content>
         </Select.Root>
 
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} placeholder="Right Start" />
           <Select.Content alignItemWithTrigger={false} side="right" align="start">
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
             <Select.Item value="banana">Banana</Select.Item>
           </Select.Content>
         </Select.Root>
 
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} placeholder="Left Start" />
           <Select.Content alignItemWithTrigger={false} side="left" align="start">
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
             <Select.Item value="banana">Banana</Select.Item>
           </Select.Content>
         </Select.Root>
@@ -478,29 +535,29 @@ export const SideOffsetAndAlignOffset: Story = {
       </Text>
 
       <div style={{ display: 'flex', gap: 'var(--space-4)', flexWrap: 'wrap', justifyContent: 'center' }}>
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} placeholder="Default (4px)" />
           <Select.Content alignItemWithTrigger={false}>
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
             <Select.Item value="banana">Banana</Select.Item>
           </Select.Content>
         </Select.Root>
 
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} placeholder="sideOffset: 16" />
           <Select.Content alignItemWithTrigger={false} sideOffset={16}>
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
             <Select.Item value="banana">Banana</Select.Item>
           </Select.Content>
         </Select.Root>
 
-        <Select.Root defaultValue="apple">
+        <Select.Root defaultValue="Apple">
           <Select.Trigger {...args} placeholder="alignOffset: 20" />
           <Select.Content alignItemWithTrigger={false} alignOffset={20}>
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
             <Select.Item value="banana">Banana</Select.Item>
           </Select.Content>
         </Select.Root>
@@ -527,8 +584,8 @@ export const ControlledMode: Story = {
         <Select.Root value={value} onValueChange={(newValue) => setValue(newValue as string | null)}>
           <Select.Trigger {...args} placeholder="Pick a fruit" />
           <Select.Content>
-            <Select.Item value="apple">Apple</Select.Item>
-            <Select.Item value="orange">Orange</Select.Item>
+            <Select.Item value="Apple">Apple</Select.Item>
+            <Select.Item value="Orange">Orange</Select.Item>
             <Select.Item value="banana">Banana</Select.Item>
             <Select.Item value="cherry">Cherry</Select.Item>
           </Select.Content>

--- a/packages/frosted-ui/src/components/select/select.stories.tsx
+++ b/packages/frosted-ui/src/components/select/select.stories.tsx
@@ -562,7 +562,7 @@ export const ManyItems: Story = {
           Select with many items scrolls when content overflows.
         </Text>
 
-        <Select.Root defaultValue="Item 25">
+        <Select.Root defaultValue="Item 2">
           <Select.Trigger {...args} />
           <Select.Content>
             {items.map((item) => (

--- a/packages/frosted-ui/src/components/select/select.stories.tsx
+++ b/packages/frosted-ui/src/components/select/select.stories.tsx
@@ -7,7 +7,20 @@ import { Code, Select, selectTriggerPropDefs, Text } from '..';
 const meta = {
   title: 'Controls/Select',
   component: Select.Trigger,
-  args: {},
+  args: {
+    variant: selectTriggerPropDefs.variant.default,
+    color: selectTriggerPropDefs.color.default,
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: selectTriggerPropDefs.variant.values,
+    },
+    color: {
+      control: 'select',
+      options: selectTriggerPropDefs.color.values,
+    },
+  },
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered',

--- a/packages/frosted-ui/src/components/select/select.tsx
+++ b/packages/frosted-ui/src/components/select/select.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ScrollArea as ScrollAreaPrimitive } from '@base-ui/react/scroll-area';
 import { Select as SelectPrimitive } from '@base-ui/react/select';
 import classNames from 'classnames';
 import * as React from 'react';
@@ -144,7 +145,22 @@ const SelectContent = (props: SelectContentProps) => {
               { 'fui-high-contrast': highContrast },
             )}
           >
-            <SelectPrimitive.List className="fui-SelectViewport">{children}</SelectPrimitive.List>
+            <ScrollAreaPrimitive.Root className="fui-ScrollAreaRoot">
+              <SelectPrimitive.List
+                render={<ScrollAreaPrimitive.Viewport className="fui-ScrollAreaViewport" tabIndex={undefined} />}
+              >
+                <ScrollAreaPrimitive.Content>
+                  <div className="fui-SelectViewport">{children}</div>
+                </ScrollAreaPrimitive.Content>
+              </SelectPrimitive.List>
+              <ScrollAreaPrimitive.Scrollbar
+                orientation="vertical"
+                className="fui-ScrollAreaScrollbar fui-r-size-1"
+                data-type="auto"
+              >
+                <ScrollAreaPrimitive.Thumb className="fui-ScrollAreaThumb" />
+              </ScrollAreaPrimitive.Scrollbar>
+            </ScrollAreaPrimitive.Root>
           </SelectPrimitive.Popup>
         </Theme>
       </SelectPrimitive.Positioner>

--- a/packages/frosted-ui/src/components/select/select.tsx
+++ b/packages/frosted-ui/src/components/select/select.tsx
@@ -46,7 +46,9 @@ SelectRoot.displayName = 'SelectRoot';
 
 type SelectTriggerOwnProps = GetPropDefTypes<typeof selectTriggerPropDefs>;
 interface SelectTriggerProps
-  extends Omit<PropsWithoutColor<typeof SelectPrimitive.Trigger>, 'render' | 'className'>, SelectTriggerOwnProps {
+  extends
+    Omit<PropsWithoutColor<typeof SelectPrimitive.Trigger>, 'render' | 'className' | 'children'>,
+    SelectTriggerOwnProps {
   className?: string;
   placeholder?: React.ReactNode;
   /** Custom render function for the selected value. Useful for multiple selection. */

--- a/packages/frosted-ui/src/components/select/select.tsx
+++ b/packages/frosted-ui/src/components/select/select.tsx
@@ -144,9 +144,7 @@ const SelectContent = (props: SelectContentProps) => {
               { 'fui-high-contrast': highContrast },
             )}
           >
-            <SelectPrimitive.ScrollUpArrow className="fui-SelectScrollArrow fui-SelectScrollUpArrow" />
             <SelectPrimitive.List className="fui-SelectViewport">{children}</SelectPrimitive.List>
-            <SelectPrimitive.ScrollDownArrow className="fui-SelectScrollArrow fui-SelectScrollDownArrow" />
           </SelectPrimitive.Popup>
         </Theme>
       </SelectPrimitive.Positioner>

--- a/packages/frosted-ui/src/components/select/select.tsx
+++ b/packages/frosted-ui/src/components/select/select.tsx
@@ -73,7 +73,7 @@ const SelectTrigger = (props: SelectTriggerProps) => {
 
   return (
     <SelectPrimitive.Trigger
-      data-accent-color={color}
+      data-accent-color={color || (variant === 'surface' ? 'gray' : color)}
       {...triggerProps}
       className={classNames(
         'fui-reset',
@@ -83,9 +83,8 @@ const SelectTrigger = (props: SelectTriggerProps) => {
         `fui-variant-${variant}`,
       )}
     >
-      <span className="fui-SelectTriggerInner">
-        <SelectPrimitive.Value>{valueChildren}</SelectPrimitive.Value>
-      </span>
+      <SelectPrimitive.Value className="fui-SelectTriggerValue">{valueChildren}</SelectPrimitive.Value>
+
       <SelectPrimitive.Icon>
         <svg className="fui-SelectIcon" xmlns="http://www.w3.org/2000/svg" viewBox="3.25 5.25 9.5 5.5" fill="none">
           <path

--- a/packages/frosted-ui/src/components/select/select.tsx
+++ b/packages/frosted-ui/src/components/select/select.tsx
@@ -16,17 +16,32 @@ type SelectRootOwnProps = GetPropDefTypes<typeof selectRootPropDefs>;
 type SelectContextValue = SelectRootOwnProps;
 const SelectContext = React.createContext<SelectContextValue>({});
 
-interface SelectRootProps
-  extends Omit<React.ComponentProps<typeof SelectPrimitive.Root>, 'className' | 'render'>, SelectContextValue {}
+// Re-export Base UI types for consumers
+type SelectRootChangeEventDetails = SelectPrimitive.Root.ChangeEventDetails;
+type SelectRootChangeEventReason = SelectPrimitive.Root.ChangeEventReason;
 
-const SelectRoot: React.FC<SelectRootProps> = (props) => {
+// Conditional value type based on multiple prop
+type SelectValue<Value, Multiple extends boolean | undefined> = Multiple extends true ? Value[] : Value;
+
+interface SelectRootPropsBase<Value, Multiple extends boolean | undefined = false>
+  extends Omit<SelectPrimitive.Root.Props<Value, Multiple>, 'className' | 'render'>, SelectContextValue {}
+
+// Overloaded types for better inference
+type SelectRootProps<Value = unknown, Multiple extends boolean | undefined = false> = SelectRootPropsBase<
+  Value,
+  Multiple
+>;
+
+function SelectRoot<Value = unknown, Multiple extends boolean | undefined = false>(
+  props: SelectRootProps<Value, Multiple>,
+) {
   const { children, size = selectRootPropDefs.size.default, ...rootProps } = props;
   return (
-    <SelectPrimitive.Root {...rootProps}>
+    <SelectPrimitive.Root {...(rootProps as SelectPrimitive.Root.Props<Value, Multiple>)}>
       <SelectContext.Provider value={React.useMemo(() => ({ size }), [size])}>{children}</SelectContext.Provider>
     </SelectPrimitive.Root>
   );
-};
+}
 SelectRoot.displayName = 'SelectRoot';
 
 type SelectTriggerOwnProps = GetPropDefTypes<typeof selectTriggerPropDefs>;
@@ -234,7 +249,10 @@ export type {
   SelectGroupLabelProps as GroupLabelProps,
   SelectGroupProps as GroupProps,
   SelectItemProps as ItemProps,
+  SelectRootChangeEventDetails as RootChangeEventDetails,
+  SelectRootChangeEventReason as RootChangeEventReason,
   SelectRootProps as RootProps,
+  SelectValue,
   SelectSeparatorProps as SeparatorProps,
   SelectTriggerProps as TriggerProps,
 };

--- a/packages/frosted-ui/src/components/select/select.tsx
+++ b/packages/frosted-ui/src/components/select/select.tsx
@@ -195,20 +195,16 @@ const SelectGroup = (props: SelectGroupProps) => (
 );
 SelectGroup.displayName = 'SelectGroup';
 
-interface SelectLabelProps extends Omit<
+interface SelectGroupLabelProps extends Omit<
   React.ComponentProps<typeof SelectPrimitive.GroupLabel>,
   'className' | 'render'
 > {
   className?: string;
 }
 
-const SelectLabel = (props: SelectLabelProps) => (
+const SelectGroupLabel = (props: SelectGroupLabelProps) => (
   <SelectPrimitive.GroupLabel {...props} className={classNames('fui-SelectLabel', props.className)} />
 );
-SelectLabel.displayName = 'SelectLabel';
-
-// Alias for backwards compatibility
-const SelectGroupLabel = SelectLabel;
 SelectGroupLabel.displayName = 'SelectGroupLabel';
 
 interface SelectSeparatorProps extends Omit<
@@ -228,7 +224,6 @@ export {
   SelectGroup as Group,
   SelectGroupLabel as GroupLabel,
   SelectItem as Item,
-  SelectLabel as Label,
   SelectRoot as Root,
   SelectSeparator as Separator,
   SelectTrigger as Trigger,
@@ -236,9 +231,9 @@ export {
 
 export type {
   SelectContentProps as ContentProps,
+  SelectGroupLabelProps as GroupLabelProps,
   SelectGroupProps as GroupProps,
   SelectItemProps as ItemProps,
-  SelectLabelProps as LabelProps,
   SelectRootProps as RootProps,
   SelectSeparatorProps as SeparatorProps,
   SelectTriggerProps as TriggerProps,


### PR DESCRIPTION
# Select Component Migration Notes

Migration from Radix UI (`radix-ui`) to Base UI (`@base-ui/react`).

## Breaking Changes

### 1. Value Display Behavior

**This is the most significant change.** In Radix, `Select.Value` automatically showed the selected item's text. In Base UI, it shows the raw `value` by default.

```tsx
// This now shows "apple" in the trigger, not "Apple"
<Select.Root defaultValue="apple">
  <Select.Trigger />
  <Select.Content>
    <Select.Item value="apple">Apple</Select.Item>
  </Select.Content>
</Select.Root>
```

**Solutions:**

1. Use the display text as the value:

   ```tsx
   <Select.Item value="Apple">Apple</Select.Item>
   ```

2. Use the new `items` prop on Root:

   ```tsx
   <Select.Root items={[{ value: 'apple', label: 'Apple' }]}>
   ```

3. Use the new `itemToStringLabel` prop on Root:

   ```tsx
   <Select.Root itemToStringLabel={(v) => capitalize(v)}>
   ```

4. Use the new `renderValue` prop on Trigger:
   ```tsx
   <Select.Trigger renderValue={(v) => labels[v]} />
   ```

### 2. `position` Prop Replaced

The `position` prop on `Select.Content` is deprecated. Use `alignItemWithTrigger` instead.

```tsx
// Before
<Select.Content position="popper">

// After
<Select.Content alignItemWithTrigger={false}>
```

| Old `position` value       | New equivalent                          |
| -------------------------- | --------------------------------------- |
| `"item-aligned"` (default) | `alignItemWithTrigger={true}` (default) |
| `"popper"`                 | `alignItemWithTrigger={false}`          |

### 3. `variant` Prop Removed from Content

The `variant` prop (`"solid"` | `"soft"`) has been removed from `Select.Content`.

### 4. `color` Prop Removed from Content

The `color` prop has been removed from `Select.Content`. Color is now only set on `Select.Trigger`.

### 5. `Select.Label` Renamed to `Select.GroupLabel`

```tsx
// Before
<Select.Label>Category</Select.Label>

// After
<Select.GroupLabel>Category</Select.GroupLabel>
```

### 6. Data Attributes Changed

| Radix                 | Base UI             |
| --------------------- | ------------------- |
| `data-state="open"`   | `data-open`         |
| `data-state="closed"` | (attribute removed) |

### 7. CSS Variables Changed

| Radix                                     | Base UI              |
| ----------------------------------------- | -------------------- |
| `--radix-select-trigger-width`            | `--anchor-width`     |
| `--radix-select-content-available-height` | `--available-height` |
| `--radix-select-content-transform-origin` | `--transform-origin` |

## New Features

### 1. `items` Prop

Pass an array of `{ value, label }` objects to `Select.Root` for automatic value-to-label mapping:

```tsx
<Select.Root items={[{ value: 'light', label: 'Light Mode' }]}>
```

### 2. `itemToStringLabel` Prop

Transform any value to a display label:

```tsx
<Select.Root itemToStringLabel={(value) => value.toUpperCase()}>
```

### 3. `renderValue` Prop

Full control over the trigger's value display:

```tsx
<Select.Trigger renderValue={(value) => <span>Selected: {value}</span>} />
```

### 4. Multiple Selection

Select multiple items:

```tsx
<Select.Root multiple defaultValue={['a', 'b']}>
```

### 5. Generic Type Parameters

`Select.Root` now supports generic type parameters for full type safety:

```tsx
// Single selection - value is typed as string | null
<Select.Root<string>
  value={value}
  onValueChange={(value) => setValue(value)} // value: string | null
>

// Multiple selection - value is typed as string[]
<Select.Root<string, true>
  multiple
  value={values}
  onValueChange={(value) => setValues(value)} // value: string[]
>
```

### 6. Explicit Positioning Props

New props on `Select.Content`:

- `side` - `"top"` | `"bottom"` | `"left"` | `"right"` (default: `"bottom"`)
- `sideOffset` - number (default: `4`)
- `align` - `"start"` | `"center"` | `"end"` (default: `"start"`)
- `alignOffset` - number
- `collisionPadding` - number (default: `10`)

## Removed Components

- `Select.ScrollUpArrow` - scrolling handled by integrated ScrollArea
- `Select.ScrollDownArrow` - scrolling handled by integrated ScrollArea

## Notes

- The internal structure uses Base UI's `Portal` → `Positioner` → `Popup` → `List` hierarchy
- Custom ScrollArea is integrated for consistent scrollbar styling
- The `alignItemWithTrigger` mode provides native select-like behavior where the selected item aligns with the trigger
