### PR TITLE
fix(radio-group): fix generic type and type inference in radio-group …

### DIFF
--- a/packages/frosted-ui/src/components/radio-button-group/radio-button-group.stories.tsx
+++ b/packages/frosted-ui/src/components/radio-button-group/radio-button-group.stories.tsx
@@ -645,3 +645,48 @@ export const InputRefGroup: Story = {
     );
   },
 };
+
+export const TypeSafeValues: Story = {
+  name: 'Type-Safe Values',
+  render: () => {
+    type Plan = 'basic' | 'pro' | 'enterprise';
+    const [plan, setPlan] = React.useState<Plan>('basic');
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text render={<div />} size="2">
+          The component is generic — pass a string union type to get autocomplete on <Code>value</Code> props and
+          type-check <Code>onValueChange</Code>.
+        </Text>
+
+        <RadioButtonGroup.Root<Plan> value={plan} onValueChange={setPlan}>
+          <div style={{ display: 'flex', gap: 'var(--space-2)' }}>
+            <RadioButtonGroup.Item value="basic">
+              <Card size="2" variant="surface">
+                <Text>Basic</Text>
+              </Card>
+            </RadioButtonGroup.Item>
+            <RadioButtonGroup.Item value="pro">
+              <Card size="2" variant="surface">
+                <Text>Pro</Text>
+              </Card>
+            </RadioButtonGroup.Item>
+            <RadioButtonGroup.Item value="enterprise">
+              <Card size="2" variant="surface">
+                <Text>Enterprise</Text>
+              </Card>
+            </RadioButtonGroup.Item>
+          </div>
+        </RadioButtonGroup.Root>
+
+        <Text size="2">
+          Selected: <Code>{plan}</Code>
+        </Text>
+
+        <Text size="1" color="gray">
+          Try changing a value to <Code>&quot;premum&quot;</Code> — TypeScript will catch the typo!
+        </Text>
+      </div>
+    );
+  },
+};

--- a/packages/frosted-ui/src/components/radio-button-group/radio-button-group.tsx
+++ b/packages/frosted-ui/src/components/radio-button-group/radio-button-group.tsx
@@ -15,15 +15,13 @@ type RadioButtonGroupOwnProps = GetPropDefTypes<typeof radioButtonGroupPropDefs>
 type RadioButtonGroupContextValue = RadioButtonGroupOwnProps;
 const RadioButtonGroupContext = React.createContext<RadioButtonGroupContextValue>({});
 
-interface RadioButtonGroupRootProps
-  extends
-    Omit<React.ComponentProps<typeof RadioButtonGroupPrimitive>, 'className' | 'style' | 'render'>,
-    RadioButtonGroupOwnProps {
+interface RadioButtonGroupRootProps<Value = unknown>
+  extends Omit<RadioButtonGroupPrimitive.Props<Value>, 'className' | 'style' | 'render'>, RadioButtonGroupOwnProps {
   className?: string;
   style?: React.CSSProperties;
 }
 
-const RadioButtonGroupRoot = (props: RadioButtonGroupRootProps) => {
+function RadioButtonGroupRoot<Value = unknown>(props: RadioButtonGroupRootProps<Value>) {
   const {
     className,
     color = radioButtonGroupPropDefs.color.default,
@@ -34,7 +32,7 @@ const RadioButtonGroupRoot = (props: RadioButtonGroupRootProps) => {
   return (
     <RadioButtonGroupPrimitive
       data-accent-color={color}
-      {...rootProps}
+      {...(rootProps as RadioButtonGroupPrimitive.Props<Value>)}
       className={classNames('fui-RadioButtonGroupRoot', className, { 'fui-high-contrast': highContrast })}
     >
       <RadioButtonGroupContext.Provider value={React.useMemo(() => ({ color, highContrast }), [color, highContrast])}>
@@ -42,7 +40,7 @@ const RadioButtonGroupRoot = (props: RadioButtonGroupRootProps) => {
       </RadioButtonGroupContext.Provider>
     </RadioButtonGroupPrimitive>
   );
-};
+}
 RadioButtonGroupRoot.displayName = 'RadioButtonGroupRoot';
 
 interface RadioButtonGroupItemProps extends Omit<

--- a/packages/frosted-ui/src/components/radio-group/radio-group.stories.tsx
+++ b/packages/frosted-ui/src/components/radio-group/radio-group.stories.tsx
@@ -553,12 +553,11 @@ const products: Product[] = [
 
 export const ObjectValues: Story = {
   name: 'Object Values',
-  render: function Render(args) {
+  render: function Render() {
     const [selected, setSelected] = React.useState<Product>(products[0]);
 
-    const handleChange = (value: unknown) => {
-      // Parse the JSON string back to object
-      setSelected(JSON.parse(value as string) as Product);
+    const handleChange = (value: string) => {
+      setSelected(JSON.parse(value) as Product);
     };
 
     return (
@@ -567,7 +566,7 @@ export const ObjectValues: Story = {
           For object values, serialize with <Code>JSON.stringify()</Code> and parse in <Code>onValueChange</Code>.
         </Text>
 
-        <RadioGroup.Root {...args} value={JSON.stringify(selected)} onValueChange={handleChange}>
+        <RadioGroup.Root value={JSON.stringify(selected)} onValueChange={handleChange}>
           {products.map((product) => (
             <RadioGroup.Item key={product.id} value={JSON.stringify(product)}>
               {product.name} — ${product.price}/mo
@@ -612,6 +611,37 @@ export const ObjectValues: Story = {
         >
           {JSON.stringify(selected, null, 2)}
         </Code>
+      </div>
+    );
+  },
+};
+
+export const TypeSafeValues: Story = {
+  name: 'Type-Safe Values',
+  render: () => {
+    type ShippingMethod = 'standard' | 'express' | 'overnight';
+    const [method, setMethod] = React.useState<ShippingMethod>('standard');
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <Text render={<div />} size="2">
+          The component is generic — pass a string union type to get autocomplete on <Code>value</Code> props and
+          type-check <Code>onValueChange</Code>.
+        </Text>
+
+        <RadioGroup.Root<ShippingMethod> value={method} onValueChange={setMethod}>
+          <RadioGroup.Item value="standard">Standard (5-7 days)</RadioGroup.Item>
+          <RadioGroup.Item value="express">Express (2-3 days)</RadioGroup.Item>
+          <RadioGroup.Item value="overnight">Overnight</RadioGroup.Item>
+        </RadioGroup.Root>
+
+        <Text size="2">
+          Selected: <Code>{method}</Code>
+        </Text>
+
+        <Text size="1" color="gray">
+          Try changing a value to <Code>&quot;standarrd&quot;</Code> — TypeScript will catch the typo!
+        </Text>
       </div>
     );
   },

--- a/packages/frosted-ui/src/components/radio-group/radio-group.tsx
+++ b/packages/frosted-ui/src/components/radio-group/radio-group.tsx
@@ -11,13 +11,13 @@ import type { GetPropDefTypes } from '../../helpers';
 
 type RadioGroupOwnProps = GetPropDefTypes<typeof radioGroupPropDefs>;
 
-interface RadioGroupRootProps
-  extends Omit<React.ComponentProps<typeof RadioGroupPrimitive>, 'className' | 'style' | 'render'>, RadioGroupOwnProps {
+interface RadioGroupRootProps<Value = unknown>
+  extends Omit<RadioGroupPrimitive.Props<Value>, 'className' | 'style' | 'render'>, RadioGroupOwnProps {
   className?: string;
   style?: React.CSSProperties;
 }
 
-const RadioGroupRoot = (props: RadioGroupRootProps) => {
+function RadioGroupRoot<Value = unknown>(props: RadioGroupRootProps<Value>) {
   const {
     className,
     size = radioGroupPropDefs.size.default,
@@ -28,13 +28,13 @@ const RadioGroupRoot = (props: RadioGroupRootProps) => {
   return (
     <RadioGroupPrimitive
       data-accent-color={color}
-      {...rootProps}
+      {...(rootProps as RadioGroupPrimitive.Props<Value>)}
       className={classNames('fui-RadioGroupRoot', className, `fui-r-size-${size}`, {
         'fui-high-contrast': highContrast,
       })}
     />
   );
-};
+}
 RadioGroupRoot.displayName = 'RadioGroupRoot';
 
 interface RadioGroupItemProps extends Omit<

--- a/packages/frosted-ui/src/components/segmented-control-radio-group/segmented-control-radio-group.stories.tsx
+++ b/packages/frosted-ui/src/components/segmented-control-radio-group/segmented-control-radio-group.stories.tsx
@@ -130,8 +130,8 @@ export const TypeSafeValues: Story = {
     return (
       <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 400 }}>
         <Text>
-          Pass a string union type to get autocomplete and catch typos at compile time. The generic defaults to{' '}
-          <Code>string</Code> if not specified.
+          Pass a string union type to get autocomplete and catch typos at compile time. Without an explicit type
+          parameter, the value type is inferred from props like <Code>value</Code> and <Code>onValueChange</Code>.
         </Text>
 
         <SegmentedControlRadioGroup.Root<Theme> value={theme} onValueChange={setTheme}>

--- a/packages/frosted-ui/src/components/segmented-control-radio-group/segmented-control-radio-group.tsx
+++ b/packages/frosted-ui/src/components/segmented-control-radio-group/segmented-control-radio-group.tsx
@@ -5,24 +5,24 @@ import { RadioGroup } from '@base-ui/react/radio-group';
 import classNames from 'classnames';
 import * as React from 'react';
 
-type SegmentedControlRadioGroupRootProps<T extends string = string> = Omit<
-  React.ComponentProps<typeof RadioGroup>,
+type SegmentedControlRadioGroupRootProps<Value = unknown> = Omit<
+  RadioGroup.Props<Value>,
   'className' | 'render' | 'value' | 'defaultValue' | 'onValueChange'
 > &
   React.ComponentProps<'div'> & {
     /** The controlled value of the selected radio item */
-    value?: T;
+    value?: Value;
     /** The default value of the selected radio item (uncontrolled) */
-    defaultValue?: T;
+    defaultValue?: Value;
     /** Callback fired when the value changes */
-    onValueChange?: (value: T, eventDetails: RadioGroup.ChangeEventDetails) => void;
+    onValueChange?: (value: Value, eventDetails: RadioGroup.ChangeEventDetails) => void;
   };
 
-function SegmentedControlRadioGroupRoot<T extends string = string>(props: SegmentedControlRadioGroupRootProps<T>) {
+function SegmentedControlRadioGroupRoot<Value = unknown>(props: SegmentedControlRadioGroupRootProps<Value>) {
   const { className, children, ...rootProps } = props;
   return (
     <RadioGroup
-      {...(rootProps as React.ComponentProps<typeof RadioGroup>)}
+      {...(rootProps as RadioGroup.Props<Value>)}
       className={classNames('fui-SegmentedControlRadioGroupRoot', className)}
     >
       <div className="fui-BaseSegmentedControlList">{children}</div>
@@ -31,16 +31,16 @@ function SegmentedControlRadioGroupRoot<T extends string = string>(props: Segmen
 }
 SegmentedControlRadioGroupRoot.displayName = 'SegmentedControlRadioGroupRoot';
 
-type SegmentedControlRadioGroupItemProps<T extends string = string> = Omit<
+type SegmentedControlRadioGroupItemProps<Value = unknown> = Omit<
   React.ComponentProps<typeof Radio.Root>,
   'className' | 'render' | 'nativeButton' | 'value'
 > &
   React.ComponentProps<'span'> & {
-    /** The unique string value of this radio item */
-    value: T;
+    /** The unique value of this radio item */
+    value: Value;
   };
 
-function SegmentedControlRadioGroupItem<T extends string = string>(props: SegmentedControlRadioGroupItemProps<T>) {
+function SegmentedControlRadioGroupItem<Value = unknown>(props: SegmentedControlRadioGroupItemProps<Value>) {
   const { children, className, style, ...itemProps } = props;
 
   return (


### PR DESCRIPTION
## fix: Make RadioGroup, RadioButtonGroup, and SegmentedControlRadioGroup generic

### Problem

After upgrading to `@base-ui/react` v1.2, `onValueChange` in `RadioGroup.Root` and `RadioButtonGroup.Root` was typed as `(value: unknown, ...) => void` with no way to narrow the type. This happened because both components extracted their props using `React.ComponentProps<typeof RadioGroupPrimitive>`, which erases the generic type parameter from base-ui and bakes in `unknown`.

`SegmentedControlRadioGroup` was already generic but used a different pattern (`<T extends string = string>`) that unnecessarily constrained the value type to strings and was inconsistent with the rest of the codebase.

### Solution

Made all three radio group components properly generic by:

1. **`RadioGroup.Root`** — Switched from `React.ComponentProps<typeof RadioGroupPrimitive>` to `RadioGroupPrimitive.Props<Value>`, making the component generic (`<Value = unknown>`). TypeScript now infers the `Value` type from props like `value` and `onValueChange`, matching base-ui's own behavior.

2. **`RadioButtonGroup.Root`** — Same fix as RadioGroup.

3. **`SegmentedControlRadioGroup.Root` / `.Item`** — Replaced `<T extends string = string>` with `<Value = unknown>` for consistency. Removed the `extends string` constraint (base-ui supports non-string values via `serializeValue()`), renamed the type parameter from `T` to `Value`, and switched from `React.ComponentProps<typeof RadioGroup>` to `RadioGroup.Props<Value>`.

All three components now follow the same pattern as `Select` and `Combobox`, which were already correctly generic with `<Value = unknown>`.

### How it works

```tsx
// Type inferred from value prop — onValueChange gets (value: string, ...) => void
<RadioGroup.Root value={selectedString} onValueChange={setSelectedString}>

// Explicit generic for string unions — full autocomplete and typo detection
type Shipping = 'standard' | 'express' | 'overnight';
<RadioGroup.Root<Shipping> value={method} onValueChange={setMethod}>
```

### Files changed

| File | Change |
|------|--------|
| `radio-group.tsx` | Made `RadioGroupRoot` generic via `RadioGroupPrimitive.Props<Value>` |
| `radio-button-group.tsx` | Made `RadioButtonGroupRoot` generic via `RadioButtonGroupPrimitive.Props<Value>` |
| `segmented-control-radio-group.tsx` | Replaced `<T extends string = string>` with `<Value = unknown>`, use `RadioGroup.Props<Value>` |
| `radio-group.stories.tsx` | Added `TypeSafeValues` story, cleaned up `ObjectValues` story |
| `radio-button-group.stories.tsx` | Added `TypeSafeValues` story |
| `segmented-control-radio-group.stories.tsx` | Updated description text in `TypeSafeValues` story |

### Breaking changes

None. The default generic is `unknown`, matching the previous effective behavior. Consumers who already cast `value` in `onValueChange` handlers will continue to work. Consumers who pass typed `value`/`onValueChange` props will now get correct inference automatically.

The only behavioral change for `SegmentedControlRadioGroup` is that the `extends string` constraint is removed, so non-string values are now technically allowed (consistent with base-ui).
