### PR TITLE
feat(scroll-gallery): scroll behavior prop - smooth or instant

### DIFF
--- a/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery-context.tsx
+++ b/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery-context.tsx
@@ -15,6 +15,13 @@ interface ScrollGalleryContextValue {
   orientation: 'horizontal' | 'vertical';
 
   /**
+   * The scroll behavior used by all programmatic scrolls (navigation,
+   * markers, controlled value changes). Reduced motion always forces
+   * `'instant'` regardless of this value.
+   */
+  scrollBehavior: ScrollBehavior;
+
+  /**
    * When true, navigation wraps around at boundaries:
    * - Previous/Next buttons don't disable and jump to the other end
    * - Marker group arrow keys wrap instead of clamping
@@ -171,5 +178,6 @@ function getScrollDistance(
  */
 const PAGE_SCROLL_FACTOR = 0.85;
 
-export { ScrollGalleryContext, useScrollGalleryContext, getScrollBehavior, getScrollDistance, getSnapAlignment, PAGE_SCROLL_FACTOR };
-export type { ScrollGalleryContextValue, ChangeSource };
+export { getScrollBehavior, getScrollDistance, getSnapAlignment, PAGE_SCROLL_FACTOR, ScrollGalleryContext, useScrollGalleryContext };
+export type { ChangeSource, ScrollGalleryContextValue };
+

--- a/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery-root.tsx
+++ b/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery-root.tsx
@@ -45,6 +45,13 @@ interface ScrollGalleryRootProps {
    * @default 'horizontal'
    */
   orientation?: 'horizontal' | 'vertical';
+  /**
+   * Controls whether programmatic scrolls (navigation, markers, controlled
+   * value changes) animate smoothly or jump instantly. Reduced motion
+   * always forces `'instant'` regardless of this value.
+   * @default 'smooth'
+   */
+  scrollBehavior?: 'smooth' | 'instant';
 }
 
 /**
@@ -70,6 +77,7 @@ const ScrollGalleryRoot = React.forwardRef<
     loop = false,
     onValueChange,
     orientation = 'horizontal',
+    scrollBehavior = 'smooth',
   } = props;
 
   const isControlled = valueProp !== undefined;
@@ -160,7 +168,7 @@ const ScrollGalleryRoot = React.forwardRef<
    */
   const scrollToItem = React.useCallback(
     (index: number, behavior?: ScrollBehavior) => {
-      behavior = behavior ?? getScrollBehavior();
+      behavior = behavior ?? getScrollBehavior(scrollBehavior);
       const viewport = viewportRef.current;
       if (!viewport) return;
 
@@ -181,7 +189,7 @@ const ScrollGalleryRoot = React.forwardRef<
 
       setActiveIndex(index, 'indicator');
     },
-    [getItemElements, orientation, setActiveIndex],
+    [getItemElements, orientation, setActiveIndex, scrollBehavior],
   );
 
   React.useImperativeHandle(forwardedRef, () => ({ scrollTo: scrollToItem }), [scrollToItem]);
@@ -209,14 +217,15 @@ const ScrollGalleryRoot = React.forwardRef<
       return;
     }
     lastScrollValueRef.current = null;
-    scrollToItem(valueProp, getScrollBehavior());
-  }, [isControlled, valueProp, scrollToItem]);
+    scrollToItem(valueProp, getScrollBehavior(scrollBehavior));
+  }, [isControlled, valueProp, scrollToItem, scrollBehavior]);
 
   const contextValue = React.useMemo<ScrollGalleryContextValue>(
     () => ({
       activeIndex,
       setActiveIndex,
       orientation,
+      scrollBehavior,
       loop,
       canScrollPrev,
       canScrollNext,
@@ -235,6 +244,7 @@ const ScrollGalleryRoot = React.forwardRef<
       activeIndex,
       setActiveIndex,
       orientation,
+      scrollBehavior,
       loop,
       canScrollPrev,
       canScrollNext,
@@ -257,3 +267,4 @@ ScrollGalleryRoot.displayName = 'ScrollGalleryRoot';
 
 export { ScrollGalleryRoot };
 export type { ScrollGalleryRootProps, ScrollGalleryRootRef };
+

--- a/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery-viewport.tsx
+++ b/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery-viewport.tsx
@@ -51,6 +51,7 @@ const ScrollGalleryViewport = React.forwardRef<
     activeIndex,
     setActiveIndex,
     orientation,
+    scrollBehavior,
     loop,
     canScrollPrev,
     canScrollNext,
@@ -488,17 +489,23 @@ const ScrollGalleryViewport = React.forwardRef<
         const pageSize = isHorizontal ? viewport.clientWidth : viewport.clientHeight;
         viewport.scrollBy({
           [isHorizontal ? 'left' : 'top']: pageDirection * pageSize * PAGE_SCROLL_FACTOR,
-          behavior: getScrollBehavior(),
+          behavior: getScrollBehavior(scrollBehavior),
         });
       }
     },
-    [activeIndex, getItemElements, loop, orientation, scrollTargetRef, scrollingRef, scrollToItem],
+    [activeIndex, getItemElements, loop, orientation, scrollBehavior, scrollTargetRef, scrollingRef, scrollToItem],
   );
 
   const state = React.useMemo<ScrollGalleryViewportState>(
     () => ({ activeIndex, orientation, canScrollPrev, canScrollNext, scrolling: isScrolling }),
     [activeIndex, orientation, canScrollPrev, canScrollNext, isScrolling],
   );
+
+  // Override CSS scroll-behavior when the prop is 'instant' so that
+  // CSS-driven scrolls (e.g. snap corrections) also jump immediately.
+  const scrollBehaviorStyle = scrollBehavior === 'instant'
+    ? { scrollBehavior: 'auto' as const }
+    : undefined;
 
   return useRender({
     render,
@@ -509,6 +516,7 @@ const ScrollGalleryViewport = React.forwardRef<
       {
         className: 'fui-ScrollGalleryViewport',
         'data-orientation': orientation,
+        style: scrollBehaviorStyle,
         onKeyDown: handleKeyDown,
       } as React.ComponentPropsWithRef<'div'>,
       elementProps as React.ComponentPropsWithRef<'div'>,
@@ -521,3 +529,4 @@ ScrollGalleryViewport.displayName = 'ScrollGalleryViewport';
 
 export { ScrollGalleryViewport };
 export type { ScrollGalleryViewportProps, ScrollGalleryViewportState };
+

--- a/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery.stories.tsx
+++ b/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery.stories.tsx
@@ -1328,6 +1328,76 @@ const testimonials = [
   },
 ];
 
+export const ScrollBehavior: Story = {
+  render: function ScrollBehaviorStory() {
+    const [behavior, setBehavior] = useState<'smooth' | 'instant'>('smooth');
+
+    return (
+      <div style={{ maxWidth: 600 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)', marginBottom: 'var(--space-4)' }}>
+          <Text size="2" weight="medium">Scroll behavior:</Text>
+          <Button
+            size="1"
+            variant={behavior === 'smooth' ? 'solid' : 'surface'}
+            onClick={() => setBehavior('smooth')}
+          >
+            Smooth
+          </Button>
+          <Button
+            size="1"
+            variant={behavior === 'instant' ? 'solid' : 'surface'}
+            onClick={() => setBehavior('instant')}
+          >
+            Instant
+          </Button>
+          <Code size="1" color="gray">{`scrollBehavior="${behavior}"`}</Code>
+        </div>
+
+        <ScrollGallery.Root scrollBehavior={behavior}>
+          <ScrollGallery.Viewport
+            style={{
+              display: 'flex',
+              gap: 'var(--space-3)',
+              overflowX: 'auto',
+              scrollSnapType: 'x mandatory',
+              scrollbarWidth: 'none',
+            }}
+          >
+            {people.map((person, i) => (
+              <ScrollGallery.Item
+                key={person.name}
+                style={{ scrollSnapAlign: 'start', flexShrink: 0, width: 200 }}
+              >
+                <Card>
+                  <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
+                    <Avatar size="3" fallback={person.initials} color={person.color} />
+                    <div>
+                      <Text render={<div />} size="2" weight="bold">{person.name}</Text>
+                      <Text render={<div />} size="1" color="gray">{person.role}</Text>
+                    </div>
+                  </div>
+                </Card>
+              </ScrollGallery.Item>
+            ))}
+          </ScrollGallery.Viewport>
+
+          <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 'var(--space-4)', marginTop: 'var(--space-3)' }}>
+            <ScrollGallery.Previous step={1} render={<IconButton variant="surface" size="1" color="gray" />}>
+              <ChevronLeft16 />
+            </ScrollGallery.Previous>
+            <ScrollGallery.ScrollMarkerGroup style={{ display: 'flex', gap: 'var(--space-1)' }}>
+              <MarkerDots count={people.length} />
+            </ScrollGallery.ScrollMarkerGroup>
+            <ScrollGallery.Next step={1} render={<IconButton variant="surface" size="1" color="gray" />}>
+              <ChevronRight16 />
+            </ScrollGallery.Next>
+          </div>
+        </ScrollGallery.Root>
+      </div>
+    );
+  },
+};
+
 export const Testimonials: Story = {
   render: () => (
     <div style={{ maxWidth: 800 }}>

--- a/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery.stories.tsx
+++ b/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery.stories.tsx
@@ -1363,7 +1363,7 @@ export const ScrollBehavior: Story = {
               scrollbarWidth: 'none',
             }}
           >
-            {people.map((person, i) => (
+            {people.map((person) => (
               <ScrollGallery.Item
                 key={person.name}
                 style={{ scrollSnapAlign: 'start', flexShrink: 0, width: 200 }}

--- a/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery.test.tsx
+++ b/packages/frosted-ui/src/components/scroll-gallery/scroll-gallery.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import * as React from 'react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ScrollGalleryItem } from './scroll-gallery-item';
 import { ScrollGalleryNext } from './scroll-gallery-next';
@@ -84,6 +84,7 @@ function Gallery({
   defaultValue = 0,
   loop = false,
   orientation = 'horizontal',
+  scrollBehavior,
   withMarkers = false,
   step,
 }: {
@@ -91,11 +92,12 @@ function Gallery({
   defaultValue?: number;
   loop?: boolean;
   orientation?: 'horizontal' | 'vertical';
+  scrollBehavior?: 'smooth' | 'instant';
   withMarkers?: boolean;
   step?: number;
 } = {}) {
   return (
-    <ScrollGalleryRoot defaultValue={defaultValue} loop={loop} orientation={orientation}>
+    <ScrollGalleryRoot defaultValue={defaultValue} loop={loop} orientation={orientation} scrollBehavior={scrollBehavior}>
       <ScrollGalleryViewport data-testid="viewport" style={{ overflow: 'auto' }}>
         {Array.from({ length: itemCount }, (_, i) => (
           <ScrollGalleryItem key={i} data-testid={`item-${i}`}>
@@ -2079,6 +2081,145 @@ describe('ScrollGallery', () => {
       expect(onValueChange).toHaveBeenCalled();
       // Without rerender with new value, active marker stays at 0 (controlled)
       expect(screen.getByTestId('marker-0')).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('scrollBehavior prop', () => {
+    it('defaults to smooth behavior for scroll button clicks', () => {
+      render(<Gallery />);
+      const viewport = screen.getByTestId('viewport');
+      mockViewportScroll(viewport, { scrollLeft: 0, scrollWidth: 1000, clientWidth: 400 });
+      const scrollBySpy = vi.fn();
+      viewport.scrollBy = scrollBySpy;
+
+      act(() => { fireEvent.scroll(viewport); });
+
+      fireEvent.click(screen.getByTestId('next'));
+
+      expect(scrollBySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ behavior: 'smooth' }),
+      );
+    });
+
+    it('scrollBehavior="instant" makes scroll buttons use instant behavior', () => {
+      render(<Gallery scrollBehavior="instant" />);
+      const viewport = screen.getByTestId('viewport');
+      mockViewportScroll(viewport, { scrollLeft: 0, scrollWidth: 1000, clientWidth: 400 });
+      const scrollBySpy = vi.fn();
+      viewport.scrollBy = scrollBySpy;
+
+      act(() => { fireEvent.scroll(viewport); });
+
+      fireEvent.click(screen.getByTestId('next'));
+
+      expect(scrollBySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ behavior: 'instant' }),
+      );
+    });
+
+    it('scrollBehavior="instant" makes marker clicks use instant behavior', () => {
+      render(<Gallery scrollBehavior="instant" withMarkers />);
+      const viewport = screen.getByTestId('viewport');
+      const scrollBySpy = vi.fn();
+      viewport.scrollBy = scrollBySpy;
+
+      const viewportRect = { left: 0, top: 0, right: 400, bottom: 300, width: 400, height: 300, x: 0, y: 0, toJSON: () => ({}) };
+      vi.spyOn(viewport, 'getBoundingClientRect').mockReturnValue(viewportRect);
+      vi.spyOn(screen.getByTestId('item-3'), 'getBoundingClientRect').mockReturnValue(
+        { left: 600, top: 0, right: 800, bottom: 100, width: 200, height: 100, x: 600, y: 0, toJSON: () => ({}) },
+      );
+
+      fireEvent.click(screen.getByTestId('marker-3'));
+
+      expect(scrollBySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ behavior: 'instant' }),
+      );
+    });
+
+    it('scrollBehavior="instant" makes step buttons use instant behavior', () => {
+      render(<Gallery scrollBehavior="instant" step={1} />);
+      const viewport = screen.getByTestId('viewport');
+      mockViewportScroll(viewport, { scrollLeft: 0, scrollWidth: 1000, clientWidth: 400 });
+      const scrollBySpy = vi.fn();
+      viewport.scrollBy = scrollBySpy;
+
+      const viewportRect = { left: 0, top: 0, right: 400, bottom: 300, width: 400, height: 300, x: 0, y: 0, toJSON: () => ({}) };
+      vi.spyOn(viewport, 'getBoundingClientRect').mockReturnValue(viewportRect);
+      for (let i = 0; i < 5; i++) {
+        const item = screen.getByTestId(`item-${i}`);
+        vi.spyOn(item, 'getBoundingClientRect').mockReturnValue(
+          { left: i * 200, top: 0, right: i * 200 + 200, bottom: 100, width: 200, height: 100, x: i * 200, y: 0, toJSON: () => ({}) },
+        );
+      }
+
+      act(() => { fireEvent.scroll(viewport); });
+
+      fireEvent.click(screen.getByTestId('next'));
+
+      expect(scrollBySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ behavior: 'instant' }),
+      );
+    });
+
+    it('scrollBehavior="instant" makes PageDown use instant behavior', () => {
+      render(<Gallery scrollBehavior="instant" />);
+      const viewport = screen.getByTestId('viewport');
+      mockViewportScroll(viewport, { scrollLeft: 0, scrollWidth: 1000, clientWidth: 400 });
+      const scrollBySpy = vi.fn();
+      viewport.scrollBy = scrollBySpy;
+
+      fireEvent.keyDown(viewport, { key: 'PageDown' });
+
+      expect(scrollBySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ behavior: 'instant' }),
+      );
+    });
+
+    it('scrollBehavior="instant" sets scroll-behavior: auto on the viewport element', () => {
+      render(<Gallery scrollBehavior="instant" />);
+      const viewport = screen.getByTestId('viewport');
+      expect(viewport.style.scrollBehavior).toBe('auto');
+    });
+
+    it('default scrollBehavior does not set inline scroll-behavior on the viewport', () => {
+      render(<Gallery />);
+      const viewport = screen.getByTestId('viewport');
+      expect(viewport.style.scrollBehavior).toBe('');
+    });
+
+    it('scrollBehavior="instant" is used by imperative scrollTo', () => {
+      const ref = React.createRef<ScrollGalleryRootRef>();
+
+      render(
+        <ScrollGalleryRoot ref={ref} scrollBehavior="instant">
+          <ScrollGalleryViewport data-testid="viewport" style={{ overflow: 'auto' }}>
+            {Array.from({ length: 5 }, (_, i) => (
+              <ScrollGalleryItem key={i} data-testid={`item-${i}`}>
+                Item {i}
+              </ScrollGalleryItem>
+            ))}
+          </ScrollGalleryViewport>
+        </ScrollGalleryRoot>,
+      );
+
+      const viewport = screen.getByTestId('viewport');
+      const scrollBySpy = vi.fn();
+      viewport.scrollBy = scrollBySpy;
+
+      const viewportRect = { left: 0, top: 0, right: 400, bottom: 300, width: 400, height: 300, x: 0, y: 0, toJSON: () => ({}) };
+      vi.spyOn(viewport, 'getBoundingClientRect').mockReturnValue(viewportRect);
+      for (let i = 0; i < 5; i++) {
+        const item = screen.getByTestId(`item-${i}`);
+        vi.spyOn(item, 'getBoundingClientRect').mockReturnValue(
+          { left: i * 200, top: 0, right: i * 200 + 200, bottom: 100, width: 200, height: 100, x: i * 200, y: 0, toJSON: () => ({}) },
+        );
+      }
+
+      act(() => { ref.current?.scrollTo(3); });
+
+      expect(scrollBySpy).toHaveBeenCalledWith(
+        expect.objectContaining({ behavior: 'instant' }),
+      );
     });
   });
 });

--- a/packages/frosted-ui/src/components/scroll-gallery/use-scroll-button.ts
+++ b/packages/frosted-ui/src/components/scroll-gallery/use-scroll-button.ts
@@ -27,6 +27,7 @@ function useScrollButton({ direction, step }: UseScrollButtonOptions): UseScroll
     getItemElements,
     loop,
     orientation,
+    scrollBehavior,
     scrollingRef,
     scrollTargetRef,
     scrollToItem,
@@ -110,7 +111,7 @@ function useScrollButton({ direction, step }: UseScrollButtonOptions): UseScroll
 
       viewport.scrollBy({
         [isHorizontal ? 'left' : 'top']: distance,
-        behavior: getScrollBehavior(),
+        behavior: getScrollBehavior(scrollBehavior),
       });
     } else {
       // Page mode (default): scroll by ~85% of the viewport.
@@ -118,13 +119,14 @@ function useScrollButton({ direction, step }: UseScrollButtonOptions): UseScroll
 
       viewport.scrollBy({
         [isHorizontal ? 'left' : 'top']: sign * pageSize * PAGE_SCROLL_FACTOR,
-        behavior: getScrollBehavior(),
+        behavior: getScrollBehavior(scrollBehavior),
       });
     }
-  }, [canScroll, disabled, getItemElements, isPrev, loop, orientation, scrollingRef, scrollTargetRef, scrollToItem, sign, step, viewportRef]);
+  }, [canScroll, disabled, getItemElements, isPrev, loop, orientation, scrollBehavior, scrollingRef, scrollTargetRef, scrollToItem, sign, step, viewportRef]);
 
   return { disabled, handleClick };
 }
 
 export { useScrollButton };
 export type { UseScrollButtonOptions, UseScrollButtonReturn };
+


### PR DESCRIPTION
Adds "scrollBehavior" prop to allow instant scroll (no animation) when clicking markers or prev/next buttons