### PR TITLE
fix(ci): figma sync lint,build,test actions not running after update

### DIFF
--- a/.github/workflows/sync-icons.yml
+++ b/.github/workflows/sync-icons.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
 
       - uses: pnpm/action-setup@v4
         with:
@@ -58,7 +58,7 @@ jobs:
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           commit-message: 'chore(icons): sync icons from Figma'
           title: 'chore(icons): sync icons from Figma'
           body: |


### PR DESCRIPTION
PRs created by GitHub Actions (Figma sync, canary/stable releases) weren't triggering CI checks because GITHUB_TOKEN doesn't trigger workflows on PRs it creates (GitHub security limitation).

This adds PAT_TOKEN to the sync-icons and release workflows so that auto-generated PRs trigger the full PR workflow (build, lint, test).