### PR TITLE
feat(skeleton): synced skeleton animation

### DIFF
--- a/packages/frosted-ui/src/components/skeleton/skeleton.css
+++ b/packages/frosted-ui/src/components/skeleton/skeleton.css
@@ -169,6 +169,7 @@
   .fui-SkeletonAvatar,
   .fui-SkeletonText::after,
   .fui-SkeletonRect {
-    animation: fui-skeleton-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    animation: fui-skeleton-pulse 2s cubic-bezier(0.45, 0, 0.55, 1) infinite;
+    animation-delay: var(--fui-skeleton-animation-delay, 0);
   }
 }

--- a/packages/frosted-ui/src/components/skeleton/skeleton.stories.tsx
+++ b/packages/frosted-ui/src/components/skeleton/skeleton.stories.tsx
@@ -1,7 +1,16 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import React from 'react';
-import { Avatar, Card, Skeleton, Text, skeletonAvatarPropDefs, skeletonRectPropDefs, skeletonTextPropDefs } from '..';
+import {
+  Avatar,
+  Button,
+  Card,
+  Skeleton,
+  Text,
+  skeletonAvatarPropDefs,
+  skeletonRectPropDefs,
+  skeletonTextPropDefs,
+} from '..';
 
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
@@ -221,6 +230,131 @@ export const RectHighContrast: Story = {
       </div>
     </div>
   ),
+};
+
+const SYNC_DEMO_VARIANTS: Array<{ label: string; render: (args: React.ComponentProps<typeof Skeleton.Avatar>) => React.ReactNode }> = [
+  {
+    label: 'Card (avatar + text + thumb)',
+    render: (args) => (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
+        <Skeleton.Avatar {...args} size="4" />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+          <Skeleton.Text {...args} size="2" style={{ width: 180 }} />
+          <Skeleton.Text {...args} size="1" style={{ width: 120 }} />
+        </div>
+        <Skeleton.Rect {...args} style={{ width: 64, height: 64 }} />
+      </div>
+    ),
+  },
+  {
+    label: 'Banner',
+    render: (args) => (
+      <Skeleton.Rect {...args} style={{ width: '100%', height: 80, maxWidth: 420, borderRadius: 'var(--radius-2)' }} />
+    ),
+  },
+  {
+    label: 'List item',
+    render: (args) => (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+        <Skeleton.Avatar {...args} size="1" shape="square" />
+        <Skeleton.Text {...args} size="1" style={{ width: 220, flex: 1 }} />
+      </div>
+    ),
+  },
+  {
+    label: 'Profile header',
+    render: (args) => (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-4)' }}>
+        <Skeleton.Avatar {...args} size="7" />
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+          <Skeleton.Text {...args} size="5" style={{ width: 140 }} />
+          <Skeleton.Text {...args} size="2" style={{ width: 200 }} />
+          <Skeleton.Text {...args} size="2" style={{ width: 160 }} />
+        </div>
+      </div>
+    ),
+  },
+  {
+    label: 'Image grid',
+    render: (args) => (
+      <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+        <Skeleton.Rect {...args} style={{ width: 72, height: 72, borderRadius: 'var(--radius-2)' }} />
+        <Skeleton.Rect {...args} style={{ width: 72, height: 72, borderRadius: 'var(--radius-2)' }} />
+        <Skeleton.Rect {...args} style={{ width: 72, height: 72, borderRadius: 'var(--radius-2)' }} />
+      </div>
+    ),
+  },
+  {
+    label: 'Article block',
+    render: (args) => (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-2)' }}>
+        <Skeleton.Text {...args} size="4" style={{ width: '80%', maxWidth: 320 }} />
+        <Skeleton.Text {...args} size="2" style={{ width: '100%', maxWidth: 380 }} />
+        <Skeleton.Text {...args} size="2" style={{ width: '90%', maxWidth: 360 }} />
+        <Skeleton.Rect {...args} style={{ width: '100%', height: 120, maxWidth: 420, borderRadius: 'var(--radius-2)', marginTop: 'var(--space-1)' }} />
+      </div>
+    ),
+  },
+  {
+    label: 'Inline chips',
+    render: (args) => (
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--space-2)' }}>
+        <Skeleton.Rect {...args} style={{ width: 56, height: 24, borderRadius: 'var(--radius-5)' }} />
+        <Skeleton.Rect {...args} style={{ width: 72, height: 24, borderRadius: 'var(--radius-5)' }} />
+        <Skeleton.Rect {...args} style={{ width: 48, height: 24, borderRadius: 'var(--radius-5)' }} />
+        <Skeleton.Rect {...args} style={{ width: 64, height: 24, borderRadius: 'var(--radius-5)' }} />
+      </div>
+    ),
+  },
+  {
+    label: 'Table row',
+    render: (args) => (
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-4)' }}>
+        <Skeleton.Avatar {...args} size="2" />
+        <Skeleton.Text {...args} size="2" style={{ width: 100 }} />
+        <Skeleton.Text {...args} size="1" style={{ width: 80 }} />
+        <Skeleton.Text {...args} size="1" style={{ width: 60 }} />
+      </div>
+    ),
+  },
+];
+
+/**
+ * All skeleton instances use a negative `animation-delay` so they stay in sync with a global phase,
+ * regardless of when they mounted. Watch the pulse—all shapes should dim and brighten together.
+ * Use "Add row" to mount new skeletons; they join the same phase immediately.
+ */
+export const SyncedAnimation: Story = {
+  name: 'Synced animation',
+  args: {
+    color: skeletonTextPropDefs.color.default,
+    highContrast: skeletonTextPropDefs.highContrast.default,
+  },
+  render: (args) => {
+    const [rows, setRows] = React.useState(3);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', alignItems: 'flex-start', maxWidth: 480 }}>
+        <p style={{ margin: 0, fontSize: 'var(--font-size-2)', color: 'var(--gray-11)' }}>
+          All skeletons pulse in sync. Click &quot;Add row&quot; to see more layouts—new ones join the same phase.
+        </p>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+          {Array.from({ length: rows }, (_, i) => {
+            const variant = SYNC_DEMO_VARIANTS[i % SYNC_DEMO_VARIANTS.length];
+            return (
+              <div key={i} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+                <span style={{ fontSize: 'var(--font-size-1)', color: 'var(--gray-9)' }}>{variant.label}</span>
+                {variant.render(args)}
+              </div>
+            );
+          })}
+        </div>
+        <Button type="button" onClick={() => setRows((n) => n + 1)}>
+          Add row
+        </Button>
+      </div>
+    );
+  },
 };
 
 export const Composed: Story = {

--- a/packages/frosted-ui/src/components/skeleton/skeleton.tsx
+++ b/packages/frosted-ui/src/components/skeleton/skeleton.tsx
@@ -5,6 +5,18 @@ import * as React from 'react';
 import type { GetPropDefTypes, PropsWithoutColor } from '../../helpers';
 import { skeletonAvatarPropDefs, skeletonRectPropDefs, skeletonTextPropDefs } from './skeleton.props';
 
+/** Must match the animation duration in skeleton.css (fui-skeleton-pulse) */
+const SKELETON_PULSE_DURATION_S = 2;
+
+function useSkeletonAnimationSync(ref: React.RefObject<HTMLDivElement | null>) {
+  React.useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const phaseSec = (performance.now() / 1000) % SKELETON_PULSE_DURATION_S;
+    el.style.setProperty('--fui-skeleton-animation-delay', `-${phaseSec}s`);
+  }, [ref]);
+}
+
 type SkeletonAvatarOwnProps = GetPropDefTypes<typeof skeletonAvatarPropDefs>;
 
 interface SkeletonAvatarProps extends PropsWithoutColor<'div'>, SkeletonAvatarOwnProps {}
@@ -15,11 +27,25 @@ const SkeletonAvatar = (props: SkeletonAvatarProps) => {
     shape = skeletonAvatarPropDefs.shape.default,
     color = skeletonAvatarPropDefs.color.default,
     highContrast = skeletonAvatarPropDefs.highContrast.default,
+    ref: refProp,
     ...skeletonAvatarProps
   } = props;
 
+  const ref = React.useRef<HTMLDivElement>(null);
+  useSkeletonAnimationSync(ref);
+
+  const setRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      if (typeof refProp === 'function') refProp(node);
+      else if (refProp) (refProp as React.MutableRefObject<HTMLDivElement | null>).current = node;
+    },
+    [refProp],
+  );
+
   return (
     <div
+      ref={setRef}
       data-accent-color={color}
       className={classNames('fui-SkeletonAvatar', className, `fui-r-size-${size}`, `fui-shape-${shape}`, {
         'fui-high-contrast': highContrast,
@@ -39,11 +65,25 @@ const SkeletonText = (props: SkeletonTextProps) => {
     size = skeletonTextPropDefs.size.default,
     color = skeletonTextPropDefs.color.default,
     highContrast = skeletonTextPropDefs.highContrast.default,
+    ref: refProp,
     ...skeletonTextProps
   } = props;
 
+  const ref = React.useRef<HTMLDivElement>(null);
+  useSkeletonAnimationSync(ref);
+
+  const setRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      if (typeof refProp === 'function') refProp(node);
+      else if (refProp) (refProp as React.MutableRefObject<HTMLDivElement | null>).current = node;
+    },
+    [refProp],
+  );
+
   return (
     <div
+      ref={setRef}
       data-accent-color={color}
       className={classNames('fui-SkeletonText', className, `fui-r-size-${size}`, { 'fui-high-contrast': highContrast })}
       {...skeletonTextProps}
@@ -60,11 +100,25 @@ const SkeletonRect = (props: SkeletonRectProps) => {
     className,
     color = skeletonRectPropDefs.color.default,
     highContrast = skeletonRectPropDefs.highContrast.default,
+    ref: refProp,
     ...skeletonRectProps
   } = props;
 
+  const ref = React.useRef<HTMLDivElement>(null);
+  useSkeletonAnimationSync(ref);
+
+  const setRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      (ref as React.MutableRefObject<HTMLDivElement | null>).current = node;
+      if (typeof refProp === 'function') refProp(node);
+      else if (refProp) (refProp as React.MutableRefObject<HTMLDivElement | null>).current = node;
+    },
+    [refProp],
+  );
+
   return (
     <div
+      ref={setRef}
       data-accent-color={color}
       className={classNames('fui-SkeletonRect', className, { 'fui-high-contrast': highContrast })}
       {...skeletonRectProps}


### PR DESCRIPTION
# Skeleton: synced pulse animation

## Summary

All skeleton instances on the page now pulse in sync. New skeletons join the same animation phase as existing ones, no matter when they mount (e.g. after loading more content or navigating).

## What changed

- **Sync behavior** – On mount, each skeleton sets a negative `animation-delay` so its 2s pulse starts at the current “global” phase (`(performance.now() / 1000) % 2`). Every skeleton stays in the same phase without a shared timeline or :root animation.
- **Ref forwarding** – Avatar, Text, and Rect accept an optional `ref` and merge it with the internal ref used for the sync logic.
- **Story** – New “Synced animation” story with multiple layout variants (card, banner, list item, profile, grid, etc.) and an “Add row” button to demo late-mounted skeletons joining the same phase.

## Why

Previously each skeleton started its animation from 0% when it mounted, so skeletons that appeared at different times were out of phase. Syncing them improves perceived polish and reduces visual noise when many skeletons are on screen or appear over time.

## Technical notes

- **SSR / hydration** – Phase is applied in `useLayoutEffect` (client-only), so server and first client render match; no hydration mismatch.
- **Performance** – One `setProperty` per instance at mount; no :root variable, no document-wide invalidation. Animation remains compositor-driven.
- **Reduced motion** – Unchanged; animation is still gated by `prefers-reduced-motion: no-preference`.

## How to verify

1. Open **Components → Skeleton → Synced animation** in Storybook.
2. Confirm all skeletons pulse in unison.
3. Click “Add row” and confirm new rows pulse in sync with existing ones.
