### PR TITLE
Feat tabs colors

### DIFF
--- a/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
+++ b/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
@@ -19,36 +19,14 @@
   user-select: none;
 }
 
-.fui-BaseTabsTriggerInner,
-.fui-BaseTabsTriggerInnerHidden {
+.fui-BaseTabsTriggerInner {
   display: flex;
   align-items: center;
   justify-content: center;
-}
-
-.fui-BaseTabsTriggerInner {
-  position: absolute;
-}
-
-.fui-BaseTabsTrigger:not([data-selected]):not([data-active]) .fui-BaseTabsTriggerInner,
-.fui-TabsNavLink:not([data-active]) .fui-BaseTabsTriggerInner {
-  letter-spacing: var(--tabs-trigger-inactive-letter-spacing);
-  word-spacing: var(--tabs-trigger-inactive-word-spacing);
-}
-
-.fui-BaseTabsTrigger[data-selected] .fui-BaseTabsTriggerInner,
-.fui-BaseTabsTrigger[data-active] .fui-BaseTabsTriggerInner,
-.fui-TabsNavLink[data-active] .fui-BaseTabsTriggerInner {
   font-weight: var(--font-weight-medium);
-  letter-spacing: var(--tabs-trigger-active-letter-spacing);
-  word-spacing: var(--tabs-trigger-active-word-spacing);
-}
 
-.fui-BaseTabsTriggerInnerHidden {
-  visibility: hidden;
-  font-weight: var(--font-weight-medium);
-  letter-spacing: var(--tabs-trigger-active-letter-spacing);
-  word-spacing: var(--tabs-trigger-active-word-spacing);
+  padding: var(--tabs-trigger-inner-padding-y) var(--tabs-trigger-inner-padding-x);
+  border-radius: var(--tabs-trigger-inner-border-radius);
 }
 
 /***************************************************************************************************
@@ -57,30 +35,24 @@
  *                                                                                                 *
  ***************************************************************************************************/
 
-.fui-BaseTabsTriggerInner,
-.fui-BaseTabsTriggerInnerHidden {
-  padding: var(--tabs-trigger-inner-padding-y) var(--tabs-trigger-inner-padding-x);
-  border-radius: var(--tabs-trigger-inner-border-radius);
-}
-
 .fui-BaseTabsList {
   &:where(.fui-r-size-1) {
     height: 36px;
     font-size: var(--font-size-1);
     line-height: var(--line-height-1);
     letter-spacing: var(--letter-spacing-1);
-    --tabs-trigger-inner-padding-x: calc(1.5 * var(--space-1));
-    --tabs-trigger-inner-padding-y: var(--space-1);
-    --tabs-trigger-inner-border-radius: var(--radius-2);
+    --tabs-trigger-inner-padding-x: 6px;
+    --tabs-trigger-inner-padding-y: 4px;
+    --tabs-trigger-inner-border-radius: 4px;
   }
   &:where(.fui-r-size-2) {
     height: var(--space-7);
     font-size: var(--font-size-2);
     line-height: var(--line-height-2);
     letter-spacing: var(--letter-spacing-2);
-    --tabs-trigger-inner-padding-x: calc(1.25 * var(--space-2));
-    --tabs-trigger-inner-padding-y: var(--space-1);
-    --tabs-trigger-inner-border-radius: var(--radius-3);
+    --tabs-trigger-inner-padding-x: 10px;
+    --tabs-trigger-inner-padding-y: 4px;
+    --tabs-trigger-inner-border-radius: 6px;
   }
 }
 

--- a/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
+++ b/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
@@ -64,6 +64,10 @@
 
 .fui-BaseTabsList {
   box-shadow: inset 0 -1px 0 0 var(--gray-a5);
+  --active-tab-indicator-color: var(--accent-10);
+  &:where(.fui-high-contrast) {
+    --active-tab-indicator-color: var(--accent-12);
+  }
 }
 
 .fui-BaseTabsTrigger {
@@ -92,7 +96,7 @@
     bottom: 0;
     left: 0;
     right: 0;
-    background-color: var(--accent-10);
+    background-color: var(--active-tab-indicator-color);
   }
 }
 

--- a/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
+++ b/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
@@ -63,7 +63,7 @@
  ***************************************************************************************************/
 
 .fui-BaseTabsList {
-  box-shadow: inset 0 -1px 0 0 var(--gray-a5);
+  box-shadow: inset 0 -1px 0 0 var(--color-stroke);
   --active-tab-indicator-color: var(--accent-10);
   &:where(.fui-high-contrast) {
     --active-tab-indicator-color: var(--accent-12);

--- a/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
+++ b/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
@@ -35,12 +35,19 @@
  *                                                                                                 *
  ***************************************************************************************************/
 
+.fui-BaseTabsTrigger {
+  padding-left: var(--tabs-trigger-padding-x);
+  padding-right: var(--tabs-trigger-padding-x);
+}
+
 .fui-BaseTabsList {
   &:where(.fui-r-size-1) {
     height: 36px;
     font-size: var(--font-size-1);
     line-height: var(--line-height-1);
     letter-spacing: var(--letter-spacing-1);
+    --tabs-trigger-padding-x: var(--space-1);
+
     --tabs-trigger-inner-padding-x: 6px;
     --tabs-trigger-inner-padding-y: 4px;
     --tabs-trigger-inner-border-radius: 4px;
@@ -50,6 +57,8 @@
     font-size: var(--font-size-2);
     line-height: var(--line-height-2);
     letter-spacing: var(--letter-spacing-2);
+    --tabs-trigger-padding-x: var(--space-1);
+
     --tabs-trigger-inner-padding-x: 10px;
     --tabs-trigger-inner-padding-y: 4px;
     --tabs-trigger-inner-border-radius: 6px;

--- a/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
+++ b/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css
@@ -57,11 +57,6 @@
  *                                                                                                 *
  ***************************************************************************************************/
 
-.fui-BaseTabsTrigger {
-  padding-left: var(--tabs-trigger-padding-x);
-  padding-right: var(--tabs-trigger-padding-x);
-}
-
 .fui-BaseTabsTriggerInner,
 .fui-BaseTabsTriggerInnerHidden {
   padding: var(--tabs-trigger-inner-padding-y) var(--tabs-trigger-inner-padding-x);
@@ -74,7 +69,6 @@
     font-size: var(--font-size-1);
     line-height: var(--line-height-1);
     letter-spacing: var(--letter-spacing-1);
-    --tabs-trigger-padding-x: var(--space-1);
     --tabs-trigger-inner-padding-x: calc(1.5 * var(--space-1));
     --tabs-trigger-inner-padding-y: var(--space-1);
     --tabs-trigger-inner-border-radius: var(--radius-2);
@@ -84,7 +78,6 @@
     font-size: var(--font-size-2);
     line-height: var(--line-height-2);
     letter-spacing: var(--letter-spacing-2);
-    --tabs-trigger-padding-x: var(--space-1);
     --tabs-trigger-inner-padding-x: calc(1.25 * var(--space-2));
     --tabs-trigger-inner-padding-y: var(--space-1);
     --tabs-trigger-inner-border-radius: var(--radius-3);
@@ -102,7 +95,7 @@
 }
 
 .fui-BaseTabsTrigger {
-  color: var(--gray-a11);
+  color: var(--gray-a10);
 
   @media (hover: hover) {
     &:where(:hover) {
@@ -110,9 +103,6 @@
     }
     &:where(:hover) :where(.fui-BaseTabsTriggerInner) {
       background-color: var(--gray-a3);
-    }
-    &:where(:focus-visible:hover) :where(.fui-BaseTabsTriggerInner) {
-      background-color: var(--accent-a3);
     }
   }
   &:where([data-selected], [data-active]) {

--- a/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.props.ts
+++ b/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.props.ts
@@ -1,13 +1,15 @@
-import { colorProp, PropDef } from '../../helpers';
+import { colorProp, highContrastProp, PropDef } from '../../helpers';
 
 const sizes = ['1', '2'] as const;
 
 const baseTabsListPropDefs = {
   size: { type: 'enum', values: sizes, default: '2' },
   color: colorProp,
+  highContrast: highContrastProp,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
   color: typeof colorProp;
+  highContrast: typeof highContrastProp;
 };
 
 export { baseTabsListPropDefs };

--- a/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.props.ts
+++ b/packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.props.ts
@@ -1,11 +1,13 @@
-import { PropDef } from '../../helpers';
+import { colorProp, PropDef } from '../../helpers';
 
 const sizes = ['1', '2'] as const;
 
 const baseTabsListPropDefs = {
   size: { type: 'enum', values: sizes, default: '2' },
+  color: colorProp,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
+  color: typeof colorProp;
 };
 
 export { baseTabsListPropDefs };

--- a/packages/frosted-ui/src/components/tabs-nav/tabs-nav.css
+++ b/packages/frosted-ui/src/components/tabs-nav/tabs-nav.css
@@ -1,5 +1,13 @@
 @import '../base-tabs-list/base-tabs-list.css';
 
+/* List (ul) uses display:contents so the nav is the single layout container; both Root and List are required by Base UI. */
+.fui-TabsNavListContents {
+  display: contents;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
 .fui-TabsNavItem {
   display: flex;
 }

--- a/packages/frosted-ui/src/components/tabs-nav/tabs-nav.stories.tsx
+++ b/packages/frosted-ui/src/components/tabs-nav/tabs-nav.stories.tsx
@@ -9,6 +9,17 @@ const meta = {
   component: TabsNav.Root,
   args: {
     size: tabsNavPropDefs.size.default,
+    color: tabsNavPropDefs.color.default,
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: tabsNavPropDefs.size.values,
+    },
+    color: {
+      control: 'select',
+      options: tabsNavPropDefs.color.values,
+    },
   },
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
@@ -32,6 +43,35 @@ export const Default: Story = {
         </TabsNav.Link>
         <TabsNav.Link href="#">Documents</TabsNav.Link>
         <TabsNav.Link href="#">Settings</TabsNav.Link>
+      </TabsNav.Root>
+    </div>
+  ),
+};
+
+export const Color: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', width: 600 }}>
+      <TabsNav.Root {...args} color="indigo">
+        <TabsNav.Link active={true} href="#">
+          Account
+        </TabsNav.Link>
+        <TabsNav.Link href="#">Documents</TabsNav.Link>
+        <TabsNav.Link href="#">Settings</TabsNav.Link>
+      </TabsNav.Root>
+
+      <TabsNav.Root {...args} color="cyan">
+        <TabsNav.Link href="#">Overview</TabsNav.Link>
+        <TabsNav.Link active href="#">
+          Analytics
+        </TabsNav.Link>
+        <TabsNav.Link href="#">Reports</TabsNav.Link>
+      </TabsNav.Root>
+
+      <TabsNav.Root {...args} color="crimson">
+        <TabsNav.Link active href="#">
+          One
+        </TabsNav.Link>
+        <TabsNav.Link href="#">Two</TabsNav.Link>
       </TabsNav.Root>
     </div>
   ),

--- a/packages/frosted-ui/src/components/tabs-nav/tabs-nav.stories.tsx
+++ b/packages/frosted-ui/src/components/tabs-nav/tabs-nav.stories.tsx
@@ -10,6 +10,7 @@ const meta = {
   args: {
     size: tabsNavPropDefs.size.default,
     color: tabsNavPropDefs.color.default,
+    highContrast: tabsNavPropDefs.highContrast.default,
   },
   argTypes: {
     size: {
@@ -19,6 +20,9 @@ const meta = {
     color: {
       control: 'select',
       options: tabsNavPropDefs.color.values,
+    },
+    highContrast: {
+      control: 'boolean',
     },
   },
   parameters: {
@@ -72,6 +76,29 @@ export const Color: Story = {
           One
         </TabsNav.Link>
         <TabsNav.Link href="#">Two</TabsNav.Link>
+      </TabsNav.Root>
+    </div>
+  ),
+};
+
+export const HighContrast: Story = {
+  name: 'High Contrast',
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', width: 600 }}>
+      <TabsNav.Root {...args} highContrast={false}>
+        <TabsNav.Link active href="#">
+          Account
+        </TabsNav.Link>
+        <TabsNav.Link href="#">Documents</TabsNav.Link>
+        <TabsNav.Link href="#">Settings</TabsNav.Link>
+      </TabsNav.Root>
+
+      <TabsNav.Root {...args} highContrast>
+        <TabsNav.Link href="#">Overview</TabsNav.Link>
+        <TabsNav.Link active href="#">
+          Analytics
+        </TabsNav.Link>
+        <TabsNav.Link href="#">Reports</TabsNav.Link>
       </TabsNav.Root>
     </div>
   ),

--- a/packages/frosted-ui/src/components/tabs-nav/tabs-nav.stories.tsx
+++ b/packages/frosted-ui/src/components/tabs-nav/tabs-nav.stories.tsx
@@ -52,6 +52,28 @@ export const Default: Story = {
   ),
 };
 
+export const Size: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', width: 600 }}>
+      <TabsNav.Root {...args} size="1">
+        <TabsNav.Link active href="#">
+          Account
+        </TabsNav.Link>
+        <TabsNav.Link href="#">Documents</TabsNav.Link>
+        <TabsNav.Link href="#">Settings</TabsNav.Link>
+      </TabsNav.Root>
+
+      <TabsNav.Root {...args} size="2">
+        <TabsNav.Link href="#">Overview</TabsNav.Link>
+        <TabsNav.Link active href="#">
+          Analytics
+        </TabsNav.Link>
+        <TabsNav.Link href="#">Reports</TabsNav.Link>
+      </TabsNav.Root>
+    </div>
+  ),
+};
+
 export const Color: Story = {
   render: (args) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', width: 600 }}>

--- a/packages/frosted-ui/src/components/tabs-nav/tabs-nav.tsx
+++ b/packages/frosted-ui/src/components/tabs-nav/tabs-nav.tsx
@@ -44,7 +44,6 @@ const TabsNavLink = (props: TabsNavLinkProps) => {
         className={classNames('fui-reset', 'fui-BaseTabsTrigger', 'fui-TabsNavLink', className)}
       >
         <span className="fui-BaseTabsTriggerInner fui-TabsNavLinkInner">{children}</span>
-        <span className="fui-BaseTabsTriggerInnerHidden fui-TabsNavLinkInnerHidden">{children}</span>
       </NavigationMenu.Link>
     </NavigationMenu.Item>
   );

--- a/packages/frosted-ui/src/components/tabs-nav/tabs-nav.tsx
+++ b/packages/frosted-ui/src/components/tabs-nav/tabs-nav.tsx
@@ -21,14 +21,23 @@ const TabsNavRoot = (props: TabsNavRootProps) => {
     ...rootProps
   } = props;
 
+  // Base UI requires both Root (context + <nav>) and List (<ul> + CompositeRoot). We apply tab-list
+  // styling to Root and use display:contents on List so the nav is the single layout container.
   return (
-    <NavigationMenu.Root className="fui-TabsNavRoot" {...rootProps}>
-      <NavigationMenu.List
-        data-accent-color={color}
-        className={classNames('fui-reset', 'fui-BaseTabsList', 'fui-TabsNavList', className, `fui-r-size-${size}`, {
-          'fui-high-contrast': highContrast,
-        })}
-      >
+    <NavigationMenu.Root
+      data-accent-color={color}
+      className={classNames(
+        'fui-TabsNavRoot',
+        'fui-reset',
+        'fui-BaseTabsList',
+        'fui-TabsNavList',
+        className,
+        `fui-r-size-${size}`,
+        { 'fui-high-contrast': highContrast },
+      )}
+      {...rootProps}
+    >
+      <NavigationMenu.List className="fui-reset fui-TabsNavListContents">
         {children}
       </NavigationMenu.List>
     </NavigationMenu.Root>

--- a/packages/frosted-ui/src/components/tabs-nav/tabs-nav.tsx
+++ b/packages/frosted-ui/src/components/tabs-nav/tabs-nav.tsx
@@ -12,11 +12,12 @@ type TabsNavRootProps = Omit<React.ComponentProps<typeof NavigationMenu.Root>, '
   TabsNavOwnProps;
 
 const TabsNavRoot = (props: TabsNavRootProps) => {
-  const { children, className, size = tabsNavPropDefs.size.default, ...rootProps } = props;
+  const { children, className, size = tabsNavPropDefs.size.default, color = tabsNavPropDefs.color.default, ...rootProps } = props;
 
   return (
     <NavigationMenu.Root className="fui-TabsNavRoot" {...rootProps}>
       <NavigationMenu.List
+        data-accent-color={color}
         className={classNames('fui-reset', 'fui-BaseTabsList', 'fui-TabsNavList', className, `fui-r-size-${size}`)}
       >
         {children}

--- a/packages/frosted-ui/src/components/tabs-nav/tabs-nav.tsx
+++ b/packages/frosted-ui/src/components/tabs-nav/tabs-nav.tsx
@@ -12,13 +12,22 @@ type TabsNavRootProps = Omit<React.ComponentProps<typeof NavigationMenu.Root>, '
   TabsNavOwnProps;
 
 const TabsNavRoot = (props: TabsNavRootProps) => {
-  const { children, className, size = tabsNavPropDefs.size.default, color = tabsNavPropDefs.color.default, ...rootProps } = props;
+  const {
+    children,
+    className,
+    size = tabsNavPropDefs.size.default,
+    color = tabsNavPropDefs.color.default,
+    highContrast = tabsNavPropDefs.highContrast.default,
+    ...rootProps
+  } = props;
 
   return (
     <NavigationMenu.Root className="fui-TabsNavRoot" {...rootProps}>
       <NavigationMenu.List
         data-accent-color={color}
-        className={classNames('fui-reset', 'fui-BaseTabsList', 'fui-TabsNavList', className, `fui-r-size-${size}`)}
+        className={classNames('fui-reset', 'fui-BaseTabsList', 'fui-TabsNavList', className, `fui-r-size-${size}`, {
+          'fui-high-contrast': highContrast,
+        })}
       >
         {children}
       </NavigationMenu.List>

--- a/packages/frosted-ui/src/components/tabs/tabs.stories.tsx
+++ b/packages/frosted-ui/src/components/tabs/tabs.stories.tsx
@@ -9,6 +9,17 @@ const meta = {
   component: Tabs.List,
   args: {
     size: tabsListPropDefs.size.default,
+    color: tabsListPropDefs.color.default,
+  },
+  argTypes: {
+    size: {
+      control: 'select',
+      options: tabsListPropDefs.size.values,
+    },
+    color: {
+      control: 'select',
+      options: tabsListPropDefs.color.values,
+    },
   },
   parameters: {
     // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
@@ -45,6 +56,59 @@ export const Default: Story = {
 
         <Tabs.Content value="settings" style={{ padding: '12px 16px 8px 16px' }}>
           <Text size="2">Edit your profile or update contact information.</Text>
+        </Tabs.Content>
+      </Tabs.Root>
+    </div>
+  ),
+};
+
+export const Color: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', width: 600 }}>
+      <Tabs.Root defaultValue="account">
+        <Tabs.List {...args} color="indigo">
+          <Tabs.Trigger value="account">Account</Tabs.Trigger>
+          <Tabs.Trigger value="documents">Documents</Tabs.Trigger>
+          <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="account" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Indigo accent.</Text>
+        </Tabs.Content>
+        <Tabs.Content value="documents" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Documents.</Text>
+        </Tabs.Content>
+        <Tabs.Content value="settings" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Settings.</Text>
+        </Tabs.Content>
+      </Tabs.Root>
+
+      <Tabs.Root defaultValue="tab1">
+        <Tabs.List {...args} color="cyan">
+          <Tabs.Trigger value="tab1">Overview</Tabs.Trigger>
+          <Tabs.Trigger value="tab2">Analytics</Tabs.Trigger>
+          <Tabs.Trigger value="tab3">Reports</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="tab1" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Cyan accent.</Text>
+        </Tabs.Content>
+        <Tabs.Content value="tab2" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Analytics.</Text>
+        </Tabs.Content>
+        <Tabs.Content value="tab3" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Reports.</Text>
+        </Tabs.Content>
+      </Tabs.Root>
+
+      <Tabs.Root defaultValue="one">
+        <Tabs.List {...args} color="crimson">
+          <Tabs.Trigger value="one">One</Tabs.Trigger>
+          <Tabs.Trigger value="two">Two</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="one" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Crimson accent.</Text>
+        </Tabs.Content>
+        <Tabs.Content value="two" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Two.</Text>
         </Tabs.Content>
       </Tabs.Root>
     </div>

--- a/packages/frosted-ui/src/components/tabs/tabs.stories.tsx
+++ b/packages/frosted-ui/src/components/tabs/tabs.stories.tsx
@@ -10,6 +10,7 @@ const meta = {
   args: {
     size: tabsListPropDefs.size.default,
     color: tabsListPropDefs.color.default,
+    highContrast: tabsListPropDefs.highContrast.default,
   },
   argTypes: {
     size: {
@@ -19,6 +20,9 @@ const meta = {
     color: {
       control: 'select',
       options: tabsListPropDefs.color.values,
+    },
+    highContrast: {
+      control: 'boolean',
     },
   },
   parameters: {
@@ -109,6 +113,47 @@ export const Color: Story = {
         </Tabs.Content>
         <Tabs.Content value="two" style={{ padding: '12px 16px 8px 16px' }}>
           <Text size="2">Two.</Text>
+        </Tabs.Content>
+      </Tabs.Root>
+    </div>
+  ),
+};
+
+export const HighContrast: Story = {
+  name: 'High Contrast',
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', width: 600 }}>
+      <Tabs.Root defaultValue="account">
+        <Tabs.List {...args} highContrast={false}>
+          <Tabs.Trigger value="account">Account</Tabs.Trigger>
+          <Tabs.Trigger value="documents">Documents</Tabs.Trigger>
+          <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="account" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Default indicator (accent-10).</Text>
+        </Tabs.Content>
+        <Tabs.Content value="documents" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Documents.</Text>
+        </Tabs.Content>
+        <Tabs.Content value="settings" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Settings.</Text>
+        </Tabs.Content>
+      </Tabs.Root>
+
+      <Tabs.Root defaultValue="tab1">
+        <Tabs.List {...args} highContrast>
+          <Tabs.Trigger value="tab1">Overview</Tabs.Trigger>
+          <Tabs.Trigger value="tab2">Analytics</Tabs.Trigger>
+          <Tabs.Trigger value="tab3">Reports</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="tab1" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">High contrast indicator (accent-12).</Text>
+        </Tabs.Content>
+        <Tabs.Content value="tab2" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Analytics.</Text>
+        </Tabs.Content>
+        <Tabs.Content value="tab3" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Reports.</Text>
         </Tabs.Content>
       </Tabs.Root>
     </div>

--- a/packages/frosted-ui/src/components/tabs/tabs.stories.tsx
+++ b/packages/frosted-ui/src/components/tabs/tabs.stories.tsx
@@ -66,6 +66,46 @@ export const Default: Story = {
   ),
 };
 
+export const Size: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', width: 600 }}>
+      <Tabs.Root defaultValue="account">
+        <Tabs.List {...args} size="1">
+          <Tabs.Trigger value="account">Account</Tabs.Trigger>
+          <Tabs.Trigger value="documents">Documents</Tabs.Trigger>
+          <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="account" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Size 1.</Text>
+        </Tabs.Content>
+        <Tabs.Content value="documents" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Documents.</Text>
+        </Tabs.Content>
+        <Tabs.Content value="settings" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Settings.</Text>
+        </Tabs.Content>
+      </Tabs.Root>
+
+      <Tabs.Root defaultValue="tab1">
+        <Tabs.List {...args} size="2">
+          <Tabs.Trigger value="tab1">Overview</Tabs.Trigger>
+          <Tabs.Trigger value="tab2">Analytics</Tabs.Trigger>
+          <Tabs.Trigger value="tab3">Reports</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="tab1" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Size 2.</Text>
+        </Tabs.Content>
+        <Tabs.Content value="tab2" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Analytics.</Text>
+        </Tabs.Content>
+        <Tabs.Content value="tab3" style={{ padding: '12px 16px 8px 16px' }}>
+          <Text size="2">Reports.</Text>
+        </Tabs.Content>
+      </Tabs.Root>
+    </div>
+  ),
+};
+
 export const Color: Story = {
   render: (args) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-6)', width: 600 }}>

--- a/packages/frosted-ui/src/components/tabs/tabs.tsx
+++ b/packages/frosted-ui/src/components/tabs/tabs.tsx
@@ -23,10 +23,11 @@ type TabsListProps = Omit<PropsWithoutColor<typeof TabsPrimitive.List>, 'classNa
   TabsListOwnProps;
 
 const TabsList = (props: TabsListProps) => {
-  const { className, size = tabsListPropDefs.size.default, ...listProps } = props;
+  const { className, size = tabsListPropDefs.size.default, color = tabsListPropDefs.color.default, ...listProps } = props;
   return (
     <TabsPrimitive.List
       {...listProps}
+      data-accent-color={color}
       className={classNames('fui-BaseTabsList', 'fui-TabsList', className, `fui-r-size-${size}`)}
     />
   );

--- a/packages/frosted-ui/src/components/tabs/tabs.tsx
+++ b/packages/frosted-ui/src/components/tabs/tabs.tsx
@@ -23,12 +23,20 @@ type TabsListProps = Omit<PropsWithoutColor<typeof TabsPrimitive.List>, 'classNa
   TabsListOwnProps;
 
 const TabsList = (props: TabsListProps) => {
-  const { className, size = tabsListPropDefs.size.default, color = tabsListPropDefs.color.default, ...listProps } = props;
+  const {
+    className,
+    size = tabsListPropDefs.size.default,
+    color = tabsListPropDefs.color.default,
+    highContrast = tabsListPropDefs.highContrast.default,
+    ...listProps
+  } = props;
   return (
     <TabsPrimitive.List
       {...listProps}
       data-accent-color={color}
-      className={classNames('fui-BaseTabsList', 'fui-TabsList', className, `fui-r-size-${size}`)}
+      className={classNames('fui-BaseTabsList', 'fui-TabsList', className, `fui-r-size-${size}`, {
+        'fui-high-contrast': highContrast,
+      })}
     />
   );
 };

--- a/packages/frosted-ui/src/components/tabs/tabs.tsx
+++ b/packages/frosted-ui/src/components/tabs/tabs.tsx
@@ -44,7 +44,6 @@ const TabsTrigger = (props: TabsTriggerProps) => {
       className={classNames('fui-reset', 'fui-BaseTabsTrigger', 'fui-TabsTrigger', className)}
     >
       <span className="fui-BaseTabsTriggerInner fui-TabsTriggerInner">{children}</span>
-      <span className="fui-BaseTabsTriggerInnerHidden fui-TabsTriggerInnerHidden">{children}</span>
     </TabsPrimitive.Tab>
   );
 };


### PR DESCRIPTION
# Tabs & TabsNav: color, highContrast, Size stories, and TabsNav layout

<img width="763" height="387" alt="Screenshot 2026-02-17 at 13 15 00" src="https://github.com/user-attachments/assets/38afbbeb-c06b-4384-aa9e-8cd1d23cabfd" />

<img width="763" height="387" alt="Screenshot 2026-02-17 at 13 15 23" src="https://github.com/user-attachments/assets/79599f05-9ab4-43fd-9239-9d12ec4bbd9c" />

## Summary

Adds `color` and `highContrast` props to Tabs and TabsNav, improves Storybook controls, adds Size stories, and refines TabsNav so the navigation bar is a single layout container while still using Base UI’s required Root + List primitives.

## Changes

### Color prop

- **base-tabs-list** – Extended `baseTabsListPropDefs` with `color` (using `colorProp`).
- **Tabs** – `Tabs.List` accepts `color` and sets `data-accent-color` on the list so the tab indicator uses the theme accent.
- **TabsNav** – `TabsNav.Root` accepts `color` and sets `data-accent-color` on the root `<nav>` (tab list styling lives on Root).
- **Stories** – Default args and **Color** story added for both Tabs and TabsNav (e.g. indigo, cyan, crimson).

### High contrast prop

- **base-tabs-list** – Added `highContrast` via `highContrastProp` to the shared prop defs.
- **base-tabs-list.css** – When `.fui-high-contrast` is set on the list, the selected tab indicator uses `var(--accent-12)` instead of `var(--accent-10)`.
- **Tabs** – `Tabs.List` supports `highContrast` and applies the `fui-high-contrast` class.
- **TabsNav** – `TabsNav.Root` supports `highContrast` and passes the class into the root className.
- **Stories** – `highContrast` in args/argTypes and a **High Contrast** story for both components.

### Storybook controls

- **Tabs & TabsNav stories** – `argTypes` updated so `size` and `color` use `control: 'select'` with options from the prop defs, and `highContrast` uses `control: 'boolean'`.

### Size stories

- **Tabs** – New **Size** story showing `size="1"` and `size="2"` tab strips with content.
- **TabsNav** – New **Size** story showing `size="1"` and `size="2"` nav bars.

### TabsNav structure (Root + List)

- Base UI’s NavigationMenu requires both **Root** (context + `<nav>`) and **List** (`<ul>` + CompositeRoot); neither can be dropped without reimplementing behavior.
- Tab-list styling (e.g. `fui-BaseTabsList`, size, color, highContrast, `className`) is applied on **Root** so the `<nav>` is the single visible layout container.
- **List** (`<ul>`) gets `fui-TabsNavListContents`, which uses `display: contents` (and list reset) so the `<ul>` doesn’t create an extra box; the `<li>` items participate in the nav’s flex layout.
- A short comment in `tabs-nav.tsx` explains why both primitives are kept and how the styling/layout split works.

## Files touched

- `packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.props.ts` – color, highContrast.
- `packages/frosted-ui/src/components/base-tabs-list/base-tabs-list.css` – high-contrast indicator rule.
- `packages/frosted-ui/src/components/tabs/tabs.tsx` – color, highContrast on List.
- `packages/frosted-ui/src/components/tabs/tabs.stories.tsx` – args/argTypes, Color, High Contrast, Size stories.
- `packages/frosted-ui/src/components/tabs-nav/tabs-nav.tsx` – styling on Root, display:contents list, comment.
- `packages/frosted-ui/src/components/tabs-nav/tabs-nav.css` – `.fui-TabsNavListContents` (display: contents + list reset).
- `packages/frosted-ui/src/components/tabs-nav/tabs-nav.stories.tsx` – args/argTypes, Color, High Contrast, Size stories.

## Usage

```tsx
// Tabs – color and highContrast on List
<Tabs.Root defaultValue="account">
  <Tabs.List color="indigo" highContrast size="2">
    <Tabs.Trigger value="account">Account</Tabs.Trigger>
    …
  </Tabs.List>
  …
</Tabs.Root>

// TabsNav – color and highContrast on Root
<TabsNav.Root color="cyan" highContrast size="2">
  <TabsNav.Link active href="#">Account</TabsNav.Link>
  …
</TabsNav.Root>
```

## Notes

- `display: contents` on the TabsNav list has broad support in modern browsers (see [caniuse](https://caniuse.com/?search=display%3A+contents)); using the render prop does not allow flattening the required Root/List structure.
