### PR TITLE
ci(icons): fix max buffer causing failed npm release

### DIFF
--- a/packages/frosted-ui-icons/package.json
+++ b/packages/frosted-ui-icons/package.json
@@ -53,7 +53,6 @@
     "build:js": "pnpm build:js:cjs && pnpm build:js:esm",
     "build:js:cjs": "tsc --project tsconfig-cjs.json",
     "build:js:esm": "tsc --project tsconfig-esm.json",
-    "prepublishOnly": "pnpm run build",
     "release": "turbo-module publish"
   },
   "peerDependencies": {


### PR DESCRIPTION
Summary

The @frosted-ui/icons package was failing to publish during canary releases due to a ERR_CHILD_PROCESS_STDIO_MAXBUFFER error

The prepublishOnly: "pnpm run build" script triggered a redundant rebuild during npm publish (turbo already runs build before release), and the ~15,000 dist files generated npm notice output that exceeded Node.js's child process stderr buffer limit

Removed prepublishOnly from the icons package — the turbo pipeline ("release": { "dependsOn": ["build"] }) already guarantees a fresh build before publish
