### PR TITLE
fix: prevent Avatar and AvatarStack first-render squishing

### DIFF
--- a/packages/frosted-ui/src/components/avatar/avatar.css
+++ b/packages/frosted-ui/src/components/avatar/avatar.css
@@ -1,10 +1,10 @@
 .fui-AvatarRoot {
-  container-type: inline-size;
   display: inline-flex;
   align-items: center;
   justify-content: center;
   vertical-align: middle;
   user-select: none;
+  aspect-ratio: 1 / 1;
   width: var(--avatar-size);
   height: var(--avatar-size);
   flex-shrink: 0;
@@ -67,32 +67,33 @@
   line-height: 1.4;
   letter-spacing: 0.05em;
   &:where(.fui-one-letter) {
-    font-size: 45cqw;
+    font-size: calc(var(--avatar-size) * 0.45);
   }
   &:where(.fui-two-letters) {
-    /* prettier-ignore */
-    font-size: 40cqw;
+    font-size: calc(var(--avatar-size) * 0.4);
   }
 }
 
 .fui-AvatarRoot {
+  --avatar-size: var(--space-7, 40px);
+
   &:where(.fui-r-size-0) {
-    --avatar-size: var(--space-4);
+    --avatar-size: var(--space-4, 16px);
   }
   &:where(.fui-r-size-1) {
-    --avatar-size: var(--space-5);
+    --avatar-size: var(--space-5, 24px);
   }
   &:where(.fui-r-size-2) {
-    --avatar-size: var(--space-6);
+    --avatar-size: var(--space-6, 32px);
   }
   &:where(.fui-r-size-3) {
-    --avatar-size: var(--space-7);
+    --avatar-size: var(--space-7, 40px);
   }
   &:where(.fui-r-size-4) {
-    --avatar-size: var(--space-8);
+    --avatar-size: var(--space-8, 48px);
   }
   &:where(.fui-r-size-5) {
-    --avatar-size: var(--space-9);
+    --avatar-size: var(--space-9, 64px);
   }
   &:where(.fui-r-size-6) {
     --avatar-size: 80px;

--- a/packages/frosted-ui/src/components/avatar/avatar.css
+++ b/packages/frosted-ui/src/components/avatar/avatar.css
@@ -1,4 +1,5 @@
 .fui-AvatarRoot {
+  container-type: inline-size;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -67,10 +68,11 @@
   line-height: 1.4;
   letter-spacing: 0.05em;
   &:where(.fui-one-letter) {
-    font-size: calc(var(--avatar-size) * 0.45);
+    font-size: 45cqw;
   }
   &:where(.fui-two-letters) {
-    font-size: calc(var(--avatar-size) * 0.4);
+    /* prettier-ignore */
+    font-size: 40cqw;
   }
 }
 

--- a/packages/frosted-ui/src/components/avatar/avatar.tsx
+++ b/packages/frosted-ui/src/components/avatar/avatar.tsx
@@ -55,8 +55,8 @@ const Avatar = (props: AvatarProps) => {
     width: 'var(--avatar-size)',
     height: 'var(--avatar-size)',
     aspectRatio: '1 / 1',
-    ...style,
-  } as React.CSSProperties;
+    ...(typeof style === 'object' && style !== null ? style : {}),
+  };
 
   return (
     <AvatarPrimitive.Root

--- a/packages/frosted-ui/src/components/avatar/avatar.tsx
+++ b/packages/frosted-ui/src/components/avatar/avatar.tsx
@@ -14,19 +14,6 @@ interface AvatarProps extends PropsWithoutColor<typeof AvatarPrimitive.Image>, A
   fallback: NonNullable<AvatarOwnProps['fallback']>;
 }
 
-const AVATAR_SIZE_MAP: Record<(typeof avatarPropDefs.size.values)[number], string> = {
-  '0': 'var(--space-4, 16px)',
-  '1': 'var(--space-5, 24px)',
-  '2': 'var(--space-6, 32px)',
-  '3': 'var(--space-7, 40px)',
-  '4': 'var(--space-8, 48px)',
-  '5': 'var(--space-9, 64px)',
-  '6': '80px',
-  '7': '96px',
-  '8': '128px',
-  '9': '160px',
-};
-
 const Avatar = (props: AvatarProps) => {
   const {
     className,
@@ -50,14 +37,6 @@ const Avatar = (props: AvatarProps) => {
     }
   }, [fallbackProp]);
 
-  const rootStyle = {
-    '--avatar-size': AVATAR_SIZE_MAP[size],
-    width: 'var(--avatar-size)',
-    height: 'var(--avatar-size)',
-    aspectRatio: '1 / 1',
-    ...(typeof style === 'object' && style !== null ? style : {}),
-  };
-
   return (
     <AvatarPrimitive.Root
       data-accent-color={color}
@@ -68,7 +47,7 @@ const Avatar = (props: AvatarProps) => {
         { 'fui-high-contrast': highContrast },
         `fui-shape-${shape}`,
       )}
-      style={rootStyle}
+      style={style}
     >
       <AvatarPrimitive.Image
         className="fui-AvatarImage"

--- a/packages/frosted-ui/src/components/avatar/avatar.tsx
+++ b/packages/frosted-ui/src/components/avatar/avatar.tsx
@@ -14,6 +14,19 @@ interface AvatarProps extends PropsWithoutColor<typeof AvatarPrimitive.Image>, A
   fallback: NonNullable<AvatarOwnProps['fallback']>;
 }
 
+const AVATAR_SIZE_MAP: Record<(typeof avatarPropDefs.size.values)[number], string> = {
+  '0': 'var(--space-4, 16px)',
+  '1': 'var(--space-5, 24px)',
+  '2': 'var(--space-6, 32px)',
+  '3': 'var(--space-7, 40px)',
+  '4': 'var(--space-8, 48px)',
+  '5': 'var(--space-9, 64px)',
+  '6': '80px',
+  '7': '96px',
+  '8': '128px',
+  '9': '160px',
+};
+
 const Avatar = (props: AvatarProps) => {
   const {
     className,
@@ -37,6 +50,14 @@ const Avatar = (props: AvatarProps) => {
     }
   }, [fallbackProp]);
 
+  const rootStyle = {
+    '--avatar-size': AVATAR_SIZE_MAP[size],
+    width: 'var(--avatar-size)',
+    height: 'var(--avatar-size)',
+    aspectRatio: '1 / 1',
+    ...style,
+  } as React.CSSProperties;
+
   return (
     <AvatarPrimitive.Root
       data-accent-color={color}
@@ -47,7 +68,7 @@ const Avatar = (props: AvatarProps) => {
         { 'fui-high-contrast': highContrast },
         `fui-shape-${shape}`,
       )}
-      style={style}
+      style={rootStyle}
     >
       <AvatarPrimitive.Image
         className="fui-AvatarImage"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a first-render layout glitch where `Avatar` could briefly appear squished, including avatars rendered inside `AvatarStack`.

## Findings

- `AvatarStack.Avatar` renders `Avatar`, so both shared the same first-render behavior.
- The initial TSX inline-size workaround was not the right long-term approach because Avatar sizing should remain CSS-driven.
- `container-type` + `cqw` are required so fallback initials stay proportional when consumers override avatar dimensions with custom values.

## What changed

- Reverted inline size injection from `avatar.tsx`; `style` remains pass-through.
- Kept sizing logic in `avatar.css` and stabilized first paint with CSS:
  - Added `aspect-ratio: 1 / 1` on `.fui-AvatarRoot`.
  - Added default `--avatar-size` plus token fallbacks (`var(--space-X, <px>)`) for built-in sizes.
- Restored container-query fallback text behavior:
  - `container-type: inline-size` on `.fui-AvatarRoot`.
  - Fallback font sizes back to `45cqw` / `40cqw` for one/two-letter initials.

## Impact

- Prevents Avatar from appearing squished on first render.
- `AvatarStack` inherits the fix automatically through shared `Avatar` implementation.
- Preserves dynamic fallback-text scaling for custom consumer-defined avatar sizes.

## Validation

- Previous CI type error from inline-style casting was fixed in an earlier follow-up.
- Local lint/build validation remains limited in this cloud workspace because dependencies are not installed (`node_modules`/`turbo` missing).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1186a377-483e-4fd2-9a9a-35e09d33722c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1186a377-483e-4fd2-9a9a-35e09d33722c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

