### PR TITLE
ci: use PAT for 'Sync auto-release PRs' job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,6 @@ jobs:
         uses: whopio/turbo-module@v0.1.0-canary.3
         with:
           action: sync
-          token: ${{ github.token }}
+          token: ${{ secrets.PAT_TOKEN }}
           published: ${{ steps.release.outputs.published }}
           initial-commit: 3d821dfeec0e67a8b33de2993ba292e58b315d06


### PR DESCRIPTION
Forgot to also use the PAT in the automatic canary PRs jobs
https://github.com/whopio/frosted-ui/pull/470