### PR TITLE
Fix toast promise

### DIFF
--- a/packages/frosted-ui/src/components/toast/toast-manager.test.ts
+++ b/packages/frosted-ui/src/components/toast/toast-manager.test.ts
@@ -94,7 +94,7 @@ describe('toast.promise', () => {
       });
 
       const loadingCalls = mockManagerAdd.mock.calls.filter(
-        ([opts]: [Record<string, unknown>]) => opts.type === 'loading',
+        (args) => args[0].type === 'loading',
       );
       expect(loadingCalls).toHaveLength(0);
     });
@@ -105,7 +105,7 @@ describe('toast.promise', () => {
       });
 
       const successCalls = mockManagerAdd.mock.calls.filter(
-        ([opts]: [Record<string, unknown>]) => opts.type === 'success',
+        (args) => args[0].type === 'success',
       );
       expect(successCalls).toHaveLength(1);
       expect(successCalls[0][0]).toMatchObject({ title: 'Done!', type: 'success' });
@@ -119,7 +119,7 @@ describe('toast.promise', () => {
       });
 
       const successUpdateCalls = mockManagerUpdate.mock.calls.filter(
-        ([, opts]: [string, Record<string, unknown>]) => opts.type === 'success',
+        (args) => args[1].type === 'success',
       );
       expect(successUpdateCalls).toHaveLength(0);
 
@@ -136,7 +136,7 @@ describe('toast.promise', () => {
       ).rejects.toThrow('boom');
 
       const errorUpdateCalls = mockManagerUpdate.mock.calls.filter(
-        ([, opts]: [string, Record<string, unknown>]) => opts.type === 'error',
+        (args) => args[1].type === 'error',
       );
       expect(errorUpdateCalls).toHaveLength(0);
 
@@ -168,7 +168,7 @@ describe('toast.promise', () => {
       });
 
       const successUpdateCalls = mockManagerUpdate.mock.calls.filter(
-        ([, opts]: [string, Record<string, unknown>]) => opts.type === 'success',
+        (args) => args[1].type === 'success',
       );
       expect(successUpdateCalls).toHaveLength(0);
       expect(mockManagerClose).toHaveBeenCalled();
@@ -183,7 +183,7 @@ describe('toast.promise', () => {
       ).rejects.toThrow('boom');
 
       const errorUpdateCalls = mockManagerUpdate.mock.calls.filter(
-        ([, opts]: [string, Record<string, unknown>]) => opts.type === 'error',
+        (args) => args[1].type === 'error',
       );
       expect(errorUpdateCalls).toHaveLength(0);
       expect(mockManagerClose).toHaveBeenCalled();

--- a/packages/frosted-ui/src/components/toast/toast-manager.test.ts
+++ b/packages/frosted-ui/src/components/toast/toast-manager.test.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let mockManagerAdd: ReturnType<typeof vi.fn>;
+let mockManagerUpdate: ReturnType<typeof vi.fn>;
+let mockManagerClose: ReturnType<typeof vi.fn>;
+
+vi.mock('@base-ui/react/toast', () => {
+  let idCounter = 0;
+  return {
+    Toast: {
+      createToastManager: () => {
+        mockManagerAdd = vi.fn((opts) => {
+          const id = opts?.id ?? `toast-${++idCounter}`;
+          return id;
+        });
+        mockManagerUpdate = vi.fn();
+        mockManagerClose = vi.fn();
+        return { add: mockManagerAdd, update: mockManagerUpdate, close: mockManagerClose };
+      },
+    },
+  };
+});
+
+let toast: typeof import('./toast-manager').toast;
+
+beforeEach(async () => {
+  vi.resetModules();
+
+  let idCounter = 0;
+  mockManagerAdd = vi.fn((opts) => {
+    const id = opts?.id ?? `toast-${++idCounter}`;
+    return id;
+  });
+  mockManagerUpdate = vi.fn();
+  mockManagerClose = vi.fn();
+
+  vi.doMock('@base-ui/react/toast', () => ({
+    Toast: {
+      createToastManager: () => ({
+        add: mockManagerAdd,
+        update: mockManagerUpdate,
+        close: mockManagerClose,
+      }),
+    },
+  }));
+
+  const mod = await import('./toast-manager');
+  toast = mod.toast;
+});
+
+describe('toast.promise', () => {
+  describe('with all options defined', () => {
+    it('creates a loading toast, then updates to success', async () => {
+      const result = await toast.promise(Promise.resolve('data'), {
+        loading: 'Loading...',
+        success: 'Done!',
+        error: 'Failed',
+      });
+
+      expect(result).toBe('data');
+      expect(mockManagerAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Loading...', type: 'loading' }),
+      );
+      expect(mockManagerUpdate).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ title: 'Done!', type: 'success' }),
+      );
+    });
+
+    it('creates a loading toast, then updates to error on rejection', async () => {
+      const err = new Error('boom');
+      await expect(
+        toast.promise(Promise.reject(err), {
+          loading: 'Loading...',
+          success: 'Done!',
+          error: 'Failed',
+        }),
+      ).rejects.toThrow('boom');
+
+      expect(mockManagerAdd).toHaveBeenCalledWith(
+        expect.objectContaining({ title: 'Loading...', type: 'loading' }),
+      );
+      expect(mockManagerUpdate).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ title: 'Failed', type: 'error' }),
+      );
+    });
+  });
+
+  describe('with loading undefined', () => {
+    it('does not create a loading toast when loading is undefined', async () => {
+      await toast.promise(Promise.resolve('data'), {
+        success: 'Done!',
+      });
+
+      const loadingCalls = mockManagerAdd.mock.calls.filter(
+        ([opts]: [Record<string, unknown>]) => opts.type === 'loading',
+      );
+      expect(loadingCalls).toHaveLength(0);
+    });
+
+    it('still creates a success toast when loading is undefined', async () => {
+      await toast.promise(Promise.resolve('data'), {
+        success: 'Done!',
+      });
+
+      const successCalls = mockManagerAdd.mock.calls.filter(
+        ([opts]: [Record<string, unknown>]) => opts.type === 'success',
+      );
+      expect(successCalls).toHaveLength(1);
+      expect(successCalls[0][0]).toMatchObject({ title: 'Done!', type: 'success' });
+    });
+  });
+
+  describe('with success undefined', () => {
+    it('dismisses the loading toast instead of showing an empty success toast', async () => {
+      await toast.promise(Promise.resolve('data'), {
+        loading: 'Loading...',
+      });
+
+      const successUpdateCalls = mockManagerUpdate.mock.calls.filter(
+        ([, opts]: [string, Record<string, unknown>]) => opts.type === 'success',
+      );
+      expect(successUpdateCalls).toHaveLength(0);
+
+      expect(mockManagerClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('with error undefined', () => {
+    it('dismisses the loading toast instead of showing an empty error toast', async () => {
+      await expect(
+        toast.promise(Promise.reject(new Error('boom')), {
+          loading: 'Loading...',
+        }),
+      ).rejects.toThrow('boom');
+
+      const errorUpdateCalls = mockManagerUpdate.mock.calls.filter(
+        ([, opts]: [string, Record<string, unknown>]) => opts.type === 'error',
+      );
+      expect(errorUpdateCalls).toHaveLength(0);
+
+      expect(mockManagerClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('with all options undefined', () => {
+    it('does not create or update any toasts', async () => {
+      await toast.promise(Promise.resolve('data'), {});
+
+      expect(mockManagerAdd).not.toHaveBeenCalled();
+      expect(mockManagerUpdate).not.toHaveBeenCalled();
+    });
+
+    it('does not create or update any toasts on rejection', async () => {
+      await expect(toast.promise(Promise.reject(new Error('boom')), {})).rejects.toThrow('boom');
+
+      expect(mockManagerAdd).not.toHaveBeenCalled();
+      expect(mockManagerUpdate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with function options', () => {
+    it('evaluates the success function and skips toast when it returns undefined', async () => {
+      await toast.promise(Promise.resolve('data'), {
+        loading: 'Loading...',
+        success: () => undefined as unknown as string,
+      });
+
+      const successUpdateCalls = mockManagerUpdate.mock.calls.filter(
+        ([, opts]: [string, Record<string, unknown>]) => opts.type === 'success',
+      );
+      expect(successUpdateCalls).toHaveLength(0);
+      expect(mockManagerClose).toHaveBeenCalled();
+    });
+
+    it('evaluates the error function and skips toast when it returns undefined', async () => {
+      await expect(
+        toast.promise(Promise.reject(new Error('boom')), {
+          loading: 'Loading...',
+          error: () => undefined as unknown as string,
+        }),
+      ).rejects.toThrow('boom');
+
+      const errorUpdateCalls = mockManagerUpdate.mock.calls.filter(
+        ([, opts]: [string, Record<string, unknown>]) => opts.type === 'error',
+      );
+      expect(errorUpdateCalls).toHaveLength(0);
+      expect(mockManagerClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('finally callback', () => {
+    it('calls finally regardless of outcome', async () => {
+      const finallyCb = vi.fn();
+      await toast.promise(Promise.resolve('data'), {
+        loading: 'Loading...',
+        success: 'Done!',
+        finally: finallyCb,
+      });
+      expect(finallyCb).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/frosted-ui/src/components/toast/toast-manager.test.ts
+++ b/packages/frosted-ui/src/components/toast/toast-manager.test.ts
@@ -1,3 +1,4 @@
+import type * as React from 'react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 let mockManagerAdd: ReturnType<typeof vi.fn>;
@@ -110,6 +111,25 @@ describe('toast.promise', () => {
       expect(successCalls).toHaveLength(1);
       expect(successCalls[0][0]).toMatchObject({ title: 'Done!', type: 'success' });
     });
+
+    it('creates an error toast directly when loading is undefined and promise rejects', async () => {
+      await expect(
+        toast.promise(Promise.reject(new Error('boom')), {
+          error: 'Failed',
+        }),
+      ).rejects.toThrow('boom');
+
+      const loadingCalls = mockManagerAdd.mock.calls.filter(
+        (args) => args[0].type === 'loading',
+      );
+      expect(loadingCalls).toHaveLength(0);
+
+      const errorCalls = mockManagerAdd.mock.calls.filter(
+        (args) => args[0].type === 'error',
+      );
+      expect(errorCalls).toHaveLength(1);
+      expect(errorCalls[0][0]).toMatchObject({ title: 'Failed', type: 'error' });
+    });
   });
 
   describe('with success undefined', () => {
@@ -158,9 +178,26 @@ describe('toast.promise', () => {
       expect(mockManagerAdd).not.toHaveBeenCalled();
       expect(mockManagerUpdate).not.toHaveBeenCalled();
     });
+
+    it('returns the resolved value even when no toasts are shown', async () => {
+      const result = await toast.promise(Promise.resolve('data'), {});
+      expect(result).toBe('data');
+    });
   });
 
   describe('with function options', () => {
+    it('does not create a loading toast when loading function returns undefined', async () => {
+      await toast.promise(Promise.resolve('data'), {
+        loading: () => undefined as unknown as React.ReactNode,
+        success: 'Done!',
+      });
+
+      const loadingCalls = mockManagerAdd.mock.calls.filter(
+        (args) => args[0].type === 'loading',
+      );
+      expect(loadingCalls).toHaveLength(0);
+    });
+
     it('evaluates the success function and skips toast when it returns undefined', async () => {
       await toast.promise(Promise.resolve('data'), {
         loading: 'Loading...',

--- a/packages/frosted-ui/src/components/toast/toast-manager.ts
+++ b/packages/frosted-ui/src/components/toast/toast-manager.ts
@@ -284,23 +284,32 @@ function info(title: React.ReactNode, options?: ToastOptions) {
 
 function promise<T>(promiseOrFn: Promise<T> | (() => Promise<T>), options: ToastPromiseOptions<T>) {
   const pos = options.position ?? _defaultPosition;
-  const loadingTitle = typeof options.loading === 'function' ? options.loading() : options.loading;
-  const id = loading(loadingTitle as React.ReactNode, { position: pos });
+
+  let id: string | undefined;
+  if (options.loading !== undefined) {
+    const loadingTitle = typeof options.loading === 'function' ? options.loading() : options.loading;
+    id = loading(loadingTitle as React.ReactNode, { position: pos });
+  }
 
   const promiseValue = typeof promiseOrFn === 'function' ? promiseOrFn() : promiseOrFn;
 
-  // Route through our own addOrUpdate so the success/error phase uses our
-  // interaction-aware scheduledDismissals instead of Base UI's internal
-  // timer system (which has a FocusGuard-related resume bug).
   const handled = promiseValue.then(
     (data) => {
       const title = typeof options.success === 'function' ? options.success(data) : options.success;
-      success(title as React.ReactNode, { id, position: pos });
+      if (title !== undefined) {
+        success(title as React.ReactNode, { ...(id ? { id } : {}), position: pos });
+      } else if (id) {
+        dismiss(id);
+      }
       return data;
     },
     (err) => {
       const title = typeof options.error === 'function' ? options.error(err) : options.error;
-      error(title as React.ReactNode, { id, position: pos });
+      if (title !== undefined) {
+        error(title as React.ReactNode, { ...(id ? { id } : {}), position: pos });
+      } else if (id) {
+        dismiss(id);
+      }
       return Promise.reject(err);
     },
   );

--- a/packages/frosted-ui/src/components/toast/toast-manager.ts
+++ b/packages/frosted-ui/src/components/toast/toast-manager.ts
@@ -288,7 +288,9 @@ function promise<T>(promiseOrFn: Promise<T> | (() => Promise<T>), options: Toast
   let id: string | undefined;
   if (options.loading !== undefined) {
     const loadingTitle = typeof options.loading === 'function' ? options.loading() : options.loading;
-    id = loading(loadingTitle as React.ReactNode, { position: pos });
+    if (loadingTitle !== undefined) {
+      id = loading(loadingTitle as React.ReactNode, { position: pos });
+    }
   }
 
   const promiseValue = typeof promiseOrFn === 'function' ? promiseOrFn() : promiseOrFn;

--- a/packages/frosted-ui/src/components/toast/toast.stories.tsx
+++ b/packages/frosted-ui/src/components/toast/toast.stories.tsx
@@ -137,6 +137,99 @@ export const PromiseError: Story = {
   ),
 };
 
+export const PromiseConditional: Story = {
+  name: 'Promise — Conditional Toasts',
+  render: () => {
+    const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)' }}>
+        <div style={{ maxWidth: 480 }}>
+          <Text size="2" color="gray">
+            <Code size="1">toast.promise</Code> conditionally skips toast creation when an option is{' '}
+            <Code size="1">undefined</Code>. If <Code size="1">loading</Code> is undefined, no loading spinner appears.
+            If <Code size="1">success</Code> or <Code size="1">error</Code> is undefined, the loading toast (if any) is
+            dismissed silently. This matches sonner&apos;s behavior.
+          </Text>
+        </div>
+        <div style={{ display: 'flex', gap: 'var(--space-3)', flexWrap: 'wrap' }}>
+          <Button
+            onClick={() =>
+              toast.promise(delay(2000).then(() => 'done'), {
+                loading: 'Saving...',
+                success: 'Saved!',
+                error: 'Failed to save',
+              })
+            }
+          >
+            All options defined
+          </Button>
+
+          <Button
+            onClick={() =>
+              toast.promise(delay(2000).then(() => 'done'), {
+                loading: 'Working...',
+                success: undefined,
+              })
+            }
+          >
+            No success toast
+          </Button>
+
+          <Button
+            onClick={() =>
+              toast.promise(
+                delay(2000).then(() => {
+                  throw new Error('oops');
+                }),
+                {
+                  loading: 'Submitting...',
+                  error: undefined,
+                },
+              )
+            }
+          >
+            No error toast
+          </Button>
+
+          <Button
+            onClick={() =>
+              toast.promise(delay(1500).then(() => 'done'), {
+                success: 'Background task complete!',
+              })
+            }
+          >
+            No loading, only success
+          </Button>
+
+          <Button
+            onClick={() =>
+              toast.promise(
+                delay(1500).then(() => {
+                  throw new Error('fail');
+                }),
+                {
+                  error: 'Background task failed',
+                },
+              )
+            }
+          >
+            No loading, only error
+          </Button>
+
+          <Button
+            onClick={() =>
+              toast.promise(delay(1000).then(() => 'silent'), {})
+            }
+          >
+            All undefined (silent)
+          </Button>
+        </div>
+      </div>
+    );
+  },
+};
+
 export const LoadingReplace: Story = {
   name: 'Loading → Replace',
   render: () => {


### PR DESCRIPTION
## fix(toast): skip empty toasts when `toast.promise` options are undefined

### Problem

`toast.promise` unconditionally created and updated toasts for every phase (loading, success, error), even when the corresponding option was `undefined`. This resulted in toasts with an icon (spinner/checkmark/error) but no title text — effectively empty, meaningless toasts.

This is a regression from [sonner's behavior](https://github.com/emilkowalski/sonner/blob/main/src/state.ts), which many call sites depend on. Sonner's `toast.promise` conditionally skips toast creation when options are undefined:

- `loading: undefined` → no loading toast is created
- `success: undefined` → the loading toast is dismissed (no success toast shown)
- `error: undefined` → the loading toast is dismissed (no error toast shown)

### Impact

Every consumer of `toast.promise` (and wrappers like `withToastPromise`) that relies on the "no message = no toast" convention was showing empty toasts. Common patterns affected:

```ts
// "Fire-and-forget" — only show error if it fails
toast.promise(saveDraft(), { error: 'Failed to save draft' });

// Only care about the loading phase
toast.promise(syncData(), { loading: 'Syncing...' });
```

### Fix

Changed the `promise` function in `toast-manager.ts` to conditionally handle each phase:

| Phase | Before | After |
|-------|--------|-------|
| **Loading** | Always created a loading toast | Only created if `loading` option resolves to a non-`undefined` value |
| **Success** | Always updated/created a success toast | If title is `undefined`: dismisses the loading toast (if one exists), otherwise does nothing |
| **Error** | Always updated/created an error toast | Same pattern as success |
| **No loading + defined success/error** | N/A (always had loading) | Creates a new success/error toast via `add` (not `update`) since there's no existing toast to update |

When all options are `undefined`, no toast is created at any phase and the promise return value is preserved.

### Files changed

| File | Change |
|------|--------|
| `toast-manager.ts` | Conditional logic in the `promise` function (+18 −7) |
| `toast-manager.test.ts` | **New** — 14 unit tests covering all combinations (all defined, loading undefined, success undefined, error undefined, all undefined, function options returning undefined, return value preservation, finally callback) |
| `toast.stories.tsx` | New **"Promise — Conditional Toasts"** story with 6 interactive buttons demonstrating each scenario |

### Test plan

- [x] All 14 new unit tests pass (`pnpm --filter=frosted-ui test`)
- [x] Existing test suite (103 tests) still passes — no regressions
- [x] No TypeScript errors, no lint errors
- [x] Verify in Storybook: open **Components / Toast / Promise — Conditional Toasts**
  - "All options defined" → loading spinner → success toast
  - "No success toast" → loading spinner → silently dismissed
  - "No error toast" → loading spinner → silently dismissed on failure
  - "No loading, only success" → no spinner, success toast after delay
  - "No loading, only error" → no spinner, error toast after delay
  - "All undefined (silent)" → no visible toast at all
- [ ] Smoke-test existing `toast.promise` call sites in the app to confirm no behavior change when all three options are provided
