### PR TITLE
fix(ci): pin npm@10 to prevent release workflow failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN: $([ -n "$ACTIONS_ID_TOKEN_REQUEST_TOKEN" ] && echo present || echo missing)"
 
       - name: Update npm for OIDC trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@10
         if: steps.check.outputs.can-publish == 'true'
 
       - name: Clear npm auth to force OIDC


### PR DESCRIPTION
## Summary

- The release workflow for PR #540 failed because `npm install -g npm@latest` crashes on Node 22 runners with `MODULE_NOT_FOUND: Cannot find module 'promise-retry'` when upgrading to npm 11.x
- Node 22 already ships with npm 10.x which fully supports OIDC trusted publishing (added in npm 9.5.0)
- Pins to `npm@10` to avoid the broken self-upgrade path

## Context

After merging PR #540, the "Build, test, release" workflow ([run](https://github.com/whopio/frosted-ui/actions/runs/24514842367)) failed at the "Update npm for OIDC trusted publishing" step, causing all publish steps to be skipped. The canary.134 release was never published to npm.

## Next steps

After this PR merges, merge the pending canary release PR #542 to publish the new version.

## Test plan

- [ ] Verify the release workflow passes on merge to main
- [ ] Verify canary release PR #542 publishes successfully after this fix

