### PR TITLE
Feat new callout

### DIFF
--- a/packages/frosted-ui/src/components/callout/callout.css
+++ b/packages/frosted-ui/src/components/callout/callout.css
@@ -4,6 +4,7 @@
   justify-content: flex-start;
   text-align: left;
   color: var(--accent-a11);
+  background-color: var(--accent-a3);
 
   &:where(.fui-high-contrast) {
     color: var(--accent-12);
@@ -47,29 +48,4 @@
     padding: var(--space-5);
     border-radius: var(--radius-6);
   }
-}
-
-/***************************************************************************************************
- *                                                                                                 *
- * VARIANTS                                                                                        *
- *                                                                                                 *
- ***************************************************************************************************/
-
-/* soft */
-
-.fui-CalloutRoot:where(.fui-variant-soft) {
-  background-color: var(--accent-a3);
-}
-
-/* surface */
-
-.fui-CalloutRoot:where(.fui-variant-surface) {
-  box-shadow: inset 0 0 0 1px var(--accent-a6);
-  background-color: var(--accent-a2);
-}
-
-/* outline */
-
-.fui-CalloutRoot:where(.fui-variant-outline) {
-  box-shadow: inset 0 0 0 1px var(--accent-a7);
 }

--- a/packages/frosted-ui/src/components/callout/callout.css
+++ b/packages/frosted-ui/src/components/callout/callout.css
@@ -5,10 +5,10 @@
   text-align: left;
   color: var(--accent-a11);
   background-color: var(--accent-a3);
-  row-gap: var(--space-2);
-  column-gap: var(--space-3);
-  padding: var(--space-4);
-  border-radius: var(--radius-5);
+  row-gap: 4px;
+  column-gap: 8px;
+  padding: 12px;
+  border-radius: 12px;
 }
 
 .fui-CalloutIcon {

--- a/packages/frosted-ui/src/components/callout/callout.css
+++ b/packages/frosted-ui/src/components/callout/callout.css
@@ -9,10 +9,6 @@
   column-gap: var(--space-3);
   padding: var(--space-4);
   border-radius: var(--radius-5);
-
-  &:where(.fui-high-contrast) {
-    color: var(--accent-12);
-  }
 }
 
 .fui-CalloutIcon {

--- a/packages/frosted-ui/src/components/callout/callout.css
+++ b/packages/frosted-ui/src/components/callout/callout.css
@@ -5,6 +5,10 @@
   text-align: left;
   color: var(--accent-a11);
   background-color: var(--accent-a3);
+  row-gap: var(--space-2);
+  column-gap: var(--space-3);
+  padding: var(--space-4);
+  border-radius: var(--radius-5);
 
   &:where(.fui-high-contrast) {
     color: var(--accent-12);
@@ -21,31 +25,4 @@
 /* Anything that’s not an icon goes to the right of the icon */
 .fui-CalloutRoot > :where(:not(.fui-CalloutIcon)) {
   grid-column-start: -1;
-}
-
-/***************************************************************************************************
- *                                                                                                 *
- * SIZES                                                                                           *
- *                                                                                                 *
- ***************************************************************************************************/
-
-.fui-CalloutRoot {
-  &:where(.fui-r-size-1) {
-    row-gap: var(--space-2);
-    column-gap: var(--space-2);
-    padding: var(--space-3) var(--space-4);
-    border-radius: var(--radius-5);
-  }
-  &:where(.fui-r-size-2) {
-    row-gap: var(--space-2);
-    column-gap: var(--space-3);
-    padding: var(--space-4);
-    border-radius: var(--radius-5);
-  }
-  &:where(.fui-r-size-3) {
-    row-gap: var(--space-3);
-    column-gap: var(--space-3);
-    padding: var(--space-5);
-    border-radius: var(--radius-6);
-  }
 }

--- a/packages/frosted-ui/src/components/callout/callout.css
+++ b/packages/frosted-ui/src/components/callout/callout.css
@@ -5,7 +5,7 @@
   text-align: left;
   color: var(--accent-a11);
   background-color: var(--accent-a3);
-  row-gap: 4px;
+  row-gap: 2px;
   column-gap: 8px;
   padding: 12px;
   border-radius: 12px;
@@ -21,4 +21,104 @@
 /* Anything that’s not an icon goes to the right of the icon */
 .fui-CalloutRoot > :where(:not(.fui-CalloutIcon)) {
   grid-column-start: -1;
+}
+
+.fui-CalloutActions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+}
+
+.fui-CalloutAction {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  flex-shrink: 0;
+  user-select: none;
+  vertical-align: top;
+  cursor: pointer;
+
+  height: var(--space-6);
+  gap: 8px;
+  padding-left: 12px;
+  padding-right: 12px;
+  border-radius: 8px;
+
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-2);
+  line-height: var(--line-height-2);
+  letter-spacing: var(--letter-spacing-2);
+
+  color: var(--gray-12);
+
+  &:where([aria-busy]) {
+    position: relative;
+  }
+}
+
+/* primary - matches `soft` button styling with an added border */
+.fui-CalloutAction:where(.fui-variant-primary) {
+  border: 1px solid var(--accent-a12);
+
+  &:where(:focus-visible) {
+    outline: 2px solid var(--accent-a8);
+  }
+  @media (hover: hover) {
+    &:where(:hover) {
+      background-color: var(--accent-a4);
+    }
+  }
+
+  &:where([data-pressed]),
+  &:where([data-state='open']) {
+    background-color: var(--accent-a4);
+  }
+  &:where(:active:not([data-state='open'])) {
+    background-color: var(--accent-a5);
+  }
+
+  &:where([data-disabled]) {
+    cursor: var(--cursor-disabled);
+    color: var(--accent-a8);
+    border: 1px solid var(--accent-a6);
+    background-color: transparent;
+  }
+}
+
+/* secondary - matches `ghost` button styling */
+.fui-CalloutAction:where(.fui-variant-secondary) {
+  @media (hover: hover) {
+    &:where(:hover) {
+      background-color: var(--accent-a3);
+    }
+  }
+  &:where(:focus-visible) {
+    outline: 2px solid var(--accent-a8);
+  }
+
+  &:where([data-pressed]),
+  &:where([data-state='open']) {
+    background-color: var(--accent-a3);
+  }
+  &:where(:active:not([data-state='open'])) {
+    background-color: var(--accent-a4);
+  }
+
+  &:where([data-disabled]) {
+    cursor: var(--cursor-disabled);
+    color: var(--accent-a8);
+    background-color: transparent;
+  }
+}
+/* watcher-test-marker */
+
+.fui-CalloutTitle {
+  color: var(--gray-12);
+}
+
+.fui-CalloutDescription {
+  color: var(--accent-a12);
 }

--- a/packages/frosted-ui/src/components/callout/callout.css
+++ b/packages/frosted-ui/src/components/callout/callout.css
@@ -5,7 +5,6 @@
   text-align: left;
   color: var(--accent-a11);
   background-color: var(--accent-a3);
-  row-gap: 2px;
   column-gap: 8px;
   padding: 12px;
   border-radius: 12px;
@@ -28,7 +27,9 @@
   flex-direction: row;
   align-items: center;
   gap: 8px;
-  margin-top: 6px;
+  :where(.fui-CalloutTitle + &, .fui-CalloutDescription + &) {
+    margin-top: 8px;
+  }
 }
 
 .fui-CalloutAction {
@@ -113,7 +114,6 @@
     background-color: transparent;
   }
 }
-/* watcher-test-marker */
 
 .fui-CalloutTitle {
   color: var(--gray-12);
@@ -121,4 +121,7 @@
 
 .fui-CalloutDescription {
   color: var(--accent-a12);
+  &:where(.fui-CalloutTitle + &) {
+    margin-top: 2px;
+  }
 }

--- a/packages/frosted-ui/src/components/callout/callout.props.ts
+++ b/packages/frosted-ui/src/components/callout/callout.props.ts
@@ -1,11 +1,9 @@
-import { colorProp, highContrastProp } from '../../helpers';
+import { colorProp } from '../../helpers';
 
 const calloutRootPropDefs = {
   color: { ...colorProp, default: undefined },
-  highContrast: highContrastProp,
 } satisfies {
   color: typeof colorProp;
-  highContrast: typeof highContrastProp;
 };
 
 export { calloutRootPropDefs };

--- a/packages/frosted-ui/src/components/callout/callout.props.ts
+++ b/packages/frosted-ui/src/components/callout/callout.props.ts
@@ -2,16 +2,13 @@ import type { PropDef } from '../../helpers';
 import { colorProp, highContrastProp } from '../../helpers';
 
 const sizes = ['1', '2', '3'] as const;
-const variants = ['soft', 'surface', 'outline'] as const;
 
 const calloutRootPropDefs = {
   size: { type: 'enum', values: sizes, default: '2' },
-  variant: { type: 'enum', values: variants, default: 'soft' },
   color: { ...colorProp, default: undefined },
   highContrast: highContrastProp,
 } satisfies {
   size: PropDef<(typeof sizes)[number]>;
-  variant: PropDef<(typeof variants)[number]>;
   color: typeof colorProp;
   highContrast: typeof highContrastProp;
 };

--- a/packages/frosted-ui/src/components/callout/callout.props.ts
+++ b/packages/frosted-ui/src/components/callout/callout.props.ts
@@ -1,14 +1,9 @@
-import type { PropDef } from '../../helpers';
 import { colorProp, highContrastProp } from '../../helpers';
 
-const sizes = ['1', '2', '3'] as const;
-
 const calloutRootPropDefs = {
-  size: { type: 'enum', values: sizes, default: '2' },
   color: { ...colorProp, default: undefined },
   highContrast: highContrastProp,
 } satisfies {
-  size: PropDef<(typeof sizes)[number]>;
   color: typeof colorProp;
   highContrast: typeof highContrastProp;
 };

--- a/packages/frosted-ui/src/components/callout/callout.stories.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.stories.tsx
@@ -25,7 +25,6 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     color: calloutRootPropDefs.color.default,
-    variant: calloutRootPropDefs.variant.default,
     children: (
       <>
         You will need to upgrade to the <Link href="#">newest Frosted-UI version</Link> now.
@@ -45,7 +44,6 @@ export const Default: Story = {
 export const Size: Story = {
   args: {
     color: calloutRootPropDefs.color.default,
-    variant: calloutRootPropDefs.variant.default,
     children: (
       <>
         You will need to upgrade to the <Link href="#">newest Frosted-UI version</Link> now.
@@ -84,51 +82,9 @@ export const Size: Story = {
   ),
 };
 
-export const Variant: Story = {
-  args: {
-    color: calloutRootPropDefs.color.default,
-    children: (
-      <>
-        You will need to upgrade to the <Link href="#">newest Frosted-UI version</Link> now.
-      </>
-    ),
-  },
-  render: ({ children, ...args }: CalloutRootProps) => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
-      <Callout.Root {...args} variant="soft">
-        <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
-        </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
-      </Callout.Root>
-
-      <Callout.Root {...args} variant="surface">
-        <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
-        </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
-      </Callout.Root>
-
-      <Callout.Root {...args} variant="outline">
-        <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
-        </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
-      </Callout.Root>
-    </div>
-  ),
-};
-
 export const Color: Story = {
   args: {
     color: calloutRootPropDefs.color.default,
-    variant: calloutRootPropDefs.variant.default,
     children: (
       <>
         You will need to upgrade to the <Link href="#">newest Frosted-UI version</Link> now.
@@ -171,7 +127,6 @@ export const SemanticColor: Story = {
   name: 'Semantic color',
   args: {
     color: calloutRootPropDefs.color.default,
-    variant: calloutRootPropDefs.variant.default,
     children: (
       <>
         You will need to upgrade to the <Link href="#">newest Frosted-UI version</Link> now.
@@ -223,7 +178,6 @@ export const HighContrast: Story = {
   name: 'High Contrast',
   args: {
     color: calloutRootPropDefs.color.default,
-    variant: calloutRootPropDefs.variant.default,
     children: (
       <>
         You will need to upgrade to the <Link href="#">newest Frosted-UI version</Link> now.
@@ -232,7 +186,7 @@ export const HighContrast: Story = {
   },
   render: ({ children, ...args }: CalloutRootProps) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
-      <Callout.Root {...args} variant="soft">
+      <Callout.Root {...args}>
         <Callout.Icon>
           <Callout.Icon>
             <InfoCircle16 />
@@ -241,7 +195,7 @@ export const HighContrast: Story = {
         <Callout.Text>{children}</Callout.Text>
       </Callout.Root>
 
-      <Callout.Root {...args} variant="soft" highContrast>
+      <Callout.Root {...args} highContrast>
         <Callout.Icon>
           <Callout.Icon>
             <InfoCircle16 />

--- a/packages/frosted-ui/src/components/callout/callout.stories.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.stories.tsx
@@ -30,6 +30,10 @@ export const Default: Story = {
       <Callout.Description>
         Upgrade to Pro to keep access to analytics, webhooks, and priority support.
       </Callout.Description>
+      <Callout.Actions>
+        <Callout.Action>Upgrade to Pro</Callout.Action>
+        <Callout.Action variant="secondary">Remind me later</Callout.Action>
+      </Callout.Actions>
     </Callout.Root>
   ),
 };
@@ -43,6 +47,10 @@ export const Color: Story = {
         </Callout.Icon>
         <Callout.Title>New feature available</Callout.Title>
         <Callout.Description>You can now accept crypto payments directly from your checkout page.</Callout.Description>
+        <Callout.Actions>
+          <Callout.Action>Enable crypto payments</Callout.Action>
+          <Callout.Action variant="secondary">Learn more</Callout.Action>
+        </Callout.Actions>
       </Callout.Root>
 
       <Callout.Root {...args} color="green">
@@ -53,6 +61,10 @@ export const Color: Story = {
         <Callout.Description>
           Your $1,250.00 payout was deposited to your bank account ending in 4821.
         </Callout.Description>
+        <Callout.Actions>
+          <Callout.Action>View payout details</Callout.Action>
+          <Callout.Action variant="secondary">Dismiss</Callout.Action>
+        </Callout.Actions>
       </Callout.Root>
 
       <Callout.Root {...args} color="red">
@@ -63,6 +75,10 @@ export const Color: Story = {
         <Callout.Description>
           The card on file was declined. Update your billing details to avoid service interruption.
         </Callout.Description>
+        <Callout.Actions>
+          <Callout.Action>Update billing</Callout.Action>
+          <Callout.Action variant="secondary">Try again</Callout.Action>
+        </Callout.Actions>
       </Callout.Root>
     </div>
   ),
@@ -78,6 +94,10 @@ export const SemanticColor: Story = {
         </Callout.Icon>
         <Callout.Title>API maintenance scheduled</Callout.Title>
         <Callout.Description>Our REST API will be read-only on March 15 from 2–4 AM UTC.</Callout.Description>
+        <Callout.Actions>
+          <Callout.Action>View status page</Callout.Action>
+          <Callout.Action variant="secondary">Dismiss</Callout.Action>
+        </Callout.Actions>
       </Callout.Root>
 
       <Callout.Root {...args} color="success">
@@ -86,6 +106,10 @@ export const SemanticColor: Story = {
         </Callout.Icon>
         <Callout.Title>Store connected</Callout.Title>
         <Callout.Description>Stripe is now linked and ready to accept payments.</Callout.Description>
+        <Callout.Actions>
+          <Callout.Action>Go to dashboard</Callout.Action>
+          <Callout.Action variant="secondary">Dismiss</Callout.Action>
+        </Callout.Actions>
       </Callout.Root>
 
       <Callout.Root {...args} color="warning">
@@ -96,6 +120,10 @@ export const SemanticColor: Story = {
         <Callout.Description>
           Verify your business address by April 1 to continue receiving payouts.
         </Callout.Description>
+        <Callout.Actions>
+          <Callout.Action>Verify address</Callout.Action>
+          <Callout.Action variant="secondary">Remind me later</Callout.Action>
+        </Callout.Actions>
       </Callout.Root>
 
       <Callout.Root {...args} color="danger">
@@ -104,8 +132,107 @@ export const SemanticColor: Story = {
         </Callout.Icon>
         <Callout.Title>Account restricted</Callout.Title>
         <Callout.Description>Payouts are paused until you submit updated tax documentation.</Callout.Description>
+        <Callout.Actions>
+          <Callout.Action>Submit documents</Callout.Action>
+          <Callout.Action variant="secondary">Contact support</Callout.Action>
+        </Callout.Actions>
       </Callout.Root>
     </div>
+  ),
+};
+
+export const ActionRenderProp: Story = {
+  name: 'Action render prop',
+  render: (args: CalloutRootProps) => (
+    <>
+      <div style={{ maxWidth: 500, marginBottom: 'var(--space-4)' }}>
+        <Text>
+          Use the <Code>render</Code> prop on <Code>Callout.Action</Code> to render actions as links for navigation
+          without losing callout action styling.
+        </Text>
+      </div>
+      <Callout.Root {...args} color="info">
+        <Callout.Icon>
+          <InfoCircle16 />
+        </Callout.Icon>
+        <Callout.Title>Your trial ends in 3 days</Callout.Title>
+        <Callout.Description>
+          Upgrade to Pro to keep access to analytics, webhooks, and priority support.
+        </Callout.Description>
+        <Callout.Actions>
+          <Callout.Action render={<a href="/billing" />}>Upgrade to Pro</Callout.Action>
+          <Callout.Action variant="secondary">Remind me later</Callout.Action>
+        </Callout.Actions>
+      </Callout.Root>
+    </>
+  ),
+};
+
+export const ActionLoading: Story = {
+  name: 'Action loading',
+  render: (args: CalloutRootProps) => {
+    const [loading, setLoading] = React.useState(false);
+
+    return (
+      <>
+        <div style={{ maxWidth: 500, marginBottom: 'var(--space-4)' }}>
+          <Text>
+            Use the <Code>loading</Code> prop on <Code>Callout.Action</Code> to show a spinner and disable the action
+            while an async task is in progress.
+          </Text>
+        </div>
+        <Callout.Root {...args} color="warning">
+          <Callout.Icon>
+            <InfoCircle16 />
+          </Callout.Icon>
+          <Callout.Title>Action required</Callout.Title>
+          <Callout.Description>
+            Verify your business address by April 1 to continue receiving payouts.
+          </Callout.Description>
+          <Callout.Actions>
+            <Callout.Action
+              loading={loading}
+              onClick={() => {
+                setLoading(true);
+                setTimeout(() => setLoading(false), 2000);
+              }}
+            >
+              Verify address
+            </Callout.Action>
+            <Callout.Action variant="secondary">Remind me later</Callout.Action>
+          </Callout.Actions>
+        </Callout.Root>
+      </>
+    );
+  },
+};
+
+export const ActionDisabled: Story = {
+  name: 'Action disabled',
+  render: (args: CalloutRootProps) => (
+    <>
+      <div style={{ maxWidth: 500, marginBottom: 'var(--space-4)' }}>
+        <Text>
+          Use the <Code>disabled</Code> prop on <Code>Callout.Action</Code> to prevent interaction, for example while a
+          prerequisite step is incomplete.
+        </Text>
+      </div>
+      <Callout.Root {...args} color="info">
+        <Callout.Icon>
+          <InfoCircle16 />
+        </Callout.Icon>
+        <Callout.Title>Finish setting up your store</Callout.Title>
+        <Callout.Description>
+          Connect a payment provider before you can publish your store to customers.
+        </Callout.Description>
+        <Callout.Actions>
+          <Callout.Action disabled>Publish store</Callout.Action>
+          <Callout.Action variant="secondary" disabled>
+            Preview
+          </Callout.Action>
+        </Callout.Actions>
+      </Callout.Root>
+    </>
   ),
 };
 
@@ -132,6 +259,10 @@ export const AsAlert: Story = {
           <Callout.Description>
             You don&apos;t have permission to view this page. Contact your workspace admin for access.
           </Callout.Description>
+          <Callout.Actions>
+            <Callout.Action>Request access</Callout.Action>
+            <Callout.Action variant="secondary">Go back</Callout.Action>
+          </Callout.Actions>
         </Callout.Root>
       </div>
     </>

--- a/packages/frosted-ui/src/components/callout/callout.stories.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.stories.tsx
@@ -133,39 +133,6 @@ export const SemanticColor: Story = {
   ),
 };
 
-export const HighContrast: Story = {
-  name: 'High Contrast',
-  args: {
-    color: calloutRootPropDefs.color.default,
-    children: (
-      <>
-        You will need to upgrade to the <Link href="#">newest Frosted-UI version</Link> now.
-      </>
-    ),
-  },
-  render: ({ children, ...args }: CalloutRootProps) => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
-      <Callout.Root {...args}>
-        <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
-        </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
-      </Callout.Root>
-
-      <Callout.Root {...args} highContrast>
-        <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
-        </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
-      </Callout.Root>
-    </div>
-  ),
-};
-
 export const AsAlert: Story = {
   name: 'As Alert',
 

--- a/packages/frosted-ui/src/components/callout/callout.stories.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.stories.tsx
@@ -22,19 +22,35 @@ export const Default: Story = {
     color: calloutRootPropDefs.color.default,
   },
   render: (args: CalloutRootProps) => (
-    <Callout.Root {...args}>
-      <Callout.Icon>
-        <InfoCircle16 />
-      </Callout.Icon>
-      <Callout.Title>Your trial ends in 3 days</Callout.Title>
-      <Callout.Description>
-        Upgrade to Pro to keep access to analytics, webhooks, and priority support.
-      </Callout.Description>
-      <Callout.Actions>
-        <Callout.Action>Upgrade to Pro</Callout.Action>
-        <Callout.Action variant="secondary">Remind me later</Callout.Action>
-      </Callout.Actions>
-    </Callout.Root>
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+      <Callout.Root {...args}>
+        <Callout.Icon>
+          <InfoCircle16 />
+        </Callout.Icon>
+        <Callout.Title>Your trial ends in 3 days</Callout.Title>
+        <Callout.Description>
+          Upgrade to Pro to keep access to analytics, webhooks, and priority support.
+        </Callout.Description>
+        <Callout.Actions>
+          <Callout.Action>Upgrade to Pro</Callout.Action>
+          <Callout.Action variant="secondary">Remind me later</Callout.Action>
+        </Callout.Actions>
+      </Callout.Root>
+      <Callout.Root {...args}>
+        <Callout.Icon>
+          <InfoCircle16 />
+        </Callout.Icon>
+        <div style={{ display: 'flex', gap: 16, alignItems: 'center' }}>
+          <div>
+            <Callout.Title>2 members are waiting for approval</Callout.Title>
+            <Callout.Description>Review pending requests to give them access to your community.</Callout.Description>
+          </div>
+          <Callout.Actions>
+            <Callout.Action>Review requests</Callout.Action>
+          </Callout.Actions>
+        </div>
+      </Callout.Root>
+    </div>
   ),
 };
 

--- a/packages/frosted-ui/src/components/callout/callout.stories.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.stories.tsx
@@ -5,78 +5,64 @@ import React from 'react';
 import { Callout, Code, Link, Text, calloutRootPropDefs } from '..';
 import { RootProps as CalloutRootProps } from '../../../src/components/callout/callout';
 
-// More on how to set up stories at: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
   title: 'Components/Callout',
   component: Callout.Root,
   parameters: {
-    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/react/configure/story-layout
     layout: 'centered',
   },
-
-  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/react/writing-docs/autodocs
   tags: ['autodocs'],
 } satisfies Meta<typeof Callout.Root>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-// More on writing stories with args: https://storybook.js.org/docs/react/writing-stories/args
 export const Default: Story = {
   args: {
     color: calloutRootPropDefs.color.default,
-    children: (
-      <>
-        You will need to upgrade to the <Link href="#">newest Frosted-UI version</Link> now.
-      </>
-    ),
   },
-  render: ({ children, ...args }: CalloutRootProps) => (
+  render: (args: CalloutRootProps) => (
     <Callout.Root {...args}>
       <Callout.Icon>
         <InfoCircle16 />
       </Callout.Icon>
-      <Callout.Title>{children}</Callout.Title>
+      <Callout.Title>Your trial ends in 3 days</Callout.Title>
+      <Callout.Description>
+        Upgrade to Pro to keep access to analytics, webhooks, and priority support.
+      </Callout.Description>
     </Callout.Root>
   ),
 };
 
 export const Color: Story = {
-  args: {
-    color: calloutRootPropDefs.color.default,
-    children: (
-      <>
-        You will need to upgrade to the <Link href="#">newest Frosted-UI version</Link> now.
-      </>
-    ),
-  },
-  render: ({ children, ...args }: CalloutRootProps) => (
+  render: (args: CalloutRootProps) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
       <Callout.Root {...args} color="blue">
         <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
+          <InfoCircle16 />
         </Callout.Icon>
-        <Callout.Title>{children}</Callout.Title>
+        <Callout.Title>New feature available</Callout.Title>
+        <Callout.Description>You can now accept crypto payments directly from your checkout page.</Callout.Description>
       </Callout.Root>
 
       <Callout.Root {...args} color="green">
         <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
+          <InfoCircle16 />
         </Callout.Icon>
-        <Callout.Title>{children}</Callout.Title>
+        <Callout.Title>Payout sent</Callout.Title>
+        <Callout.Description>
+          Your $1,250.00 payout was deposited to your bank account ending in 4821.
+        </Callout.Description>
       </Callout.Root>
 
       <Callout.Root {...args} color="red">
         <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
+          <InfoCircle16 />
         </Callout.Icon>
-        <Callout.Title>{children}</Callout.Title>
+        <Callout.Title>Payment failed</Callout.Title>
+        <Callout.Description>
+          The card on file was declined. Update your billing details to avoid service interruption.
+        </Callout.Description>
       </Callout.Root>
     </div>
   ),
@@ -84,50 +70,40 @@ export const Color: Story = {
 
 export const SemanticColor: Story = {
   name: 'Semantic color',
-  args: {
-    color: calloutRootPropDefs.color.default,
-    children: (
-      <>
-        You will need to upgrade to the <Link href="#">newest Frosted-UI version</Link> now.
-      </>
-    ),
-  },
-  render: ({ children, ...args }: CalloutRootProps) => (
+  render: (args: CalloutRootProps) => (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)' }}>
       <Callout.Root {...args} color="info">
         <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
+          <InfoCircle16 />
         </Callout.Icon>
-        <Callout.Title>{children}</Callout.Title>
+        <Callout.Title>API maintenance scheduled</Callout.Title>
+        <Callout.Description>Our REST API will be read-only on March 15 from 2–4 AM UTC.</Callout.Description>
       </Callout.Root>
 
       <Callout.Root {...args} color="success">
         <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
+          <InfoCircle16 />
         </Callout.Icon>
-        <Callout.Title>{children}</Callout.Title>
+        <Callout.Title>Store connected</Callout.Title>
+        <Callout.Description>Stripe is now linked and ready to accept payments.</Callout.Description>
       </Callout.Root>
 
       <Callout.Root {...args} color="warning">
         <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
+          <InfoCircle16 />
         </Callout.Icon>
-        <Callout.Title>{children}</Callout.Title>
+        <Callout.Title>Action required</Callout.Title>
+        <Callout.Description>
+          Verify your business address by April 1 to continue receiving payouts.
+        </Callout.Description>
       </Callout.Root>
 
       <Callout.Root {...args} color="danger">
         <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
+          <InfoCircle16 />
         </Callout.Icon>
-        <Callout.Title>{children}</Callout.Title>
+        <Callout.Title>Account restricted</Callout.Title>
+        <Callout.Description>Payouts are paused until you submit updated tax documentation.</Callout.Description>
       </Callout.Root>
     </div>
   ),
@@ -151,10 +127,11 @@ export const AsAlert: Story = {
       <br />
       <div style={{ display: 'inline-block' }}>
         <Callout.Root {...args} color="red" role="alert">
-          <Callout.Icon>
-            <Callout.Icon>🚨</Callout.Icon>
-          </Callout.Icon>
-          <Callout.Title>Access denied. Please contact the network administrator to view this page.</Callout.Title>
+          <Callout.Icon>🚨</Callout.Icon>
+          <Callout.Title>Unable to load dashboard</Callout.Title>
+          <Callout.Description>
+            You don&apos;t have permission to view this page. Contact your workspace admin for access.
+          </Callout.Description>
         </Callout.Root>
       </div>
     </>

--- a/packages/frosted-ui/src/components/callout/callout.stories.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.stories.tsx
@@ -10,6 +10,13 @@ const meta = {
   component: Callout.Root,
   parameters: {
     layout: 'centered',
+    controls: { include: ['color'] },
+  },
+  argTypes: {
+    color: {
+      control: { type: 'select' },
+      options: calloutRootPropDefs.color.values,
+    },
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof Callout.Root>;
@@ -167,7 +174,7 @@ export const ActionRenderProp: Story = {
           without losing callout action styling.
         </Text>
       </div>
-      <Callout.Root {...args} color="info">
+      <Callout.Root {...args}>
         <Callout.Icon>
           <InfoCircle16 />
         </Callout.Icon>
@@ -197,7 +204,7 @@ export const ActionLoading: Story = {
             while an async task is in progress.
           </Text>
         </div>
-        <Callout.Root {...args} color="warning">
+        <Callout.Root {...args}>
           <Callout.Icon>
             <InfoCircle16 />
           </Callout.Icon>
@@ -233,7 +240,7 @@ export const ActionDisabled: Story = {
           prerequisite step is incomplete.
         </Text>
       </div>
-      <Callout.Root {...args} color="info">
+      <Callout.Root {...args}>
         <Callout.Icon>
           <InfoCircle16 />
         </Callout.Icon>
@@ -269,7 +276,7 @@ export const AsAlert: Story = {
       </div>
       <br />
       <div style={{ display: 'inline-block' }}>
-        <Callout.Root {...args} color="red" role="alert">
+        <Callout.Root {...args} role="alert">
           <Callout.Icon>🚨</Callout.Icon>
           <Callout.Title>Unable to load dashboard</Callout.Title>
           <Callout.Description>

--- a/packages/frosted-ui/src/components/callout/callout.stories.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.stories.tsx
@@ -36,7 +36,7 @@ export const Default: Story = {
       <Callout.Icon>
         <InfoCircle16 />
       </Callout.Icon>
-      <Callout.Text>{children}</Callout.Text>
+      <Callout.Title>{children}</Callout.Title>
     </Callout.Root>
   ),
 };
@@ -58,7 +58,7 @@ export const Color: Story = {
             <InfoCircle16 />
           </Callout.Icon>
         </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
+        <Callout.Title>{children}</Callout.Title>
       </Callout.Root>
 
       <Callout.Root {...args} color="green">
@@ -67,7 +67,7 @@ export const Color: Story = {
             <InfoCircle16 />
           </Callout.Icon>
         </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
+        <Callout.Title>{children}</Callout.Title>
       </Callout.Root>
 
       <Callout.Root {...args} color="red">
@@ -76,7 +76,7 @@ export const Color: Story = {
             <InfoCircle16 />
           </Callout.Icon>
         </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
+        <Callout.Title>{children}</Callout.Title>
       </Callout.Root>
     </div>
   ),
@@ -100,7 +100,7 @@ export const SemanticColor: Story = {
             <InfoCircle16 />
           </Callout.Icon>
         </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
+        <Callout.Title>{children}</Callout.Title>
       </Callout.Root>
 
       <Callout.Root {...args} color="success">
@@ -109,7 +109,7 @@ export const SemanticColor: Story = {
             <InfoCircle16 />
           </Callout.Icon>
         </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
+        <Callout.Title>{children}</Callout.Title>
       </Callout.Root>
 
       <Callout.Root {...args} color="warning">
@@ -118,7 +118,7 @@ export const SemanticColor: Story = {
             <InfoCircle16 />
           </Callout.Icon>
         </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
+        <Callout.Title>{children}</Callout.Title>
       </Callout.Root>
 
       <Callout.Root {...args} color="danger">
@@ -127,7 +127,7 @@ export const SemanticColor: Story = {
             <InfoCircle16 />
           </Callout.Icon>
         </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
+        <Callout.Title>{children}</Callout.Title>
       </Callout.Root>
     </div>
   ),
@@ -154,7 +154,7 @@ export const AsAlert: Story = {
           <Callout.Icon>
             <Callout.Icon>🚨</Callout.Icon>
           </Callout.Icon>
-          <Callout.Text>Access denied. Please contact the network administrator to view this page.</Callout.Text>
+          <Callout.Title>Access denied. Please contact the network administrator to view this page.</Callout.Title>
         </Callout.Root>
       </div>
     </>

--- a/packages/frosted-ui/src/components/callout/callout.stories.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.stories.tsx
@@ -41,47 +41,6 @@ export const Default: Story = {
   ),
 };
 
-export const Size: Story = {
-  args: {
-    color: calloutRootPropDefs.color.default,
-    children: (
-      <>
-        You will need to upgrade to the <Link href="#">newest Frosted-UI version</Link> now.
-      </>
-    ),
-  },
-  render: ({ children, ...args }: CalloutRootProps) => (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--space-3)', alignItems: 'flex-start' }}>
-      <Callout.Root {...args} size="3">
-        <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
-        </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
-      </Callout.Root>
-
-      <Callout.Root {...args} size="2">
-        <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
-        </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
-      </Callout.Root>
-
-      <Callout.Root {...args} size="1">
-        <Callout.Icon>
-          <Callout.Icon>
-            <InfoCircle16 />
-          </Callout.Icon>
-        </Callout.Icon>
-        <Callout.Text>{children}</Callout.Text>
-      </Callout.Root>
-    </div>
-  ),
-};
-
 export const Color: Story = {
   args: {
     color: calloutRootPropDefs.color.default,

--- a/packages/frosted-ui/src/components/callout/callout.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.tsx
@@ -1,9 +1,12 @@
 'use client';
 
+import { Button } from '@base-ui/react/button';
 import classNames from 'classnames';
 import * as React from 'react';
 
+import { Spinner } from '../spinner';
 import { Text, type TextProps } from '../text';
+import { VisuallyHidden } from '../visually-hidden';
 import { calloutRootPropDefs } from './callout.props';
 
 import type { GetPropDefTypes, PropsWithoutColor } from '../../helpers';
@@ -75,8 +78,93 @@ const CalloutDescription = (props: CalloutDescriptionProps) => {
 };
 CalloutDescription.displayName = 'CalloutDescription';
 
-export { CalloutDescription as Description, CalloutIcon as Icon, CalloutRoot as Root, CalloutTitle as Title };
+interface CalloutActionsProps extends PropsWithoutColor<'div'> {}
+
+const CalloutActions = (props: CalloutActionsProps) => {
+  return <div {...props} className={classNames('fui-CalloutActions', props.className)} />;
+};
+CalloutActions.displayName = 'CalloutActions';
+
+type CalloutActionVariant = 'primary' | 'secondary';
+
+type CalloutActionProps = Omit<PropsWithoutColor<typeof Button>, 'className'> &
+  Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color' | 'disabled'> & {
+    variant?: CalloutActionVariant;
+    loading?: boolean;
+    className?: string;
+  };
+
+const CalloutAction = (props: CalloutActionProps) => {
+  const {
+    children,
+    variant = 'primary',
+    loading,
+    disabled = props.loading,
+    className,
+    render,
+    ...actionProps
+  } = props;
+
+  const actionClassName = classNames('fui-reset', 'fui-CalloutAction', `fui-variant-${variant}`, className);
+
+  const content = loading ? (
+    <>
+      {/**
+       * We need a wrapper to set `visibility: hidden` to hide the button content whilst we show the `Spinner`.
+       * The button is a flex container with a `gap`, so we use `display: contents` to ensure the correct flex layout.
+       *
+       * However, `display: contents` removes the content from the accessibility tree in some browsers,
+       * so we force remove it with `aria-hidden` and re-add it in the tree with `VisuallyHidden`
+       */}
+      <span style={{ display: 'contents', visibility: 'hidden' }} aria-hidden>
+        {children}
+      </span>
+      <VisuallyHidden>{children}</VisuallyHidden>
+
+      <span
+        style={{
+          position: 'absolute',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          inset: '0',
+        }}
+      >
+        <Spinner size="2" />
+      </span>
+    </>
+  ) : (
+    children
+  );
+
+  return (
+    <Button
+      render={render}
+      {...actionProps}
+      className={actionClassName}
+      aria-busy={loading || undefined}
+      // The `data-disabled` attribute enables correct styles when doing `<Callout.Action render={<a />} disabled>`
+      data-disabled={disabled || undefined}
+      disabled={disabled}
+    >
+      {content}
+    </Button>
+  );
+};
+CalloutAction.displayName = 'CalloutAction';
+
+export {
+  CalloutAction as Action,
+  CalloutActions as Actions,
+  CalloutDescription as Description,
+  CalloutIcon as Icon,
+  CalloutRoot as Root,
+  CalloutTitle as Title,
+};
 export type {
+  CalloutActionProps as ActionProps,
+  CalloutActionsProps as ActionsProps,
+  CalloutActionVariant as ActionVariant,
   CalloutDescriptionProps as DescriptionProps,
   CalloutIconProps as IconProps,
   CalloutRootProps as RootProps,

--- a/packages/frosted-ui/src/components/callout/callout.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.tsx
@@ -20,7 +20,6 @@ const CalloutRoot = (props: CalloutRootProps) => {
     children,
     className,
     size = calloutRootPropDefs.size.default,
-    variant = calloutRootPropDefs.variant.default,
     color = calloutRootPropDefs.color.default,
     highContrast = calloutRootPropDefs.highContrast.default,
     ...rootProps
@@ -29,7 +28,7 @@ const CalloutRoot = (props: CalloutRootProps) => {
     <div
       data-accent-color={color}
       {...rootProps}
-      className={classNames('fui-CalloutRoot', className, `fui-r-size-${size}`, `fui-variant-${variant}`, {
+      className={classNames('fui-CalloutRoot', className, `fui-r-size-${size}`, {
         'fui-high-contrast': highContrast,
       })}
     >

--- a/packages/frosted-ui/src/components/callout/callout.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.tsx
@@ -3,7 +3,7 @@
 import classNames from 'classnames';
 import * as React from 'react';
 
-import { Text, textPropDefs, type TextProps } from '../text';
+import { Text, type TextProps } from '../text';
 import { calloutRootPropDefs } from './callout.props';
 
 import type { GetPropDefTypes, PropsWithoutColor } from '../../helpers';
@@ -19,7 +19,6 @@ const CalloutRoot = (props: CalloutRootProps) => {
   const {
     children,
     className,
-    size = calloutRootPropDefs.size.default,
     color = calloutRootPropDefs.color.default,
     highContrast = calloutRootPropDefs.highContrast.default,
     ...rootProps
@@ -28,13 +27,11 @@ const CalloutRoot = (props: CalloutRootProps) => {
     <div
       data-accent-color={color}
       {...rootProps}
-      className={classNames('fui-CalloutRoot', className, `fui-r-size-${size}`, {
+      className={classNames('fui-CalloutRoot', className, {
         'fui-high-contrast': highContrast,
       })}
     >
-      <CalloutContext.Provider
-        value={React.useMemo(() => ({ size, color, highContrast }), [size, color, highContrast])}
-      >
+      <CalloutContext.Provider value={React.useMemo(() => ({ color, highContrast }), [color, highContrast])}>
         {children}
       </CalloutContext.Provider>
     </div>
@@ -45,12 +42,12 @@ CalloutRoot.displayName = 'CalloutRoot';
 interface CalloutIconProps extends PropsWithoutColor<'div'> {}
 
 const CalloutIcon = (props: CalloutIconProps) => {
-  const { color, size, highContrast } = React.useContext(CalloutContext);
+  const { color, highContrast } = React.useContext(CalloutContext);
   return (
     <Text
       render={<div />}
       color={color}
-      size={getTextSize(size)}
+      size="2"
       highContrast={highContrast}
       {...props}
       className={classNames('fui-CalloutIcon', props.className)}
@@ -62,11 +59,11 @@ CalloutIcon.displayName = 'CalloutIcon';
 type CalloutTextProps = TextProps;
 
 const CalloutText = (props: CalloutTextProps) => {
-  const { color, size, highContrast } = React.useContext(CalloutContext);
+  const { color, highContrast } = React.useContext(CalloutContext);
   return (
     <Text
       render={<p />}
-      size={getTextSize(size)}
+      size="2"
       color={color}
       highContrast={highContrast}
       weight="medium"
@@ -76,17 +73,6 @@ const CalloutText = (props: CalloutTextProps) => {
   );
 };
 CalloutText.displayName = 'CalloutText';
-
-function getTextSize(size: CalloutRootOwnProps['size']): React.ComponentProps<typeof Text>['size'] {
-  if (size === undefined) return undefined;
-
-  return getNonResponsiveTextSize(size);
-}
-function getNonResponsiveTextSize(
-  size: (typeof calloutRootPropDefs.size.values)[number],
-): (typeof textPropDefs.size.values)[number] {
-  return size === '3' ? '3' : '2';
-}
 
 export { CalloutIcon as Icon, CalloutRoot as Root, CalloutText as Text };
 export type { CalloutIconProps as IconProps, CalloutRootProps as RootProps, CalloutTextProps as TextProps };

--- a/packages/frosted-ui/src/components/callout/callout.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.tsx
@@ -16,24 +16,10 @@ const CalloutContext = React.createContext<CalloutContextValue>({});
 interface CalloutRootProps extends PropsWithoutColor<'div'>, CalloutContextValue {}
 
 const CalloutRoot = (props: CalloutRootProps) => {
-  const {
-    children,
-    className,
-    color = calloutRootPropDefs.color.default,
-    highContrast = calloutRootPropDefs.highContrast.default,
-    ...rootProps
-  } = props;
+  const { children, className, color = calloutRootPropDefs.color.default, ...rootProps } = props;
   return (
-    <div
-      data-accent-color={color}
-      {...rootProps}
-      className={classNames('fui-CalloutRoot', className, {
-        'fui-high-contrast': highContrast,
-      })}
-    >
-      <CalloutContext.Provider value={React.useMemo(() => ({ color, highContrast }), [color, highContrast])}>
-        {children}
-      </CalloutContext.Provider>
+    <div data-accent-color={color} {...rootProps} className={classNames('fui-CalloutRoot', className)}>
+      <CalloutContext.Provider value={React.useMemo(() => ({ color }), [color])}>{children}</CalloutContext.Provider>
     </div>
   );
 };
@@ -42,13 +28,12 @@ CalloutRoot.displayName = 'CalloutRoot';
 interface CalloutIconProps extends PropsWithoutColor<'div'> {}
 
 const CalloutIcon = (props: CalloutIconProps) => {
-  const { color, highContrast } = React.useContext(CalloutContext);
+  const { color } = React.useContext(CalloutContext);
   return (
     <Text
       render={<div />}
       color={color}
       size="2"
-      highContrast={highContrast}
       {...props}
       className={classNames('fui-CalloutIcon', props.className)}
     />
@@ -59,13 +44,12 @@ CalloutIcon.displayName = 'CalloutIcon';
 type CalloutTextProps = TextProps;
 
 const CalloutText = (props: CalloutTextProps) => {
-  const { color, highContrast } = React.useContext(CalloutContext);
+  const { color } = React.useContext(CalloutContext);
   return (
     <Text
       render={<p />}
       size="2"
       color={color}
-      highContrast={highContrast}
       weight="medium"
       {...props}
       className={classNames('fui-CalloutText', props.className)}

--- a/packages/frosted-ui/src/components/callout/callout.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.tsx
@@ -41,9 +41,9 @@ const CalloutIcon = (props: CalloutIconProps) => {
 };
 CalloutIcon.displayName = 'CalloutIcon';
 
-type CalloutTextProps = TextProps;
+type CalloutTitleProps = TextProps;
 
-const CalloutText = (props: CalloutTextProps) => {
+const CalloutTitle = (props: CalloutTitleProps) => {
   const { color } = React.useContext(CalloutContext);
   return (
     <Text
@@ -52,11 +52,11 @@ const CalloutText = (props: CalloutTextProps) => {
       color={color}
       weight="medium"
       {...props}
-      className={classNames('fui-CalloutText', props.className)}
+      className={classNames('fui-CalloutTitle', props.className)}
     />
   );
 };
-CalloutText.displayName = 'CalloutText';
+CalloutTitle.displayName = 'CalloutTitle';
 
-export { CalloutIcon as Icon, CalloutRoot as Root, CalloutText as Text };
-export type { CalloutIconProps as IconProps, CalloutRootProps as RootProps, CalloutTextProps as TextProps };
+export { CalloutIcon as Icon, CalloutRoot as Root, CalloutTitle as Title };
+export type { CalloutIconProps as IconProps, CalloutRootProps as RootProps, CalloutTitleProps as TitleProps };

--- a/packages/frosted-ui/src/components/callout/callout.tsx
+++ b/packages/frosted-ui/src/components/callout/callout.tsx
@@ -50,7 +50,8 @@ const CalloutTitle = (props: CalloutTitleProps) => {
       render={<p />}
       size="2"
       color={color}
-      weight="medium"
+      weight="semi-bold"
+      highContrast
       {...props}
       className={classNames('fui-CalloutTitle', props.className)}
     />
@@ -58,5 +59,26 @@ const CalloutTitle = (props: CalloutTitleProps) => {
 };
 CalloutTitle.displayName = 'CalloutTitle';
 
-export { CalloutIcon as Icon, CalloutRoot as Root, CalloutTitle as Title };
-export type { CalloutIconProps as IconProps, CalloutRootProps as RootProps, CalloutTitleProps as TitleProps };
+type CalloutDescriptionProps = TextProps;
+
+const CalloutDescription = (props: CalloutDescriptionProps) => {
+  const { color } = React.useContext(CalloutContext);
+  return (
+    <Text
+      render={<p />}
+      size="2"
+      color={color}
+      {...props}
+      className={classNames('fui-CalloutDescription', props.className)}
+    />
+  );
+};
+CalloutDescription.displayName = 'CalloutDescription';
+
+export { CalloutDescription as Description, CalloutIcon as Icon, CalloutRoot as Root, CalloutTitle as Title };
+export type {
+  CalloutDescriptionProps as DescriptionProps,
+  CalloutIconProps as IconProps,
+  CalloutRootProps as RootProps,
+  CalloutTitleProps as TitleProps,
+};

--- a/packages/frosted-ui/src/components/combobox/combobox.stories.tsx
+++ b/packages/frosted-ui/src/components/combobox/combobox.stories.tsx
@@ -672,7 +672,7 @@ export const FormValidation: Story = {
           </Button>
         </Form>
         {submitted && (
-          <Callout.Root size="1" style={{ marginTop: 12 }}>
+          <Callout.Root style={{ marginTop: 12 }}>
             <Callout.Text>
               Submitted: <strong>{JSON.stringify(submitted)}</strong>
             </Callout.Text>

--- a/packages/frosted-ui/src/components/combobox/combobox.stories.tsx
+++ b/packages/frosted-ui/src/components/combobox/combobox.stories.tsx
@@ -673,9 +673,9 @@ export const FormValidation: Story = {
         </Form>
         {submitted && (
           <Callout.Root style={{ marginTop: 12 }}>
-            <Callout.Text>
+            <Callout.Title>
               Submitted: <strong>{JSON.stringify(submitted)}</strong>
-            </Callout.Text>
+            </Callout.Title>
           </Callout.Root>
         )}
       </div>

--- a/packages/frosted-ui/src/components/credit-card/credit-card.stories.tsx
+++ b/packages/frosted-ui/src/components/credit-card/credit-card.stories.tsx
@@ -624,7 +624,7 @@ export const FormIntegration: Story = {
 
         {submitted && (
           <Callout.Root color="success" style={{ marginTop: 12 }}>
-            <Callout.Text>Card saved successfully!</Callout.Text>
+            <Callout.Title>Card saved successfully!</Callout.Title>
           </Callout.Root>
         )}
 

--- a/packages/frosted-ui/src/components/credit-card/credit-card.stories.tsx
+++ b/packages/frosted-ui/src/components/credit-card/credit-card.stories.tsx
@@ -623,7 +623,7 @@ export const FormIntegration: Story = {
         </Form>
 
         {submitted && (
-          <Callout.Root color="success" size="1" style={{ marginTop: 12 }}>
+          <Callout.Root color="success" style={{ marginTop: 12 }}>
             <Callout.Text>Card saved successfully!</Callout.Text>
           </Callout.Root>
         )}

--- a/packages/frosted-ui/src/components/field/field.stories.tsx
+++ b/packages/frosted-ui/src/components/field/field.stories.tsx
@@ -352,12 +352,12 @@ export const FieldsetDisabled: Story = {
 
         {submitted && (
           <Callout.Root color="success" style={{ marginTop: 16 }}>
-            <Callout.Text>
+            <Callout.Title>
               Order submitted!
               <pre style={{ marginTop: 8, fontSize: 11, whiteSpace: 'pre-wrap' }}>
                 {JSON.stringify(submitted, null, 2)}
               </pre>
-            </Callout.Text>
+            </Callout.Title>
           </Callout.Root>
         )}
       </div>
@@ -553,7 +553,7 @@ export const WithSliderBudget: Story = {
 
         {submitted && (
           <Callout.Root color="success" style={{ marginTop: 16 }}>
-            <Callout.Text>Budget set to ${budget.toLocaleString()}/month</Callout.Text>
+            <Callout.Title>Budget set to ${budget.toLocaleString()}/month</Callout.Title>
           </Callout.Root>
         )}
       </div>
@@ -728,7 +728,7 @@ export const WithCombobox: Story = {
 
         {submitted && (
           <Callout.Root color="success" style={{ marginTop: 16 }}>
-            <Callout.Text>
+            <Callout.Title>
               Profile saved!
               <pre
                 style={{
@@ -742,7 +742,7 @@ export const WithCombobox: Story = {
               >
                 {JSON.stringify(submitted, null, 2)}
               </pre>
-            </Callout.Text>
+            </Callout.Title>
           </Callout.Root>
         )}
       </div>
@@ -1120,13 +1120,13 @@ export const CustomValidation: Story = {
               <Callout.Icon>
                 {isChecking ? <Spinner size="1" /> : isAvailable ? <Checkmark12 /> : <XMarkSmall12 />}
               </Callout.Icon>
-              <Callout.Text>
+              <Callout.Title>
                 {isChecking
                   ? 'Checking availability...'
                   : isAvailable
                     ? 'Username is available!'
                     : 'Username is already taken'}
-              </Callout.Text>
+              </Callout.Title>
             </Callout.Root>
           )}
 
@@ -1273,7 +1273,7 @@ export const FormExample: Story = {
             <Callout.Icon>
               <Checkmark12 />
             </Callout.Icon>
-            <Callout.Text>
+            <Callout.Title>
               Form submitted successfully!
               <pre
                 style={{
@@ -1287,7 +1287,7 @@ export const FormExample: Story = {
               >
                 {JSON.stringify(formData, null, 2)}
               </pre>
-            </Callout.Text>
+            </Callout.Title>
           </Callout.Root>
         )}
       </div>
@@ -1718,10 +1718,10 @@ export const AllValidityStates: Story = {
 
           {/* Submit to test all */}
           <Callout.Root color="info">
-            <Callout.Text>
+            <Callout.Title>
               Submit the form to see validation errors. Each field demonstrates a different <Code>ValidityState</Code>{' '}
               property.
-            </Callout.Text>
+            </Callout.Title>
           </Callout.Root>
 
           <Button type="submit" style={{ width: '100%' }}>

--- a/packages/frosted-ui/src/components/field/field.stories.tsx
+++ b/packages/frosted-ui/src/components/field/field.stories.tsx
@@ -351,7 +351,7 @@ export const FieldsetDisabled: Story = {
         </Form>
 
         {submitted && (
-          <Callout.Root color="success" size="1" style={{ marginTop: 16 }}>
+          <Callout.Root color="success" style={{ marginTop: 16 }}>
             <Callout.Text>
               Order submitted!
               <pre style={{ marginTop: 8, fontSize: 11, whiteSpace: 'pre-wrap' }}>
@@ -552,7 +552,7 @@ export const WithSliderBudget: Story = {
         </Form>
 
         {submitted && (
-          <Callout.Root color="success" size="1" style={{ marginTop: 16 }}>
+          <Callout.Root color="success" style={{ marginTop: 16 }}>
             <Callout.Text>Budget set to ${budget.toLocaleString()}/month</Callout.Text>
           </Callout.Root>
         )}
@@ -727,7 +727,7 @@ export const WithCombobox: Story = {
         </Form>
 
         {submitted && (
-          <Callout.Root color="success" size="1" style={{ marginTop: 16 }}>
+          <Callout.Root color="success" style={{ marginTop: 16 }}>
             <Callout.Text>
               Profile saved!
               <pre
@@ -1116,11 +1116,7 @@ export const CustomValidation: Story = {
 
           {/* Availability Status */}
           {allRulesPass && username.length >= 3 && (
-            <Callout.Root
-              size="1"
-              color={isChecking ? 'gray' : isAvailable ? 'success' : 'danger'}
-              style={{ marginTop: 12 }}
-            >
+            <Callout.Root color={isChecking ? 'gray' : isAvailable ? 'success' : 'danger'} style={{ marginTop: 12 }}>
               <Callout.Icon>
                 {isChecking ? <Spinner size="1" /> : isAvailable ? <Checkmark12 /> : <XMarkSmall12 />}
               </Callout.Icon>
@@ -1721,7 +1717,7 @@ export const AllValidityStates: Story = {
           <Separator size="4" />
 
           {/* Submit to test all */}
-          <Callout.Root color="info" size="1">
+          <Callout.Root color="info">
             <Callout.Text>
               Submit the form to see validation errors. Each field demonstrates a different <Code>ValidityState</Code>{' '}
               property.

--- a/packages/frosted-ui/src/components/form/form.stories.tsx
+++ b/packages/frosted-ui/src/components/form/form.stories.tsx
@@ -92,7 +92,7 @@ export const GettingStarted: Story = {
         </Form>
 
         {submitted && (
-          <Callout.Root color="success" size="1" style={{ marginTop: 16 }}>
+          <Callout.Root color="success" style={{ marginTop: 16 }}>
             <Callout.Text>Message sent successfully!</Callout.Text>
           </Callout.Root>
         )}
@@ -237,7 +237,7 @@ export const RequiredControls: Story = {
         </Form>
 
         {submitted && (
-          <Callout.Root color="success" size="1" style={{ marginTop: 16 }}>
+          <Callout.Root color="success" style={{ marginTop: 16 }}>
             <Callout.Text>Form submitted successfully!</Callout.Text>
           </Callout.Root>
         )}
@@ -860,7 +860,7 @@ export const DirtyStateWarning: Story = {
 
         {/* Status indicator - only show after first edit or save */}
         {(isDirty || hasSaved) && (
-          <Callout.Root color={isDirty ? 'warning' : 'success'} size="1" style={{ marginBottom: 16 }}>
+          <Callout.Root color={isDirty ? 'warning' : 'success'} style={{ marginBottom: 16 }}>
             <Callout.Icon>
               <div
                 style={{
@@ -1019,7 +1019,6 @@ export const AutoSaveForm: Story = {
         {/* Save status indicator */}
         <Callout.Root
           color={saveStatus === 'saving' ? 'info' : saveStatus === 'saved' ? 'success' : 'gray'}
-          size="1"
           style={{ marginBottom: 16 }}
         >
           <Callout.Icon>

--- a/packages/frosted-ui/src/components/form/form.stories.tsx
+++ b/packages/frosted-ui/src/components/form/form.stories.tsx
@@ -93,7 +93,7 @@ export const GettingStarted: Story = {
 
         {submitted && (
           <Callout.Root color="success" style={{ marginTop: 16 }}>
-            <Callout.Text>Message sent successfully!</Callout.Text>
+            <Callout.Title>Message sent successfully!</Callout.Title>
           </Callout.Root>
         )}
       </div>
@@ -238,7 +238,7 @@ export const RequiredControls: Story = {
 
         {submitted && (
           <Callout.Root color="success" style={{ marginTop: 16 }}>
-            <Callout.Text>Form submitted successfully!</Callout.Text>
+            <Callout.Title>Form submitted successfully!</Callout.Title>
           </Callout.Root>
         )}
       </div>
@@ -871,7 +871,7 @@ export const DirtyStateWarning: Story = {
                 }}
               />
             </Callout.Icon>
-            <Callout.Text>{isDirty ? 'Unsaved changes' : 'All changes saved'}</Callout.Text>
+            <Callout.Title>{isDirty ? 'Unsaved changes' : 'All changes saved'}</Callout.Title>
           </Callout.Root>
         )}
 
@@ -1035,12 +1035,12 @@ export const AutoSaveForm: Story = {
               />
             )}
           </Callout.Icon>
-          <Callout.Text>
+          <Callout.Title>
             {saveStatus === 'saving' && 'Saving...'}
             {saveStatus === 'saved' && 'All changes saved'}
             {saveStatus === 'idle' &&
               (lastSaved ? `Last saved ${lastSaved.toLocaleTimeString()}` : 'Start typing to auto-save')}
-          </Callout.Text>
+          </Callout.Title>
         </Callout.Root>
 
         <Form>


### PR DESCRIPTION
# Callout: simplify API and add structured content + actions

<img width="825" height="262" alt="Screenshot 2026-06-30 at 16 48 50" src="https://github.com/user-attachments/assets/9909d847-98fd-41e0-912a-ae30c48bcccc" />
<img width="825" height="262" alt="Screenshot 2026-06-30 at 16 49 29" src="https://github.com/user-attachments/assets/0f3166ae-4785-42f9-88e1-276163026a21" />

Reworks the `Callout` component into a simpler, more opinionated compound component. Drops the styling props in favor of a single soft style, introduces dedicated `Title`/`Description` parts, and adds first-class `Actions`/`Action` buttons built on the same Base UI button primitive used by the rest of the library.

## Motivation

The old `Callout` exposed `variant`, `size`, and `highContrast` knobs that were rarely used and produced inconsistent callouts across the product. In practice callouts are a single, recognizable pattern: a soft surface with an icon, a title, supporting text, and optional actions. This PR codifies that pattern and makes the common case the only case.

## Changes

### Breaking

- **Removed the `variant` prop.** Callouts always use the `soft` style.
- **Removed the `size` prop.** Callouts use the former `size="2"` styling.
- **Removed the `highContrast` prop.** Callouts use the default styling.
- **Renamed `Callout.Text` → `Callout.Title`** (and `TextProps` → `TitleProps`).

### Added

- **`Callout.Description`** — supporting text rendered below the title.
- **`Callout.Actions`** — a row container for actions. Gains a top margin only when it follows a `Title` or `Description` (flat-specificity `:where()` selector).
- **`Callout.Action`** — a button built directly on `@base-ui/react/button` (mirroring `BaseButton`), with:
  - `variant="primary" | "secondary"` (`primary` = soft button styling + border, `secondary` = ghost button styling)
  - `loading` support (spinner + `aria-busy` + disabled), matching `BaseButton`
  - `render` prop support for polymorphism (e.g. rendering an anchor)
  - correct disabled/loading interaction states (no hover styles while disabled)

### Storybook

- Stories rewritten with realistic, product-style copy.
- New stories: render prop (as link), loading, disabled, and an inline (horizontal) layout.
- Controls pane limited to `Callout.Root`'s `color`, exposed as a select dropdown.
- Only the color-showcase stories pin colors; the rest respect the `color` control.

## Migration

```diff
- <Callout.Root variant="surface" size="1" highContrast>
+ <Callout.Root>
    <Callout.Icon>
      <InfoCircle16 />
    </Callout.Icon>
-   <Callout.Text>Your trial ends in 3 days</Callout.Text>
+   <Callout.Title>Your trial ends in 3 days</Callout.Title>
+   <Callout.Description>
+     Upgrade to Pro to keep access to analytics, webhooks, and priority support.
+   </Callout.Description>
+   <Callout.Actions>
+     <Callout.Action>Upgrade to Pro</Callout.Action>
+     <Callout.Action variant="secondary">Remind me later</Callout.Action>
+   </Callout.Actions>
  </Callout.Root>
```

Consumers passing `variant`, `size`, or `highContrast` will get TypeScript errors and should drop those props. `Callout.Text` references must be renamed to `Callout.Title`.
