### PR TITLE
Fix text field chrome

### DIFF
--- a/packages/frosted-ui/src/components/empty-state/empty-state.stories.tsx
+++ b/packages/frosted-ui/src/components/empty-state/empty-state.stories.tsx
@@ -288,7 +288,7 @@ export const WithAvatar: Story = {
   render: () => (
     <EmptyState.Root>
       <EmptyState.Header>
-        <EmptyState.Media>
+        <EmptyState.Media variant="ghost">
           <Avatar
             size="5"
             fallback="Luna Rose"

--- a/packages/frosted-ui/src/components/number-field/number-field.css
+++ b/packages/frosted-ui/src/components/number-field/number-field.css
@@ -1,84 +1,7 @@
 .fui-NumberFieldRoot {
-  display: flex;
+  /* NumberField-specific: center buttons vertically */
   align-items: center;
-  position: relative;
   isolation: isolate;
-
-  /* Focus state */
-  &:where(:has(.fui-NumberFieldInput:focus)) {
-    outline: 2px solid var(--color-focus-root);
-    outline-offset: -1px;
-  }
-}
-
-/* Font size on Root so Slots inherit it */
-.fui-NumberFieldRoot:where(.fui-r-size-1) {
-  font-size: var(--font-size-1);
-  letter-spacing: var(--letter-spacing-1);
-  border-radius: max(6px, var(--radius-full));
-}
-.fui-NumberFieldRoot:where(.fui-r-size-2) {
-  font-size: var(--font-size-2);
-  letter-spacing: var(--letter-spacing-2);
-  border-radius: max(8px, var(--radius-full));
-}
-.fui-NumberFieldRoot:where(.fui-r-size-3) {
-  font-size: var(--font-size-3);
-  letter-spacing: var(--letter-spacing-3);
-  border-radius: max(10px, var(--radius-full));
-}
-.fui-NumberFieldRoot:where(.fui-r-size-4) {
-  font-size: var(--font-size-4);
-  letter-spacing: var(--letter-spacing-4);
-  border-radius: max(14px, var(--radius-full));
-}
-
-/***************************************************************************************************
- * VARIANT STYLES - Background and border
- ***************************************************************************************************/
-
-.fui-NumberFieldRoot:where(.fui-variant-surface) {
-  --text-field-border-width: 1px;
-  background-color: var(--color-surface);
-  box-shadow:
-    inset 0 0 0 1px var(--gray-a5),
-    0px 1px 2px 0px rgba(0, 0, 0, 0.05);
-
-  @media (hover: hover) {
-    &:where(:hover:has(.fui-NumberFieldInput:not(:disabled))) {
-      box-shadow:
-        inset 0 0 0 1px var(--gray-a7),
-        0px 1px 2px 0px rgba(0, 0, 0, 0.05);
-    }
-  }
-
-  &:where(:has(.fui-NumberFieldInput:autofill), :has(.fui-NumberFieldInput[data-com-onepassword-filled])) {
-    background-color: var(--accent-a3);
-    box-shadow:
-      inset 0 0 0 1px var(--gray-a7),
-      inset 0 0 0 1px var(--accent-a4);
-  }
-
-  &:where(:has(.fui-NumberFieldInput:disabled), :has(.fui-NumberFieldInput:read-only)) {
-    background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
-  }
-}
-
-.fui-NumberFieldRoot:where(.fui-variant-soft) {
-  --text-field-border-width: 0px;
-  background-color: var(--accent-a3);
-
-  &:where(:has(.fui-NumberFieldInput:autofill), :has(.fui-NumberFieldInput[data-com-onepassword-filled])) {
-    background-color: var(--accent-a4);
-  }
-
-  &:where(:has(.fui-NumberFieldInput:focus)) {
-    outline-color: var(--accent-8);
-  }
-
-  &:where(:has(.fui-NumberFieldInput:disabled), :has(.fui-NumberFieldInput:read-only)) {
-    background-color: var(--gray-a4);
-  }
 }
 
 /* Input styling - extends TextField styles */
@@ -139,6 +62,44 @@
     height: var(--space-8);
     border-radius: max(14px, var(--radius-full));
   }
+}
+
+/* Soft variant button styling */
+:where(.fui-NumberFieldRoot.fui-variant-soft) .fui-NumberFieldButton {
+  background: transparent;
+  box-shadow: -1px 0 0 0 var(--accent-a5);
+
+  @media (hover: hover) {
+    &:where(:hover:not(:disabled):not([data-readonly])) {
+      background: var(--accent-a3);
+    }
+    &:where(:active:not(:disabled):not([data-readonly])) {
+      background: var(--accent-a4);
+    }
+  }
+
+  &:where(:disabled) {
+    box-shadow: -1px 0 0 0 var(--gray-a5);
+  }
+}
+
+/* Soft variant read-only: use gray dividers */
+:where(.fui-NumberFieldRoot.fui-variant-soft:has(.fui-NumberFieldInput:read-only)) .fui-NumberFieldButton {
+  box-shadow: -1px 0 0 0 var(--gray-a5);
+}
+
+/* Soft variant split layout: decrement needs right border, increment needs left border */
+:where(.fui-NumberFieldRoot.fui-variant-soft.fui-button-layout-split) .fui-NumberFieldDecrement {
+  box-shadow: 1px 0 0 0 var(--accent-a5);
+
+  &:where(:disabled) {
+    box-shadow: 1px 0 0 0 var(--gray-a5);
+  }
+}
+
+:where(.fui-NumberFieldRoot.fui-variant-soft.fui-button-layout-split:has(.fui-NumberFieldInput:read-only))
+  .fui-NumberFieldDecrement {
+  box-shadow: 1px 0 0 0 var(--gray-a5);
 }
 
 /***************************************************************************************************
@@ -308,6 +269,15 @@
       }
     }
   }
+
+  /* Soft variant doesn't need negative margins */
+  &:where(.fui-variant-soft) .fui-NumberFieldButtonGroup {
+    margin-left: 0;
+
+    & .fui-NumberFieldIncrement {
+      margin-left: 0;
+    }
+  }
 }
 
 /***************************************************************************************************
@@ -357,8 +327,4 @@
     color: var(--gray-a11);
     -webkit-text-fill-color: var(--gray-a11);
   }
-}
-
-.fui-NumberFieldRoot:where(:has(.fui-NumberFieldInput:disabled:focus), :has(.fui-NumberFieldInput:read-only:focus)) {
-  outline: 2px solid var(--gray-8);
 }

--- a/packages/frosted-ui/src/components/number-field/number-field.css
+++ b/packages/frosted-ui/src/components/number-field/number-field.css
@@ -3,24 +3,82 @@
   align-items: center;
   position: relative;
   isolation: isolate;
+
+  /* Focus state */
+  &:where(:has(.fui-NumberFieldInput:focus)) {
+    outline: 2px solid var(--color-focus-root);
+    outline-offset: -1px;
+  }
 }
 
 /* Font size on Root so Slots inherit it */
 .fui-NumberFieldRoot:where(.fui-r-size-1) {
   font-size: var(--font-size-1);
   letter-spacing: var(--letter-spacing-1);
+  border-radius: max(6px, var(--radius-full));
 }
 .fui-NumberFieldRoot:where(.fui-r-size-2) {
   font-size: var(--font-size-2);
   letter-spacing: var(--letter-spacing-2);
+  border-radius: max(8px, var(--radius-full));
 }
 .fui-NumberFieldRoot:where(.fui-r-size-3) {
   font-size: var(--font-size-3);
   letter-spacing: var(--letter-spacing-3);
+  border-radius: max(10px, var(--radius-full));
 }
 .fui-NumberFieldRoot:where(.fui-r-size-4) {
   font-size: var(--font-size-4);
   letter-spacing: var(--letter-spacing-4);
+  border-radius: max(14px, var(--radius-full));
+}
+
+/***************************************************************************************************
+ * VARIANT STYLES - Background and border
+ ***************************************************************************************************/
+
+.fui-NumberFieldRoot:where(.fui-variant-surface) {
+  --text-field-border-width: 1px;
+  background-color: var(--color-surface);
+  box-shadow:
+    inset 0 0 0 1px var(--gray-a5),
+    0px 1px 2px 0px rgba(0, 0, 0, 0.05);
+
+  @media (hover: hover) {
+    &:where(:hover:has(.fui-NumberFieldInput:not(:disabled))) {
+      box-shadow:
+        inset 0 0 0 1px var(--gray-a7),
+        0px 1px 2px 0px rgba(0, 0, 0, 0.05);
+    }
+  }
+
+  &:where(:has(.fui-NumberFieldInput:autofill), :has(.fui-NumberFieldInput[data-com-onepassword-filled])) {
+    background-color: var(--accent-a3);
+    box-shadow:
+      inset 0 0 0 1px var(--gray-a7),
+      inset 0 0 0 1px var(--accent-a4);
+  }
+
+  &:where(:has(.fui-NumberFieldInput:disabled), :has(.fui-NumberFieldInput:read-only)) {
+    background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
+  }
+}
+
+.fui-NumberFieldRoot:where(.fui-variant-soft) {
+  --text-field-border-width: 0px;
+  background-color: var(--accent-a3);
+
+  &:where(:has(.fui-NumberFieldInput:autofill), :has(.fui-NumberFieldInput[data-com-onepassword-filled])) {
+    background-color: var(--accent-a4);
+  }
+
+  &:where(:has(.fui-NumberFieldInput:focus)) {
+    outline-color: var(--accent-8);
+  }
+
+  &:where(:has(.fui-NumberFieldInput:disabled), :has(.fui-NumberFieldInput:read-only)) {
+    background-color: var(--gray-a4);
+  }
 }
 
 /* Input styling - extends TextField styles */
@@ -32,24 +90,13 @@
     margin: 0;
   }
 
-  @media (hover: hover) {
-    &:where(.fui-variant-surface:not(:disabled)) ~ :where(.fui-NumberFieldRoot:hover .fui-TextFieldChrome) {
-      box-shadow:
-        inset 0 0 0 1px var(--gray-a7),
-        0px 1px 2px 0px rgba(0, 0, 0, 0.05);
-    }
-  }
   /* Remove spinner buttons in Firefox */
   -moz-appearance: textfield;
   appearance: textfield;
 
-  /* Ensure input border shows above adjacent buttons when focused */
+  /* Ensure input shows above background when focused */
   &:focus {
-    z-index: 4; /* Above chrome */
-
-    & + .fui-TextFieldChrome {
-      z-index: 3; /* Above buttons (z-index: 1-2) but below input */
-    }
+    z-index: 4;
   }
 }
 
@@ -57,7 +104,7 @@
 .fui-NumberFieldButton {
   flex-shrink: 0;
   position: relative;
-  z-index: 1; /* Above TextFieldChrome (z-index: 0) so button backgrounds cover chrome borders */
+  z-index: 1; /* Above root background so button backgrounds are visible */
 
   /* Hovered/focused button should appear above other buttons for border visibility */
   &:hover {
@@ -161,6 +208,9 @@
 
   /* Decrement border radius (left side) */
   & > .fui-NumberFieldDecrement {
+    position: relative;
+    /* Make sure the focus outline stays on top of the button group */
+    z-index: -1;
     &:where(.fui-r-size-1) {
       border-radius: max(6px, var(--radius-full)) 0 0 max(6px, var(--radius-full));
     }
@@ -177,6 +227,9 @@
 
   /* Increment border radius (right side) */
   & > .fui-NumberFieldIncrement {
+    position: relative;
+    /* Make sure the focus outline stays on top of the button group */
+    z-index: -1;
     &:where(.fui-r-size-1) {
       border-radius: 0 max(6px, var(--radius-full)) max(6px, var(--radius-full)) 0;
     }
@@ -190,31 +243,6 @@
       border-radius: 0 max(14px, var(--radius-full)) max(14px, var(--radius-full)) 0;
     }
   }
-
-  /* TextFieldChrome positioning - overlap 1px into buttons to hide input borders */
-  & > .fui-TextFieldChrome {
-    border-radius: 0;
-  }
-
-  &:has(.fui-r-size-1) > .fui-TextFieldChrome {
-    left: calc(var(--space-5) - 1px);
-    right: calc(var(--space-5) - 1px);
-  }
-
-  &:has(.fui-r-size-2) > .fui-TextFieldChrome {
-    left: calc(var(--space-6) - 1px);
-    right: calc(var(--space-6) - 1px);
-  }
-
-  &:has(.fui-r-size-3) > .fui-TextFieldChrome {
-    left: calc(var(--space-7) - 1px);
-    right: calc(var(--space-7) - 1px);
-  }
-
-  &:has(.fui-r-size-4) > .fui-TextFieldChrome {
-    left: calc(var(--space-8) - 1px);
-    right: calc(var(--space-8) - 1px);
-  }
 }
 
 /***************************************************************************************************
@@ -222,9 +250,12 @@
  ***************************************************************************************************/
 
 .fui-NumberFieldButtonGroup {
+  position: relative;
+  /* Make sure the focus outline stays on top of the button group */
+  z-index: -1;
   display: flex;
   flex-direction: row;
-  margin-left: -1px; /* Collapse border with input chrome */
+  margin-left: -1px; /* Collapse border with input */
 }
 
 .fui-NumberFieldRoot.fui-button-layout-trailing {
@@ -277,32 +308,6 @@
       }
     }
   }
-
-  /* TextFieldChrome positioning - account for button group margin-left: -1px and increment margin-left: -1px */
-  & > .fui-TextFieldChrome {
-    left: 0;
-    border-radius: 0;
-  }
-
-  &:has(.fui-r-size-1) > .fui-TextFieldChrome {
-    right: calc(var(--space-5) * 2 - 2px);
-    border-radius: max(6px, var(--radius-full)) 0 0 max(6px, var(--radius-full));
-  }
-
-  &:has(.fui-r-size-2) > .fui-TextFieldChrome {
-    right: calc(var(--space-6) * 2 - 2px);
-    border-radius: max(8px, var(--radius-full)) 0 0 max(8px, var(--radius-full));
-  }
-
-  &:has(.fui-r-size-3) > .fui-TextFieldChrome {
-    right: calc(var(--space-7) * 2 - 2px);
-    border-radius: max(10px, var(--radius-full)) 0 0 max(10px, var(--radius-full));
-  }
-
-  &:has(.fui-r-size-4) > .fui-TextFieldChrome {
-    right: calc(var(--space-8) * 2 - 2px);
-    border-radius: max(14px, var(--radius-full)) 0 0 max(14px, var(--radius-full));
-  }
 }
 
 /***************************************************************************************************
@@ -330,24 +335,6 @@
       border-radius: max(14px, var(--radius-full));
     }
   }
-
-  & > .fui-TextFieldChrome {
-    left: 0;
-    right: 0;
-
-    &:where(.fui-r-size-1) {
-      border-radius: max(6px, var(--radius-full));
-    }
-    &:where(.fui-r-size-2) {
-      border-radius: max(8px, var(--radius-full));
-    }
-    &:where(.fui-r-size-3) {
-      border-radius: max(10px, var(--radius-full));
-    }
-    &:where(.fui-r-size-4) {
-      border-radius: max(14px, var(--radius-full));
-    }
-  }
 }
 
 /***************************************************************************************************
@@ -370,4 +357,8 @@
     color: var(--gray-a11);
     -webkit-text-fill-color: var(--gray-a11);
   }
+}
+
+.fui-NumberFieldRoot:where(:has(.fui-NumberFieldInput:disabled:focus), :has(.fui-NumberFieldInput:read-only:focus)) {
+  outline: 2px solid var(--gray-8);
 }

--- a/packages/frosted-ui/src/components/number-field/number-field.tsx
+++ b/packages/frosted-ui/src/components/number-field/number-field.tsx
@@ -60,11 +60,13 @@ const NumberFieldRoot = (props: NumberFieldRootProps) => {
       {...rootProps}
       render={(primitiveProps) => (
         <div
+          data-accent-color={color}
           {...primitiveProps}
           role="group"
           className={classNames(
             'fui-NumberFieldRoot',
             `fui-r-size-${size}`,
+            `fui-variant-${variant}`,
             `fui-button-layout-${buttonLayout}`,
             className,
           )}
@@ -128,21 +130,18 @@ const NumberFieldInput = React.forwardRef<HTMLInputElement, NumberFieldInputProp
   } = props;
 
   return (
-    <>
-      <NumberFieldPrimitive.Input
-        data-accent-color={color}
-        {...inputProps}
-        ref={forwardedRef}
-        className={classNames(
-          'fui-NumberFieldInput',
-          'fui-TextFieldInput',
-          className,
-          `fui-r-size-${size}`,
-          `fui-variant-${variant}`,
-        )}
-      />
-      <div data-accent-color={color} className="fui-TextFieldChrome" />
-    </>
+    <NumberFieldPrimitive.Input
+      data-accent-color={color}
+      {...inputProps}
+      ref={forwardedRef}
+      className={classNames(
+        'fui-NumberFieldInput',
+        'fui-TextFieldInput',
+        className,
+        `fui-r-size-${size}`,
+        `fui-variant-${variant}`,
+      )}
+    />
   );
 });
 NumberFieldInput.displayName = 'NumberFieldInput';

--- a/packages/frosted-ui/src/components/number-field/number-field.tsx
+++ b/packages/frosted-ui/src/components/number-field/number-field.tsx
@@ -65,6 +65,7 @@ const NumberFieldRoot = (props: NumberFieldRootProps) => {
           role="group"
           className={classNames(
             'fui-NumberFieldRoot',
+            'fui-TextFieldRoot',
             `fui-r-size-${size}`,
             `fui-variant-${variant}`,
             `fui-button-layout-${buttonLayout}`,

--- a/packages/frosted-ui/src/components/text-field/text-field.css
+++ b/packages/frosted-ui/src/components/text-field/text-field.css
@@ -223,6 +223,7 @@
 
   &:where(:has(.fui-TextFieldInput:autofill), :has(.fui-TextFieldInput[data-com-onepassword-filled])) {
     background-color: var(--accent-a4);
+    box-shadow: inset 0 0 0 1px var(--accent-a7);
   }
 
   &:where(:has(.fui-TextFieldInput:focus)) {
@@ -284,6 +285,9 @@
 .fui-TextFieldRoot:where(:has(.fui-TextFieldInput:disabled), :has(.fui-TextFieldInput:read-only)) {
   cursor: text;
 }
-.fui-TextFieldRoot:where(:has(.fui-TextFieldInput:disabled:placeholder-shown), :has(.fui-TextFieldInput:read-only:placeholder-shown)) {
+.fui-TextFieldRoot:where(
+  :has(.fui-TextFieldInput:disabled:placeholder-shown),
+  :has(.fui-TextFieldInput:read-only:placeholder-shown)
+) {
   cursor: default;
 }

--- a/packages/frosted-ui/src/components/text-field/text-field.css
+++ b/packages/frosted-ui/src/components/text-field/text-field.css
@@ -4,6 +4,12 @@
   position: relative;
   z-index: 0;
   cursor: text;
+
+  /* Focus state */
+  &:where(:has(.fui-TextFieldInput:focus)) {
+    outline: 2px solid var(--color-focus-root);
+    outline-offset: -1px;
+  }
 }
 
 .fui-TextFieldInput {
@@ -23,18 +29,6 @@
 
   /* Clip text to the inner shadow */
   border: var(--text-field-border-width) solid transparent;
-}
-
-.fui-TextFieldChrome {
-  position: absolute;
-  inset: 0;
-  z-index: 0;
-  pointer-events: none;
-
-  :where(.fui-TextFieldInput:focus) + & {
-    outline: 2px solid var(--color-focus-root);
-    outline-offset: -1px;
-  }
 }
 
 .fui-TextFieldSlot {
@@ -63,18 +57,22 @@
 .fui-TextFieldRoot:where(.fui-r-size-1) {
   font-size: var(--font-size-1);
   letter-spacing: var(--letter-spacing-1);
+  border-radius: max(6px, var(--radius-full));
 }
 .fui-TextFieldRoot:where(.fui-r-size-2) {
   font-size: var(--font-size-2);
   letter-spacing: var(--letter-spacing-2);
+  border-radius: max(8px, var(--radius-full));
 }
 .fui-TextFieldRoot:where(.fui-r-size-3) {
   font-size: var(--font-size-3);
   letter-spacing: var(--letter-spacing-3);
+  border-radius: max(10px, var(--radius-full));
 }
 .fui-TextFieldRoot:where(.fui-r-size-4) {
   font-size: var(--font-size-4);
   letter-spacing: var(--letter-spacing-4);
+  border-radius: max(14px, var(--radius-full));
 }
 
 .fui-TextFieldSlot {
@@ -114,10 +112,6 @@
       /* Clip text to the visible border radius */
       border-radius: max(6px, var(--radius-full));
     }
-
-    & ~ :where(.fui-TextFieldChrome) {
-      border-radius: max(6px, var(--radius-full));
-    }
   }
   &:where(.fui-r-size-2) {
     height: var(--space-6);
@@ -130,10 +124,6 @@
       /* Equivalent to padding-left, but doesn't cut off long values when cursor is at the end */
       text-indent: calc(var(--space-2) - var(--text-field-border-width));
       /* Clip text to the visible border radius */
-      border-radius: max(8px, var(--radius-full));
-    }
-
-    & ~ :where(.fui-TextFieldChrome) {
       border-radius: max(8px, var(--radius-full));
     }
   }
@@ -150,10 +140,6 @@
       /* Clip text to the visible border radius */
       border-radius: max(10px, var(--radius-full));
     }
-
-    & ~ :where(.fui-TextFieldChrome) {
-      border-radius: max(10px, var(--radius-full));
-    }
   }
   &:where(.fui-r-size-4) {
     height: var(--space-8);
@@ -168,104 +154,101 @@
       /* Clip text to the visible border radius */
       border-radius: max(14px, var(--radius-full));
     }
-
-    & ~ :where(.fui-TextFieldChrome) {
-      border-radius: max(14px, var(--radius-full));
-    }
   }
 }
 
-/* As an enhancement, remove border-radius on the right if there’s a slot */
+/* As an enhancement, remove border-radius on the right if there's a slot */
 .fui-TextFieldInput:where(:has(~ .fui-TextFieldSlot)) {
   border-top-right-radius: 0;
   border-bottom-right-radius: 0;
 }
 
 /***************************************************************************************************
-	*                                                                                                 *
-	* VARIANTS                                                                                        *
+ *                                                                                                 *
+ * VARIANTS                                                                                        *
  *                                                                                                 *
  ***************************************************************************************************/
 
 /* surface */
 
-.fui-TextFieldInput:where(.fui-variant-surface) {
+.fui-TextFieldRoot:where(.fui-variant-surface) {
   --text-field-border-width: 1px;
-  color: var(--gray-12);
-
-  & ~ :where(.fui-TextFieldChrome) {
-    background-color: var(--color-surface);
-    box-shadow:
-      inset 0 0 0 1px var(--gray-a5),
-      0px 1px 2px 0px rgba(0, 0, 0, 0.05);
-    /* Blend inner shadow with page background */
-    padding: 1px;
-  }
+  background-color: var(--color-surface);
+  box-shadow:
+    inset 0 0 0 1px var(--gray-a5),
+    0px 1px 2px 0px rgba(0, 0, 0, 0.05);
 
   @media (hover: hover) {
-    &:where(:not(:disabled)) ~ :where(.fui-TextFieldRoot:hover .fui-TextFieldChrome) {
+    &:where(:hover:has(.fui-TextFieldInput:not(:disabled))) {
       box-shadow:
         inset 0 0 0 1px var(--gray-a7),
         0px 1px 2px 0px rgba(0, 0, 0, 0.05);
     }
   }
+
+  &:where(:has(.fui-TextFieldInput:autofill), :has(.fui-TextFieldInput[data-com-onepassword-filled])) {
+    background-color: var(--accent-a3);
+    box-shadow:
+      inset 0 0 0 1px var(--gray-a7),
+      inset 0 0 0 1px var(--accent-a4);
+  }
+
+  &:where(:has(.fui-TextFieldInput:disabled), :has(.fui-TextFieldInput:read-only)) {
+    /* Blend with grey */
+    background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
+  }
+}
+
+.fui-TextFieldInput:where(.fui-variant-surface) {
+  color: var(--gray-12);
+
   &::placeholder {
     color: var(--gray-a10);
     /* Firefox */
     opacity: 1;
   }
+
   &:where(:autofill, [data-com-onepassword-filled]) {
     /* Reliably removes native autofill colors */
     background-clip: text;
     -webkit-text-fill-color: var(--gray-12);
-
-    & ~ :where(.fui-TextFieldChrome) {
-      background-color: var(--accent-a3);
-      box-shadow:
-        inset 0 0 0 1px var(--gray-a7),
-        inset 0 0 0 1px var(--accent-a4);
-    }
-  }
-  &:where(:disabled, :read-only) {
-    & ~ :where(.fui-TextFieldChrome) {
-      /* Blend with grey */
-      background-image: linear-gradient(var(--gray-a3), var(--gray-a3));
-    }
   }
 }
 
 /* soft */
-.fui-TextFieldInput:where(.fui-variant-soft) {
+
+.fui-TextFieldRoot:where(.fui-variant-soft) {
   --text-field-border-width: 0px;
+  background-color: var(--accent-a3);
+
+  &:where(:has(.fui-TextFieldInput:autofill), :has(.fui-TextFieldInput[data-com-onepassword-filled])) {
+    background-color: var(--accent-a4);
+  }
+
+  &:where(:has(.fui-TextFieldInput:focus)) {
+    /* Use gray outline when component color is gray */
+    outline-color: var(--accent-8);
+  }
+
+  &:where(:has(.fui-TextFieldInput:disabled), :has(.fui-TextFieldInput:read-only)) {
+    background-color: var(--gray-a4);
+  }
+}
+
+.fui-TextFieldInput:where(.fui-variant-soft) {
   color: var(--accent-12);
 
-  & ~ :where(.fui-TextFieldChrome) {
-    background-color: var(--accent-a3);
-  }
   &::placeholder {
     color: var(--accent-12);
     opacity: 0.6;
   }
+
   &:where(:autofill, [data-com-onepassword-filled]) {
     /* Reliably removes native autofill colors */
     background-clip: text;
     -webkit-text-fill-color: var(--accent-12);
+  }
 
-    & ~ :where(.fui-TextFieldChrome) {
-      background-color: var(--accent-a4);
-    }
-  }
-  &:where(:focus) {
-    & ~ :where(.fui-TextFieldChrome) {
-      /* Use gray outline when component color is gray */
-      outline-color: var(--accent-8);
-    }
-  }
-  &:where(:disabled, :read-only) {
-    & ~ :where(.fui-TextFieldChrome) {
-      background-color: var(--gray-a4);
-    }
-  }
   &::selection {
     /* Use gray selection when component color is gray */
     background-color: var(--accent-a5);
@@ -281,9 +264,6 @@
     /* Safari */
     -webkit-text-fill-color: var(--gray-a11);
 
-    &:where(:focus) + :where(.fui-TextFieldChrome) {
-      outline: 2px solid var(--gray-8);
-    }
     &::placeholder {
       opacity: 0.5;
     }
@@ -293,13 +273,17 @@
     &::selection {
       background-color: var(--gray-a5);
     }
-
-    /* Cursor in gaps around slots, as an enhancement */
-    .fui-TextFieldRoot:where(:has(&)) {
-      cursor: text;
-    }
-    .fui-TextFieldRoot:where(:has(&:placeholder-shown)) {
-      cursor: default;
-    }
   }
+}
+
+.fui-TextFieldRoot:where(:has(.fui-TextFieldInput:disabled:focus), :has(.fui-TextFieldInput:read-only:focus)) {
+  outline: 2px solid var(--gray-8);
+}
+
+/* Cursor in gaps around slots, as an enhancement */
+.fui-TextFieldRoot:where(:has(.fui-TextFieldInput:disabled), :has(.fui-TextFieldInput:read-only)) {
+  cursor: text;
+}
+.fui-TextFieldRoot:where(:has(.fui-TextFieldInput:disabled:placeholder-shown), :has(.fui-TextFieldInput:read-only:placeholder-shown)) {
+  cursor: default;
 }

--- a/packages/frosted-ui/src/components/text-field/text-field.tsx
+++ b/packages/frosted-ui/src/components/text-field/text-field.tsx
@@ -23,8 +23,9 @@ const TextFieldRoot = (props: TextFieldRootProps) => {
   } = props;
   return (
     <div
+      data-accent-color={color}
       {...rootProps}
-      className={classNames('fui-TextFieldRoot', `fui-r-size-${size}`, className)}
+      className={classNames('fui-TextFieldRoot', `fui-r-size-${size}`, `fui-variant-${variant}`, className)}
       onPointerDown={composeEventHandlers(rootProps.onPointerDown, (event) => {
         const target = event.target as HTMLElement;
         if (target.closest('input, button, a')) return;
@@ -85,16 +86,13 @@ const TextFieldInput = React.forwardRef<TextFieldInputElement, TextFieldInputPro
     ...inputProps
   } = props;
   const input = (
-    <>
-      <Input
-        data-accent-color={color}
-        spellCheck="false"
-        {...inputProps}
-        ref={forwardedRef}
-        className={classNames('fui-TextFieldInput', className, `fui-r-size-${size}`, `fui-variant-${variant}`)}
-      />
-      <div data-accent-color={color} className="fui-TextFieldChrome" />
-    </>
+    <Input
+      data-accent-color={color}
+      spellCheck="false"
+      {...inputProps}
+      ref={forwardedRef}
+      className={classNames('fui-TextFieldInput', className, `fui-r-size-${size}`, `fui-variant-${variant}`)}
+    />
   );
 
   return hasRoot ? (


### PR DESCRIPTION
# Refactor TextField and NumberField: Remove Chrome Element

## Summary

This PR refactors the `TextField` and `NumberField` components to remove the internal `TextFieldChrome` DOM element. All visual styles (background, border, box-shadow, focus ring) are now applied directly to the Root element.

## Motivation

Previously, both components used a separate `<div className="fui-TextFieldChrome">` element for visual styling. This approach had several drawbacks:

1. **Extra DOM element** - Added unnecessary complexity to the DOM tree
2. **Difficult style overrides** - Developers couldn't easily override styles like `border-radius` on the Root component since the visual styles were on an internal element
3. **Complex CSS selectors** - Required sibling selectors (`~ .fui-TextFieldChrome`) which are harder to reason about

## Changes

### TextField

**Component (`text-field.tsx`)**
- Added `data-accent-color` and `fui-variant-*` class to `TextFieldRoot`
- Removed the `<div className="fui-TextFieldChrome" />` element

**CSS (`text-field.css`)**
- Moved background, box-shadow, and border-radius styles directly to `.fui-TextFieldRoot`
- Converted sibling selectors to `:has()` selectors (e.g., `&:has(.fui-TextFieldInput:focus)`)
- Focus outline now applied directly to Root
- Maintained flat specificity using `:where()` selectors

### NumberField

**Component (`number-field.tsx`)**
- Added `fui-TextFieldRoot` class to NumberFieldRoot to inherit shared styles
- Added `data-accent-color` and `fui-variant-*` class to `NumberFieldRoot`
- Removed the `<div className="fui-TextFieldChrome" />` element

**CSS (`number-field.css`)**
- Removed duplicate variant styles (surface, soft) - now inherited from TextField
- Removed duplicate size styles (font-size, letter-spacing, border-radius) - now inherited from TextField
- Kept only NumberField-specific styles (button layout, slot positioning, etc.)
- Significantly reduced CSS file size by eliminating duplication
- Soft variant buttons now have transparent background with proper hover states
- Soft variant dividers use gray palette when disabled or read-only (instead of accent)

## Benefits

- **Simpler DOM** - One less element per TextField/NumberField instance
- **Easier customization** - Developers can now override `border-radius`, `background`, etc. directly on the Root
- **Cleaner CSS** - No more sibling selectors for chrome styling
- **DRY code** - NumberField now inherits styles from TextField via shared `fui-TextFieldRoot` class, eliminating ~100 lines of duplicate CSS
- **Better DX** - Component styling is more intuitive and matches developer expectations

## Migration

This is a non-breaking change. The public API remains the same - only internal implementation details have changed.

## Testing

- Verified all TextField stories render correctly (Default, Size, Variant, Color, With Slot)
- Verified all NumberField stories render correctly (Default, Size, Variant, Button Layout, With Slot, etc.)
- Confirmed focus states work properly
- Confirmed hover states work properly
- Confirmed disabled/read-only states work properly
