### PR TITLE
feat(hover-card): add support for handles

### DIFF
--- a/packages/frosted-ui/src/components/hover-card/hover-card.stories.tsx
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.stories.tsx
@@ -15,6 +15,7 @@ import {
   hoverCardContentPropDefs,
 } from '..';
 
+
 // More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
   title: 'Components/HoverCard',
@@ -932,6 +933,109 @@ export const DisableAnchorTracking: Story = {
           Click the button above to move the anchor elements. The left hover card will follow, while the right one stays
           fixed at its original position.
         </Text>
+      </div>
+    );
+  },
+};
+
+interface UserPayload {
+  name: string;
+  username: string;
+  avatar: string;
+  bio: string;
+  repos: number;
+  followers: number;
+}
+
+const users: Record<string, UserPayload> = {
+  whop: {
+    name: 'Whop',
+    username: '@whopio',
+    avatar: 'https://avatars.githubusercontent.com/u/91078276?s=200&v=4',
+    bio: 'Build, sell, and engage with software products.',
+    repos: 127,
+    followers: 1200,
+  },
+  vercel: {
+    name: 'Vercel',
+    username: '@vercel',
+    avatar: 'https://avatars.githubusercontent.com/u/14985020?s=200&v=4',
+    bio: 'Develop. Preview. Ship. Creators of Next.js.',
+    repos: 154,
+    followers: 8500,
+  },
+  baseui: {
+    name: 'Base UI',
+    username: '@base-ui-components',
+    avatar: 'https://avatars.githubusercontent.com/u/195592562?s=200&v=4',
+    bio: 'Unstyled UI components for building accessible web apps and design systems.',
+    repos: 1,
+    followers: 430,
+  },
+};
+
+export const MultipleTriggers: Story = {
+  name: 'Multiple Triggers',
+  args: {
+    size: '2',
+    variant: 'translucent',
+  },
+  render: function MultipleTriggersDemo(args) {
+    const handle = React.useMemo(() => HoverCard.createHandle<UserPayload>(), []);
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-4)', maxWidth: 500 }}>
+        <Text>
+          A single hover card can be opened by multiple triggers using <Code>HoverCard.createHandle()</Code>. Each
+          trigger can pass a unique <Code>payload</Code> to render different content in the same card.
+        </Text>
+
+        <Text>
+          Check out{' '}
+          <HoverCard.Trigger handle={handle} payload={users.whop}>
+            <Link href="https://github.com/whopio">Whop</Link>
+          </HoverCard.Trigger>
+          ,{' '}
+          <HoverCard.Trigger handle={handle} payload={users.vercel}>
+            <Link href="https://github.com/vercel">Vercel</Link>
+          </HoverCard.Trigger>
+          , or{' '}
+          <HoverCard.Trigger handle={handle} payload={users.baseui}>
+            <Link href="https://github.com/base-ui-components">Base UI</Link>
+          </HoverCard.Trigger>{' '}
+          on GitHub.
+        </Text>
+
+        <HoverCard.Root handle={handle}>
+          {({ payload }) => (
+            <HoverCard.Content {...args}>
+              {payload !== undefined && (
+                <div style={{ display: 'flex', gap: 'var(--space-4)' }}>
+                  <Avatar size="4" src={payload.avatar} fallback={payload.name[0]} shape="square" />
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-1)' }}>
+                    <Heading size="3" render={<h3 />}>
+                      {payload.name}
+                    </Heading>
+                    <Text render={<div />} size="2" color="gray">
+                      {payload.username}
+                    </Text>
+                    <Text render={<div />} size="2" style={{ marginTop: 'var(--space-2)', maxWidth: 280 }}>
+                      {payload.bio}
+                    </Text>
+                    <div style={{ display: 'flex', gap: 'var(--space-3)', marginTop: 'var(--space-2)' }}>
+                      <Text size="2" color="gray">
+                        <Strong>{payload.repos}</Strong> repos
+                      </Text>
+                      <Text size="2" color="gray">
+                        <Strong>{payload.followers.toLocaleString()}</Strong> followers
+                      </Text>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </HoverCard.Content>
+          )}
+        </HoverCard.Root>
       </div>
     );
   },

--- a/packages/frosted-ui/src/components/hover-card/hover-card.tsx
+++ b/packages/frosted-ui/src/components/hover-card/hover-card.tsx
@@ -8,25 +8,36 @@ import { hoverCardContentPropDefs } from './hover-card.props';
 
 import type { GetPropDefTypes } from '../../helpers';
 
-interface HoverCardRootProps extends Omit<
+const createHandle = PreviewCardPrimitive.createHandle;
+
+type HoverCardHandle<T = unknown> = ReturnType<typeof PreviewCardPrimitive.createHandle<T>>;
+
+interface HoverCardRootProps<T = unknown> extends Omit<
   React.ComponentProps<typeof PreviewCardPrimitive.Root>,
-  'className' | 'render'
-> {}
-const HoverCardRoot: React.FC<HoverCardRootProps> = (props) => <PreviewCardPrimitive.Root {...props} />;
+  'className' | 'render' | 'children' | 'handle'
+> {
+  children?: React.ReactNode | ((props: { payload: T | undefined }) => React.ReactNode);
+  handle?: HoverCardHandle<T>;
+}
+function HoverCardRoot<T = unknown>(props: HoverCardRootProps<T>) {
+  return <PreviewCardPrimitive.Root {...(props as React.ComponentProps<typeof PreviewCardPrimitive.Root>)} />;
+}
 HoverCardRoot.displayName = 'HoverCardRoot';
 
-interface HoverCardTriggerProps extends Omit<
+interface HoverCardTriggerProps<T = unknown> extends Omit<
   React.ComponentProps<typeof PreviewCardPrimitive.Trigger>,
-  'render' | 'className'
+  'render' | 'className' | 'handle' | 'payload'
 > {
   className?: string;
   children: React.ReactElement;
+  handle?: HoverCardHandle<T>;
+  payload?: T;
   /** How long to wait before the preview card opens. Specified in milliseconds. */
   delay?: number;
   /** How long to wait before closing the preview card. Specified in milliseconds. */
   closeDelay?: number;
 }
-const HoverCardTrigger = (props: HoverCardTriggerProps) => {
+function HoverCardTrigger<T = unknown>(props: HoverCardTriggerProps<T>) {
   const { children, delay = 200, closeDelay = 150, ...rest } = props;
   return (
     <PreviewCardPrimitive.Trigger
@@ -34,10 +45,10 @@ const HoverCardTrigger = (props: HoverCardTriggerProps) => {
       delay={delay}
       closeDelay={closeDelay}
       render={children}
-      {...rest}
+      {...(rest as React.ComponentProps<typeof PreviewCardPrimitive.Trigger>)}
     />
   );
-};
+}
 HoverCardTrigger.displayName = 'HoverCardTrigger';
 
 type PositionerProps = React.ComponentProps<typeof PreviewCardPrimitive.Positioner>;
@@ -119,9 +130,11 @@ const HoverCardContent = (props: HoverCardContentProps) => {
 };
 HoverCardContent.displayName = 'HoverCardContent';
 
-export { HoverCardContent as Content, HoverCardRoot as Root, HoverCardTrigger as Trigger };
+export { HoverCardContent as Content, createHandle, HoverCardRoot as Root, HoverCardTrigger as Trigger };
 export type {
   HoverCardContentProps as ContentProps,
+  HoverCardHandle as Handle,
   HoverCardRootProps as RootProps,
-  HoverCardTriggerProps as TriggerProps,
+  HoverCardTriggerProps as TriggerProps
 };
+


### PR DESCRIPTION
Add support for [detatched triggers](https://base-ui.com/react/components/preview-card#detached-triggers) with [payload](https://base-ui.com/react/components/preview-card#multiple-triggers) to `<HoverCard />`.