### PR TITLE
(turbo-module): release next canary version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-module-monorepo",
-  "version": "0.0.1-canary.157",
+  "version": "0.0.1-canary.158",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
### General Changes

- perf: stop shipping the tooltip module and emoji color map to every consumer (#729)
- perf(icons): halve per-icon bundle cost and stop loading 5,300 modules on require (#732)
- chore(icons): sync icons from Figma (#735)
- chore(pictograms): sync pictograms from Figma (#736)

### Credits
@arturbien