### PR TITLE
chore(icons): insert icon name into data-fui-* attribute for icons an…

### DIFF
--- a/packages/generate-icon-lib/src/services.ts
+++ b/packages/generate-icon-lib/src/services.ts
@@ -42,12 +42,16 @@ import { render } from './view';
 
 const transformers = {
   /**
-   * Pass SVG through SVGO to reduce size.
+   * Pass SVG through SVGO to reduce size, then stamp the root with the
+   * component name (e.g. data-fui-icon="Ban16") for DOM debugging.
    */
-  async passSVGO(svgRaw: string, mode: GeneratorMode = 'icons') {
+  async passSVGO(svgRaw: string, mode: GeneratorMode = 'icons', componentName: string) {
     const svgo = getSvgo(mode);
     const { data } = await svgo.optimize(svgRaw);
-    return data as string;
+    const dataAttr = mode === 'pictograms' ? 'data-fui-pictogram' : 'data-fui-icon';
+    const $ = cheerio.load(data as string, { xmlMode: true });
+    $('svg').attr(dataAttr, componentName);
+    return $.xml();
   },
 
   /**
@@ -567,7 +571,9 @@ export async function downloadSvgsToFs(
 ) {
   await Promise.all(
     Object.keys(urls).map(async (iconId) => {
-      const pipeline = (await fetch(urls[iconId])).text().then(async (svgRaw) => transformers.passSVGO(svgRaw, mode));
+      const pipeline = (await fetch(urls[iconId]))
+        .text()
+        .then(async (svgRaw) => transformers.passSVGO(svgRaw, mode, icons[iconId].jsxName));
       // Pictograms keep their original colors; only monochromatic UI icons get
       // their fills/strokes rewritten to "currentColor".
       const processedSvg = await (mode === 'pictograms'

--- a/packages/generate-icon-lib/src/utils.ts
+++ b/packages/generate-icon-lib/src/utils.ts
@@ -135,7 +135,6 @@ export function getPictogramRemergeSvgo() {
 
 export function getSvgo(mode: GeneratorMode = 'icons') {
   if (svgoCache[mode]) return svgoCache[mode];
-  const dataAttr = mode === 'pictograms' ? 'data-fui-pictogram' : 'data-fui-icon';
   // For pictograms we MUST preserve the per-variant element-by-element
   // correspondence so `analyzePictogramAlignment` can decide whether the
   // background variants share geometry. SVGO's `mergePaths` plugin merges
@@ -147,6 +146,10 @@ export function getSvgo(mode: GeneratorMode = 'icons') {
   // post-SVGO output preserves the original Figma topology 1:1 across
   // variants. They stay enabled for monochromatic icons where there's only
   // a single variant to reason about.
+  //
+  // `data-fui-icon` / `data-fui-pictogram` are stamped with the component
+  // name after SVGO in `passSVGO` (per-icon values can't live in this
+  // mode-level cache).
   const isPictograms = mode === 'pictograms';
   svgoCache[mode] = new SVGO({
     plugins: [
@@ -188,15 +191,6 @@ export function getSvgo(mode: GeneratorMode = 'icons') {
       { removeDimensions: false },
       { removeStyleElement: false },
       { removeScriptElement: false },
-      {
-        addAttributesToSVGElement: {
-          attributes: [
-            {
-              [dataAttr]: 'true',
-            },
-          ],
-        },
-      },
     ],
   });
   return svgoCache[mode];


### PR DESCRIPTION
Instead of setting `data-fui-icon="true"` on React component icons, insert actual icon name to make it easier to inspect the code via devtools like: `data-fui-icon="Ban16"` and `data-fui-pictogram="StorePictogram" `