### PR TITLE
fix(avatar): image and fallback squished issue

### DIFF
--- a/packages/frosted-ui/src/components/avatar/avatar.css
+++ b/packages/frosted-ui/src/components/avatar/avatar.css
@@ -1,8 +1,7 @@
 .fui-AvatarRoot {
   container-type: inline-size;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  display: inline-grid;
+  place-items: center;
   vertical-align: middle;
   user-select: none;
   width: var(--avatar-size);
@@ -31,6 +30,7 @@
 }
 
 .fui-AvatarImage {
+  grid-area: 1 / 1;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -43,6 +43,7 @@
 }
 
 .fui-AvatarFallback {
+  grid-area: 1 / 1;
   z-index: 0;
   width: 100%;
   height: 100%;

--- a/packages/frosted-ui/src/components/avatar/avatar.css
+++ b/packages/frosted-ui/src/components/avatar/avatar.css
@@ -1,6 +1,7 @@
 .fui-AvatarRoot {
   container-type: inline-size;
   display: inline-grid;
+  grid-template: 1fr / 1fr;
   place-items: center;
   vertical-align: middle;
   user-select: none;
@@ -31,6 +32,7 @@
 
 .fui-AvatarImage {
   grid-area: 1 / 1;
+  aspect-ratio: 1;
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -44,6 +46,7 @@
 
 .fui-AvatarFallback {
   grid-area: 1 / 1;
+  aspect-ratio: 1;
   z-index: 0;
   width: 100%;
   height: 100%;

--- a/packages/frosted-ui/src/components/avatar/avatar.css
+++ b/packages/frosted-ui/src/components/avatar/avatar.css
@@ -1,7 +1,6 @@
 .fui-AvatarRoot {
   container-type: inline-size;
   display: inline-grid;
-  grid-template: 1fr / 1fr;
   place-items: center;
   vertical-align: middle;
   user-select: none;
@@ -35,6 +34,7 @@
   aspect-ratio: 1;
   width: 100%;
   height: 100%;
+
   object-fit: cover;
   border-radius: inherit;
   /* Fix safari issue where animated avatars were blurred */
@@ -50,6 +50,7 @@
   z-index: 0;
   width: 100%;
   height: 100%;
+
   overflow: hidden;
   display: flex;
   align-items: center;


### PR DESCRIPTION
There's an issue where sometimes for a brief moment both the avatar fallback and avatar image elements are displayed at the same time. Since AvatarRoot is display flex, both elements get squished:

<img width="105" height="90" alt="Screenshot 2026-03-19 at 13 26 44" src="https://github.com/user-attachments/assets/18003d43-630a-4b50-8c78-48d45113c4c3" />

To fix this, make the Root `inline-grid` and place both elements on top of each other
