### PR TITLE
fix(ci): fix OIDC auth and bin permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
       - name: Install dependencies
         run: pnpm i
 
+      - name: Fix bin permissions
+        run: chmod +x node_modules/.bin/* packages/*/node_modules/.bin/* 2>/dev/null || true
+        if: steps.check.outputs.can-publish == 'true'
+
       - name: Run turbo release flow
         env:
           NPM_CONFIG_PROVENANCE: 'true'
@@ -70,8 +74,6 @@ jobs:
           TURBO_FORCE: 'true'
           TURBO_ENVIRONMENT_VARIABLES: ACTIONS_ID_TOKEN_REQUEST_URL,ACTIONS_ID_TOKEN_REQUEST_TOKEN,NPM_CONFIG_PROVENANCE,NPM_CONFIG_REGISTRY,NPM_CONFIG_ALWAYS_AUTH
           NODE_AUTH_TOKEN: ''
-          ACTIONS_ID_TOKEN_REQUEST_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}
-          ACTIONS_ID_TOKEN_REQUEST_TOKEN: ${{ env.ACTIONS_ID_TOKEN_REQUEST_TOKEN }}
         run: pnpm turbo release ${{ steps.check.outputs.filter }} --env-mode=loose
         if: steps.check.outputs.can-publish == 'true'
 


### PR DESCRIPTION
## Summary

The release workflow has been failing since late March / early April due to two layered issues. Fixing one revealed the other.

### Issue 1: `npm install -g npm@latest` crash (fixed in #544)
- `npm install -g npm@latest` on Node 22 runners fails with `MODULE_NOT_FOUND: Cannot find module 'promise-retry'` when upgrading to npm 11.x
- Already fixed by pinning to `npm@10`

### Issue 2: OIDC tokens empty → `ENEEDAUTH`
- The `env:` block sets `ACTIONS_ID_TOKEN_REQUEST_URL: ${{ env.ACTIONS_ID_TOKEN_REQUEST_URL }}` which resolves to **empty** because runner-provided env vars aren't in the workflow `env` context
- This **overrides** the actual OIDC values with empty strings, so `npm publish --provenance` fails with `ENEEDAUTH`
- **Fix**: Remove the explicit OIDC env entries. With `--env-mode=loose`, turbo already passes all process env vars through

### Issue 3: `turbo-module: Permission denied` (intermittent)
- pnpm bin shims sometimes lack execute permission on CI runners
- **Fix**: Added `chmod +x` step after `pnpm install`

## Test plan

- [ ] Verify the release workflow passes on merge to main
- [ ] Verify the subsequent canary release PR publishes successfully


Made with [Cursor](https://cursor.com)