### PR TITLE
(turbo-module): release next canary version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-module-monorepo",
-  "version": "0.0.1-canary.131",
+  "version": "0.0.1-canary.132",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
### General Changes

- chore(icons): sync icons from Figma (#497)
- ci(icons): fix max buffer causing failed npm release (#517)
- ci(release): ensure sync step runs even when release fails (#518)

### Credits
@arturbien