### PR TITLE
chore(frosted-ui): upgrade @base-ui/react to 1.8.0

### DIFF
--- a/packages/frosted-ui/package.json
+++ b/packages/frosted-ui/package.json
@@ -79,7 +79,7 @@
     "release": "turbo-module publish"
   },
   "dependencies": {
-    "@base-ui/react": "^1.7.0",
+    "@base-ui/react": "^1.8.0",
     "@internationalized/date": "^3.5.6",
     "@react-aria/calendar": "^3.5.13",
     "@react-aria/datepicker": "^3.11.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
   packages/frosted-ui:
     dependencies:
       '@base-ui/react':
-        specifier: ^1.7.0
-        version: 1.7.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        specifier: ^1.8.0
+        version: 1.8.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@internationalized/date':
         specifier: ^3.5.6
         version: 3.5.6
@@ -158,7 +158,7 @@ importers:
         version: 2.8.0
       vaul-base:
         specifier: ^1.0.0
-        version: 1.0.0(@base-ui/react@1.7.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 1.0.0(@base-ui/react@1.8.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     devDependencies:
       '@frosted-ui/colors':
         specifier: workspace:*
@@ -1159,6 +1159,10 @@ packages:
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
     engines: {node: '>=6.9.0'}
@@ -1171,8 +1175,8 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@base-ui/react@1.7.0':
-    resolution: {integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==}
+  '@base-ui/react@1.8.0':
+    resolution: {integrity: sha512-P0/1sxo6SBVZOklKMIedvTWqw2s2IQzi9x5bIVsXu980cuSOD4NeuRSs+/L7LZQfDkZP/uRZyGPyfFl/B1oH+Q==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       '@date-fns/tz': ^1.2.0
@@ -1188,8 +1192,8 @@ packages:
       date-fns:
         optional: true
 
-  '@base-ui/utils@0.3.2':
-    resolution: {integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==}
+  '@base-ui/utils@0.4.0':
+    resolution: {integrity: sha512-bO9fz25kKtPf+aZVyfQrC0PDmJdmVni31W2hCS5/Owb+inwdIL3XU26pCPRPlt4LSxZrBgLwubXQXQlKaFEZzw==}
     peerDependencies:
       '@types/react': 19.1.10
       react: ^17 || ^18 || ^19
@@ -10888,6 +10892,8 @@ snapshots:
 
   '@babel/runtime@7.29.2': {}
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -10911,10 +10917,10 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@base-ui/react@1.7.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@base-ui/react@1.8.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.29.2
-      '@base-ui/utils': 0.3.2(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@babel/runtime': 7.29.7
+      '@base-ui/utils': 0.4.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@floating-ui/react-dom': 2.1.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@floating-ui/utils': 0.2.12
       react: 19.1.0
@@ -10923,9 +10929,9 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.10
 
-  '@base-ui/utils@0.3.2(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@base-ui/utils@0.4.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       '@floating-ui/utils': 0.2.12
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
@@ -21418,9 +21424,9 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vaul-base@1.0.0(@base-ui/react@1.7.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  vaul-base@1.0.0(@base-ui/react@1.8.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
-      '@base-ui/react': 1.7.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@base-ui/react': 1.8.0(@types/react@19.1.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 


### PR DESCRIPTION
## Summary

Upgrades `@base-ui/react` from `^1.7.0` → `^1.8.0` (latest, published Sep 4, 2026).

No Frosted UI source changes were required. Validated locally:
- `tsc` (CJS + ESM) ✅
- `eslint` + `stylelint` ✅
- `vitest` — 312/312 tests passing ✅

Sources: [Base UI v1.8.0 release notes](https://base-ui.com/react/overview/releases/v1-8-0), [GitHub CHANGELOG](https://github.com/mui/base-ui/blob/master/CHANGELOG.md).

---

## Breaking changes

**Official changelog marks no breaking changes in v1.8.0.**

A few behavioral / API additions consumers (and Frosted UI wrappers) should be aware of:

| Area | Change |
|---|---|
| Avatar | New `keepMounted` prop on `<Avatar.Image>` ([#5536](https://github.com/mui/base-ui/pull/5536)) — Frosted already forwards image props, so this is available automatically |
| Combobox | New `createItems` collection API ([#5326](https://github.com/mui/base-ui/pull/5326)) |
| Toast | `update()` can take a function derived from the current toast ([#5464](https://github.com/mui/base-ui/pull/5464), [#5611](https://github.com/mui/base-ui/pull/5611), [#5629](https://github.com/mui/base-ui/pull/5629)) |
| Autocomplete / Combobox / Select | Popup can open and be browsed while `readOnly` ([#5541](https://github.com/mui/base-ui/pull/5541), [#5531](https://github.com/mui/base-ui/pull/5531)) |
| Navigation Menu | Focus stays on the trigger when opening ([#5479](https://github.com/mui/base-ui/pull/5479)) |
| Field | Neutral validity is published while async validation is in flight ([#5600](https://github.com/mui/base-ui/pull/5600)) |
| Dialog / Alert Dialog / Popover | Outside clicks from presses that began before open are ignored ([#5378](https://github.com/mui/base-ui/pull/5378)) |
| Scroll Area | Scrollbars no longer steal focus ([#5430](https://github.com/mui/base-ui/pull/5430)) |

### Frosted UI impact assessment

| Concern | Status |
|---|---|
| Compile / typecheck against 1.8.0 | Passes with no source edits |
| Existing `DialogRootActions` / `AlertDialogRootActions` imports | Still exported |
| `useRender` / `mergeProps` | Unchanged public surface |
| Toast manager `update()` | Still compatible; functional updates are additive |
| Combobox `useFilter` re-export | Still present |

---

## Full v1.8.0 changelog (from [upstream](https://base-ui.com/react/overview/releases/v1-8-0))

_Sep 4, 2026_

### General changes

- Fix label association when a control unregisters (#5456)
- Reduce animation completion work (#5535)
- Fix prop and ref merging for lazy render elements (#5562)
- Fix roving focus when items are added or removed (#5447)
- Fix hover and focus interaction issues (#5037)
- Improve trigger mount performance (#5426)
- Fix disabled anchor tracking on scroll (#5478)
- Fix transform origin for start/end alignment (#5015)
- Remove duplicate options key from arrow middleware (#5606)
- Register passive touch listeners (#5572)

### Alert Dialog

- Ignore outside clicks from presses that began before open (#5378)

### Autocomplete

- Render groups with the rowgroup role in grid mode (#5564)
- Allow opening and browsing the popup while `readOnly` (#5541)
- Move `aria-orientation` to the role owners (#5551)
- Hide group labels and scrollbars from the accessibility tree (#5598)

### Avatar

- Add `keepMounted` prop to `<Avatar.Image>` (#5536)

### Checkbox

- Fix stale and duplicated control IDs (#5457)
- Fix controlled blur validation and stale filled state (#5563)

### Checkbox Group

- Fix stale and duplicated control IDs (#5457)

### Combobox

- Fix applying `data-readonly` to `<Combobox.Trigger>` (#5418)
- Add `createItems` collection API (#5326)
- Fix cancellation when preserving the filter after selection (#5362)
- Render groups with the rowgroup role in grid mode (#5564)
- Allow opening and browsing the popup while `readOnly` (#5541)
- Move `aria-orientation` to the role owners (#5551)
- Fix record item label lookup reading from `Object.prototype` (#5518)
- Anchor multiple selection to the first selected item with a linear lookup (#5573, #5613)
- Hide group labels and scrollbars from the accessibility tree (#5598)

### Dialog

- Ignore outside clicks from presses that began before open (#5378)

### Drawer

- Ignore swipes without an attributed direction when using snap points (#5477)
- Respect canceled snap point dismissal (#5571)
- Ignore the page scroller when starting a swipe (#5567)

### Field

- Fix custom validity ownership and validation lifecycle (#5449)
- Sync controlled value changes with field state (#5460)
- Fix stale and duplicated control IDs (#5457)
- Validate once on Enter inside a Form (#5459)
- Publish neutral validity while async validation is in flight (#5600)
- Fix controlled blur validation and stale filled state (#5563)

### Form

- Fix `clearErrors` dropping updates when multiple fields change at once (#5446)

### Menu

- Play the enter transition for an initially open submenu (#4383)
- Move `aria-orientation` to the role owners (#5551)
- Hide group labels and scrollbars from the accessibility tree (#5598)

### Menubar

- Fix menubar accessibility tree to satisfy `aria-required-children` (#5058)

### Navigation Menu

- Fix pointer-events lock when sweeping quickly across a trigger (#5454)
- Keep focus on trigger when opening (#5479)
- Add disabled data attribute to `<NavigationMenu.Trigger>` (#5521)

### Number Field

- Stop incrementing when disabled during press-and-hold (#5435)
- Prevent scrubbing on horizontal wheel events (#5463)
- Preserve native and consumer-controlled selection when focusing the input (#5578, #5619)

### Popover

- Ignore outside clicks from presses that began before open (#5378)
- Fix detached trigger store migration (#5442)

### Scroll Area

- Hide group labels and scrollbars from the accessibility tree (#5598)
- Prevent scrollbars from stealing focus (#5430)

### Select

- Move `aria-orientation` to the role owners (#5551)
- Anchor multiple selection to the first selected item with a linear lookup (#5573, #5613)
- Hide group labels and scrollbars from the accessibility tree (#5598)
- Fix the root ID being ignored inside a Field (#5461)
- Remove redundant size check in `<Select.Positioner>` (#5469)
- Allow opening and browsing the popup while `readOnly` (#5531)
- Fix record item label lookup reading from `Object.prototype` (#5518)

### Slider

- Prevent update loops from unstable refs (#5441)

### Switch

- Fix controlled blur validation and stale filled state (#5563)

### Tabs

- Prevent update loops from unstable refs (#5441)
- Consider 3D transforms when positioning the indicator (#4852)

### Toast

- Allow functional toast updates derived from the current toast (#5464, #5611, #5629)

### Tooltip

- Respect trigger delay with zero provider delay (#5444)

---

## Test plan

- [x] Bump `@base-ui/react` to `^1.8.0` and refresh lockfile
- [x] `pnpm --filter=frosted-ui exec tsc --project tsconfig-esm.json --noEmit`
- [x] `pnpm --filter=frosted-ui build:js` (CJS + ESM)
- [x] `pnpm --filter=frosted-ui lint`
- [x] `pnpm --filter=frosted-ui test` (312 tests)
- [x] CI green on this PR
- [ ] Spot-check Storybook surfaces that wrap Base UI heavily (Combobox, Select, Dialog, Menu, Toast, Field) if desired before merge


Made with [Cursor](https://cursor.com)
