### PR TITLE
feat(figma-plugin): scale constraints check

### DIFF
--- a/packages/figma-icon-sync-plugin/dist/code.js
+++ b/packages/figma-icon-sync-plugin/dist/code.js
@@ -54,6 +54,15 @@
     if (visible.length !== 1) return false;
     return isShapeType(visible[0].type);
   }
+  function hasNonScaleConstraints(variant) {
+    for (const child of variant.children) {
+      if (child.visible === false) continue;
+      if (!("constraints" in child)) continue;
+      const con = child.constraints;
+      if (con.horizontal !== "SCALE" || con.vertical !== "SCALE") return true;
+    }
+    return false;
+  }
   function sizeScopedIssue(rule, name, verb, entries) {
     const sorted = [...entries].sort(
       (a, b) => (Number.isNaN(a.size) ? Infinity : a.size) - (Number.isNaN(b.size) ? Infinity : b.size)
@@ -142,12 +151,14 @@
         const sizeCounts = /* @__PURE__ */ new Map();
         const hiddenAt = [];
         const notSingleAt = [];
+        const badConstraintsAt = [];
         for (const variant of variants) {
           variantCount += 1;
           const sizeGuess = /size=(\d+)/i.exec(variant.name);
           const structSize = sizeGuess ? Number(sizeGuess[1]) : Number.NaN;
           if (hasHiddenDescendant(variant)) hiddenAt.push({ nodeId: variant.id, size: structSize });
           if (!isSingleShape(variant)) notSingleAt.push({ nodeId: variant.id, size: structSize });
+          if (hasNonScaleConstraints(variant)) badConstraintsAt.push({ nodeId: variant.id, size: structSize });
           const match = /^size=(\d+)$/i.exec(variant.name.trim());
           if (!match) {
             issues.push({
@@ -202,9 +213,10 @@
           issues.push(sizeScopedIssue("hidden-layers", name, "has hidden layers", hiddenAt));
         }
         if (notSingleAt.length > 0) {
-          issues.push(
-            sizeScopedIssue("not-single-shape", name, "isn't a single flattened shape", notSingleAt)
-          );
+          issues.push(sizeScopedIssue("not-single-shape", name, "isn't a single flattened shape", notSingleAt));
+        }
+        if (badConstraintsAt.length > 0) {
+          issues.push(sizeScopedIssue("bad-constraints", name, "isn't set to Scale", badConstraintsAt));
         }
       }
     }

--- a/packages/figma-icon-sync-plugin/dist/code.js
+++ b/packages/figma-icon-sync-plugin/dist/code.js
@@ -49,10 +49,24 @@
     }
     return false;
   }
+  function isContainerType(type) {
+    return type === "FRAME" || type === "GROUP" || type === "SECTION" || type === "COMPONENT" || type === "COMPONENT_SET" || type === "INSTANCE";
+  }
+  function hasNestedContainer(node) {
+    if (!("children" in node)) return false;
+    for (const child of node.children) {
+      if (child.visible === false) continue;
+      if (isContainerType(child.type)) return true;
+      if (hasNestedContainer(child)) return true;
+    }
+    return false;
+  }
   function isSingleShape(variant) {
     const visible = variant.children.filter((c) => c.visible !== false);
     if (visible.length !== 1) return false;
-    return isShapeType(visible[0].type);
+    if (!isShapeType(visible[0].type)) return false;
+    if (hasNestedContainer(visible[0])) return false;
+    return true;
   }
   function hasNonScaleConstraints(node) {
     for (const child of node.children) {

--- a/packages/figma-icon-sync-plugin/dist/code.js
+++ b/packages/figma-icon-sync-plugin/dist/code.js
@@ -54,12 +54,16 @@
     if (visible.length !== 1) return false;
     return isShapeType(visible[0].type);
   }
-  function hasNonScaleConstraints(variant) {
-    for (const child of variant.children) {
+  function hasNonScaleConstraints(node) {
+    for (const child of node.children) {
       if (child.visible === false) continue;
-      if (!("constraints" in child)) continue;
-      const con = child.constraints;
-      if (con.horizontal !== "SCALE" || con.vertical !== "SCALE") return true;
+      if ("constraints" in child) {
+        const con = child.constraints;
+        if (con.horizontal !== "SCALE" || con.vertical !== "SCALE") return true;
+      }
+      if ("children" in child && hasNonScaleConstraints(child)) {
+        return true;
+      }
     }
     return false;
   }

--- a/packages/figma-icon-sync-plugin/dist/ui.html
+++ b/packages/figma-icon-sync-plugin/dist/ui.html
@@ -836,8 +836,11 @@
           return;
         }
         if (!d.added.length && !d.removed.length) {
+          const since = d.comparedToVersion
+            ? '<span class="ver">v' + escapeHtml(d.comparedToVersion) + '</span>'
+            : 'the latest release';
           $('diff').innerHTML =
-            '<div class="diff-note">No icons added or removed since the last release.</div>';
+            '<div class="diff-note">No icons added or removed since ' + since + '.</div>';
           return;
         }
 

--- a/packages/figma-icon-sync-plugin/dist/ui.html
+++ b/packages/figma-icon-sync-plugin/dist/ui.html
@@ -566,6 +566,12 @@
           fail: (n) => n + ' structure issue(s)',
         },
         {
+          rules: ['bad-constraints'],
+          ok: 'Constraints set to Scale',
+          fail: (n) => n + ' icon(s) not set to Scale',
+          info: 'Each icon shape should use horizontal and vertical “Scale” constraints so it resizes correctly with its frame.',
+        },
+        {
           rules: ['orphan'],
           ok: null, // nothing to show when clean
           fail: (n) => 'Component sets outside an “Icons” frame',

--- a/packages/figma-icon-sync-plugin/src/code.ts
+++ b/packages/figma-icon-sync-plugin/src/code.ts
@@ -134,13 +134,18 @@ function isSingleShape(variant: ComponentNode): boolean {
 }
 
 // Icon shapes must use horizontal + vertical "Scale" constraints so they resize
-// with the frame. Returns true if any visible top-level layer is not Scale/Scale.
-function hasNonScaleConstraints(variant: ComponentNode): boolean {
-  for (const child of variant.children) {
+// with the frame. Checks every visible layer in the subtree (nested vectors
+// inside a boolean op / group also need Scale, not just the top-level layer).
+function hasNonScaleConstraints(node: SceneNode & ChildrenMixin): boolean {
+  for (const child of node.children) {
     if (child.visible === false) continue;
-    if (!('constraints' in child)) continue;
-    const con = (child as SceneNode & { constraints: Constraints }).constraints;
-    if (con.horizontal !== 'SCALE' || con.vertical !== 'SCALE') return true;
+    if ('constraints' in child) {
+      const con = (child as SceneNode & { constraints: Constraints }).constraints;
+      if (con.horizontal !== 'SCALE' || con.vertical !== 'SCALE') return true;
+    }
+    if ('children' in child && hasNonScaleConstraints(child as SceneNode & ChildrenMixin)) {
+      return true;
+    }
   }
   return false;
 }

--- a/packages/figma-icon-sync-plugin/src/code.ts
+++ b/packages/figma-icon-sync-plugin/src/code.ts
@@ -6,8 +6,7 @@ const ALLOWED_SIZES = [12, 16, 20, 24, 32];
 // The Actions page for the icon-sync workflow. Opening it lets a designer press
 // GitHub's own "Run workflow" button — no token needed, gated by GitHub's own
 // repo permissions.
-const SYNC_WORKFLOW_URL =
-  'https://github.com/whopio/frosted-ui/actions/workflows/sync-icons.yml';
+const SYNC_WORKFLOW_URL = 'https://github.com/whopio/frosted-ui/actions/workflows/sync-icons.yml';
 
 type Severity = 'error' | 'warning';
 
@@ -85,9 +84,7 @@ function svgDrawsFillAndStroke(svg: string): boolean {
     const strokeStyle = /(?:^|;)\s*stroke\s*:\s*([^;]+)/i.exec(styleText);
 
     const fillVal = (fillAttr ? fillAttr[1] : fillStyle ? fillStyle[1] : '').trim().toLowerCase();
-    const strokeVal = (strokeAttr ? strokeAttr[1] : strokeStyle ? strokeStyle[1] : '')
-      .trim()
-      .toLowerCase();
+    const strokeVal = (strokeAttr ? strokeAttr[1] : strokeStyle ? strokeStyle[1] : '').trim().toLowerCase();
 
     // A shape is filled only with an explicit non-"none" fill (the root <svg>
     // sets fill="none", so unset means not filled).
@@ -136,13 +133,20 @@ function isSingleShape(variant: ComponentNode): boolean {
   return isShapeType(visible[0].type);
 }
 
+// Icon shapes must use horizontal + vertical "Scale" constraints so they resize
+// with the frame. Returns true if any visible top-level layer is not Scale/Scale.
+function hasNonScaleConstraints(variant: ComponentNode): boolean {
+  for (const child of variant.children) {
+    if (child.visible === false) continue;
+    if (!('constraints' in child)) continue;
+    const con = (child as SceneNode & { constraints: Constraints }).constraints;
+    if (con.horizontal !== 'SCALE' || con.vertical !== 'SCALE') return true;
+  }
+  return false;
+}
+
 // Builds a per-icon warning whose detail pills jump to each affected size.
-function sizeScopedIssue(
-  rule: string,
-  name: string,
-  verb: string,
-  entries: { nodeId: string; size: number }[],
-): Issue {
+function sizeScopedIssue(rule: string, name: string, verb: string, entries: { nodeId: string; size: number }[]): Issue {
   const sorted = [...entries].sort(
     (a, b) => (Number.isNaN(a.size) ? Infinity : a.size) - (Number.isNaN(b.size) ? Infinity : b.size),
   );
@@ -269,6 +273,7 @@ async function scan(): Promise<{
       const sizeCounts = new Map<number, number>();
       const hiddenAt: { nodeId: string; size: number }[] = [];
       const notSingleAt: { nodeId: string; size: number }[] = [];
+      const badConstraintsAt: { nodeId: string; size: number }[] = [];
 
       for (const variant of variants) {
         variantCount += 1;
@@ -278,6 +283,7 @@ async function scan(): Promise<{
         const structSize = sizeGuess ? Number(sizeGuess[1]) : Number.NaN;
         if (hasHiddenDescendant(variant)) hiddenAt.push({ nodeId: variant.id, size: structSize });
         if (!isSingleShape(variant)) notSingleAt.push({ nodeId: variant.id, size: structSize });
+        if (hasNonScaleConstraints(variant)) badConstraintsAt.push({ nodeId: variant.id, size: structSize });
 
         // The variant name must be *exactly* `size=<number>`. An unanchored
         // match would wrongly accept mislabelled properties whose name merely
@@ -351,9 +357,13 @@ async function scan(): Promise<{
       // Rule: the icon should be a single final shape (a vector or union), not
       // multiple layers or a group/frame wrapper.
       if (notSingleAt.length > 0) {
-        issues.push(
-          sizeScopedIssue('not-single-shape', name, "isn't a single flattened shape", notSingleAt),
-        );
+        issues.push(sizeScopedIssue('not-single-shape', name, "isn't a single flattened shape", notSingleAt));
+      }
+
+      // Rule: the icon shape must use Scale/Scale constraints so it resizes with
+      // the frame.
+      if (badConstraintsAt.length > 0) {
+        issues.push(sizeScopedIssue('bad-constraints', name, "isn't set to Scale", badConstraintsAt));
       }
     }
   }
@@ -633,9 +643,7 @@ figma.ui.onmessage = async (msg: { type: string; id?: string; width?: number; he
 (async () => {
   // Restore the designer's preferred window size before scanning.
   try {
-    const saved = (await figma.clientStorage.getAsync(SIZE_KEY)) as
-      | { width?: number; height?: number }
-      | undefined;
+    const saved = (await figma.clientStorage.getAsync(SIZE_KEY)) as { width?: number; height?: number } | undefined;
     if (saved && saved.width && saved.height) {
       figma.ui.resize(
         clamp(saved.width, MIN_SIZE.width, MAX_SIZE.width),

--- a/packages/figma-icon-sync-plugin/src/code.ts
+++ b/packages/figma-icon-sync-plugin/src/code.ts
@@ -124,13 +124,43 @@ function hasHiddenDescendant(node: SceneNode): boolean {
   return false;
 }
 
-// The rendered content should be exactly one shape. We only count visible
-// children (hidden layers are caught separately) — so a lone vector or a single
-// union passes, while multiple shapes or a group/frame wrapper does not.
+// Container/wrapper nodes that shouldn't live inside a clean icon — the final
+// artwork should be flat vectors/booleans, never nested frames, groups, or
+// instances. (BOOLEAN_OPERATION is intentionally excluded: it's the flattening
+// op whose direct children are vectors.)
+function isContainerType(type: string): boolean {
+  return (
+    type === 'FRAME' ||
+    type === 'GROUP' ||
+    type === 'SECTION' ||
+    type === 'COMPONENT' ||
+    type === 'COMPONENT_SET' ||
+    type === 'INSTANCE'
+  );
+}
+
+// True if any visible descendant is a frame/group/instance wrapper — i.e. the
+// icon has nested "mess" instead of being a single flattened shape.
+function hasNestedContainer(node: SceneNode): boolean {
+  if (!('children' in node)) return false;
+  for (const child of node.children) {
+    if (child.visible === false) continue;
+    if (isContainerType(child.type)) return true;
+    if (hasNestedContainer(child)) return true;
+  }
+  return false;
+}
+
+// The rendered content should be exactly one flattened shape. We only count
+// visible children (hidden layers are caught separately) — so a lone vector or
+// a single union passes, while multiple shapes, a group/frame wrapper, or any
+// nested frame/group buried inside the shape does not.
 function isSingleShape(variant: ComponentNode): boolean {
   const visible = variant.children.filter((c) => c.visible !== false);
   if (visible.length !== 1) return false;
-  return isShapeType(visible[0].type);
+  if (!isShapeType(visible[0].type)) return false;
+  if (hasNestedContainer(visible[0])) return false;
+  return true;
 }
 
 // Icon shapes must use horizontal + vertical "Scale" constraints so they resize

--- a/packages/figma-icon-sync-plugin/src/ui.html
+++ b/packages/figma-icon-sync-plugin/src/ui.html
@@ -836,8 +836,11 @@
           return;
         }
         if (!d.added.length && !d.removed.length) {
+          const since = d.comparedToVersion
+            ? '<span class="ver">v' + escapeHtml(d.comparedToVersion) + '</span>'
+            : 'the latest release';
           $('diff').innerHTML =
-            '<div class="diff-note">No icons added or removed since the last release.</div>';
+            '<div class="diff-note">No icons added or removed since ' + since + '.</div>';
           return;
         }
 

--- a/packages/figma-icon-sync-plugin/src/ui.html
+++ b/packages/figma-icon-sync-plugin/src/ui.html
@@ -566,6 +566,12 @@
           fail: (n) => n + ' structure issue(s)',
         },
         {
+          rules: ['bad-constraints'],
+          ok: 'Constraints set to Scale',
+          fail: (n) => n + ' icon(s) not set to Scale',
+          info: 'Each icon shape should use horizontal and vertical “Scale” constraints so it resizes correctly with its frame.',
+        },
+        {
           rules: ['orphan'],
           ok: null, // nothing to show when clean
           fail: (n) => 'Component sets outside an “Icons” frame',


### PR DESCRIPTION
<img width="566" height="938" alt="Screenshot 2026-07-06 at 16 06 22" src="https://github.com/user-attachments/assets/298a9c64-c113-4018-bd1e-c3b68338a9b3" />

1. Adding another check to our Figma plugin - making sure the size constraints are set to "scale"

The reason this needs to be done is because some designers have encountered some bugs when manually resizing imported icons. This is mainly a Figma/designers concern and shouldn’t affect exported icons in code, but still worth making sure these are always set to Scale

2. Improving the "structure issues" check to also account for deeply nested layers