### PR TITLE
ci(release): ensure sync step runs even when release fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,7 @@ jobs:
         if: steps.check.outputs.can-publish == 'true'
 
       - name: Sync auto-release PRs
+        if: always()
         uses: whopio/turbo-module@v0.1.0-canary.3
         with:
           action: sync


### PR DESCRIPTION
## Summary

- The `Sync auto-release PRs` step in the release workflow was being skipped whenever the `Run turbo release flow` step failed, because GitHub Actions skips subsequent steps by default on failure
- This caused a deadlock: after the canary.130 release partially failed (colors published, icons didn't), every re-run fails because colors can't be re-published, and the sync step never runs to create a new canary PR at version 131
- Added `if: always()` to the sync step so it runs regardless of whether the release step succeeded or failed

## Context

This is the second part of the icons release fix (first was PR #517 removing `prepublishOnly`). Once merged, the push to main will trigger the release workflow. The release step will fail again (canary.130 partially published), but now the sync step will actually run and create the next canary release PR at version canary.131.

## Test plan

- [ ] Merge and verify the sync step runs in the release workflow (even if release step fails)
- [ ] Verify a new `(turbo-module): release next canary version` PR is created
- [ ] Merge the canary PR and verify all packages publish successfully